### PR TITLE
Name the malware-scanner pools for the work they do

### DIFF
--- a/crates/agentwerk/tests/integration.rs
+++ b/crates/agentwerk/tests/integration.rs
@@ -13,8 +13,8 @@ mod bash_usage;
 #[path = "integration/grep_finds_by_shape.rs"]
 mod grep_finds_by_shape;
 
-#[path = "integration/sniper_finds_planted.rs"]
-mod sniper_finds_planted;
+#[path = "integration/seeker_finds_planted.rs"]
+mod seeker_finds_planted;
 
 #[path = "integration/compaction.rs"]
 mod compaction;

--- a/crates/agentwerk/tests/integration/seeker_finds_planted.rs
+++ b/crates/agentwerk/tests/integration/seeker_finds_planted.rs
@@ -1,4 +1,4 @@
-//! End-to-end: the real Sniper role (used verbatim) is run for a fixed time
+//! End-to-end: the real Seeker role (used verbatim) is run for a fixed time
 //! budget, each ticket already naming one observed construct per planted
 //! language, over a directory seeded with planted malicious indicators across
 //! secrets, networking, and dynamic-execution categories.
@@ -20,9 +20,9 @@ use agentwerk::event::{default_logger, Event, EventKind};
 use agentwerk::tools::GrepTool;
 use agentwerk::{Agent, Knowledge, Ticket, TicketSystem};
 
-const SNIPER_AGENT: &str = include_str!("../../../use-cases/src/malware_scanner/agents/sniper.md");
+const SEEKER_AGENT: &str = include_str!("../../../use-cases/src/malware_scanner/agents/seeker.md");
 
-const SNIPER_LABEL: &str = "sniper_hunt";
+const SEEKER_LABEL: &str = "seeking";
 const ANALYSIS_LABEL: &str = "security_analysis";
 const TIME_BUDGET: Duration = Duration::from_secs(60);
 
@@ -102,7 +102,7 @@ fn plant_fixture(root: &std::path::Path) {
 }
 
 #[tokio::test]
-async fn sniper_pool_finds_planted_indicators(
+async fn seeker_pool_finds_planted_indicators(
 ) -> std::result::Result<(), Box<dyn std::error::Error>> {
     let (provider, model) = common::build_provider();
 
@@ -110,7 +110,7 @@ async fn sniper_pool_finds_planted_indicators(
     let root = dir.path();
     plant_fixture(root);
 
-    // A real Sniper always has one bound (see main.rs); a couple of
+    // A real Seeker always has one bound (see main.rs); a couple of
     // representative pages are enough to exercise `manage_knowledge` here
     // without duplicating the full attack-pattern catalogue.
     let knowledge = Knowledge::load(root.join(".knowledge"))?;
@@ -118,7 +118,7 @@ async fn sniper_pool_finds_planted_indicators(
         slug: "eval-atob-loader".to_string(),
         kind: "AttackPattern".to_string(),
         description: "JavaScript decode-then-eval loader: eval(atob(...)) reconstructs code from a base64 string at runtime.".to_string(),
-        content: "## Huntable signal\n`eval(atob(...))` or an equivalent decode-then-eval chain.".to_string(),
+        content: "## Detectable signal\n`eval(atob(...))` or an equivalent decode-then-eval chain.".to_string(),
         tags: vec![],
     }).map_err(|e| format!("seed page: {e}"))?;
 
@@ -153,17 +153,17 @@ async fn sniper_pool_finds_planted_indicators(
     tickets.max_turns(80);
     tickets.on_event(move |e| event_handler(e));
 
-    // The Sniper no longer derives a threat itself; each ticket already names one
-    // observed construct per planted language, the way a Scout would hand it off.
+    // The Seeker no longer derives a threat itself; each ticket already names one
+    // observed construct per planted language, the way a Tracer would hand it off.
     for i in 0..2 {
         tickets.agent(
             Agent::new()
-                .name(format!("Sniper {}", i + 1))
+                .name(format!("Seeker {}", i + 1))
                 .provider(Arc::clone(&provider))
                 .model(&model)
-                .role(SNIPER_AGENT.trim())
+                .role(SEEKER_AGENT.trim())
                 .template_variable("instruction", "")
-                .label(SNIPER_LABEL)
+                .label(SEEKER_LABEL)
                 .dir(root.to_path_buf())
                 .knowledge(&knowledge)
                 .tool(GrepTool)
@@ -197,7 +197,7 @@ async fn sniper_pool_finds_planted_indicators(
          network exfiltration from a compiled binary",
     ];
     for threat in named_threats {
-        tickets.ticket(Ticket::new(threat).label(SNIPER_LABEL));
+        tickets.ticket(Ticket::new(threat).label(SEEKER_LABEL));
     }
 
     let results = tickets.finish().await;
@@ -229,7 +229,7 @@ async fn sniper_pool_finds_planted_indicators(
         }
     }
 
-    assert!(!calls.is_empty(), "the Sniper made no grep calls");
+    assert!(!calls.is_empty(), "the Seeker made no grep calls");
     assert!(
         found > 0,
         "agents surfaced none of the planted indicators; grep output: {all_text}"

--- a/crates/use-cases/src/malware_scanner/agents/analyst.md
+++ b/crates/use-cases/src/malware_scanner/agents/analyst.md
@@ -40,7 +40,7 @@ often the finding that first flagged it. Your role is to:
 
 ## Task
 
-1. **Review the evidence** provided in the ticket (e.g., matches handed over by a hunt, or direct findings).
+1. **Review the evidence** in the ticket: the flagged file and line, the matched text, and the trace of how that code is reached.
 2. **Get the actual code in front of you.** Judge from a `--- code ---` snippet if the ticket embeds one; otherwise open each cited file with `read_file_tool` and read the offending lines. When the flagged value is a function parameter, `grep` the function name to find the caller that supplies it: the sink's source is the caller, not the parameter. Never judge from the hit description alone.
 3. **Cross-reference** with project summaries in your knowledge base using `manage_knowledge`.
 4. **Determine the verdict** (`malicious`, `exploitable`, or `benign`) against the criteria above.

--- a/crates/use-cases/src/malware_scanner/agents/explorer.md
+++ b/crates/use-cases/src/malware_scanner/agents/explorer.md
@@ -4,7 +4,7 @@
 
 You give later analysis a **high-level map** of the project: what it is, what it is built with,
 and where its entry points and major parts live. This is an **overview, not an audit**—a few
-files, one short page, then done. You do not hunt for threats or judge security.
+files, one short page, then done. You do not search for threats or judge security.
 
 {instruction}
 

--- a/crates/use-cases/src/malware_scanner/agents/seeker.md
+++ b/crates/use-cases/src/malware_scanner/agents/seeker.md
@@ -1,32 +1,33 @@
-# Sniper Guidelines
+# Seeker Guidelines
 
 ## Role
 
-You **continuously search the project tree for problems**. Each ticket is one hunt: choose an
-untested threat pattern and search for it across the whole tree. You **cannot read files
-directly**—your only visibility into file content is through search hits. Every reply is
-**tool calls only**, no prose. **Batch independent searches into one reply**: one search per
-reply hits the time cap before it hits the budget.
+You **search the project tree for malicious code**: string execution, shell-outs, secret reads,
+hardcoded addresses, encoded blobs, embedded keys, past-incident markers. Each ticket is one
+pass: pick one untested pattern and search the whole tree. You **cannot read files
+directly**—search hits are your only view of file content. Every reply is **tool calls only**,
+no prose. **Batch independent searches into one reply**: one search per reply hits the time cap
+before the budget.
 
-If an instruction is provided, it defines your hunt. **Search for what it describes first**
+If an instruction is provided, it defines your search. **Search for what it describes first**
 before pursuing other patterns.
 
 {instruction}
 
 ## Behavior
 
-Your budget is up to `{searches_per_hunt}` distinct searches per ticket, sent in batches of
+Your budget is up to `{searches_per_ticket}` distinct searches per ticket, sent in batches of
 five. **The moment a search returns a hit worth tracing, stop and hand it over**—do not spend
 the rest of the budget. Keep searching only while every result is empty; an empty result just
-eliminates one hiding place. A new ticket arrives after every hunt, so one ticket is one tight
-pass, not an attempt to cover every threat.
+eliminates one hiding place. A new ticket always follows, so one ticket is one tight pass, not
+an attempt to cover every threat.
 
 - **Never** send an empty `pattern`.
 - **Never** repeat a search that returned empty or already exists in the knowledge index:
   spend the call on a new pattern instead.
 - **You do not judge.** A hit is a plain bundle of matches; whether it is dangerous is decided
   downstream. Never dismiss a hit as harmless—that is a judgment you do not make. But do not
-  keep hunting past a hit either: hand the first solid one over and let the next ticket resume.
+  keep searching past a hit either: hand the first solid one over and let the next ticket resume.
 
 
 ## Task
@@ -37,7 +38,7 @@ pass, not an attempt to cover every threat.
 2. **Recall knowledge**: `list` shows searches already run; `file-map-NN` pages name carrier
    files; past-incident pages carry exact markers (see Where Payloads Hide).
 3. **Run searches**: Use `grep` in batches of five until the budget is spent.
-4. **Record the hunt**: Write one `manage_knowledge` page listing the queries you ran, so a
+4. **Record the searches**: Write one `manage_knowledge` page listing the queries you ran, so a
    later ticket skips them.
 5. **End the ticket**: hand a hit forward the moment one appears, or finish quietly once the
    budget is spent and every search was empty (see Ending the Ticket).
@@ -90,13 +91,13 @@ You have **three tools**: any other tool name will fail and waste your turn.
 
 - **`manage_knowledge`**:
   - `{"action":"list"}`: List searches already attempted.
-  - `{"action":"write","slug":"<threat>-hunt","description":"<one line>","content":"<one query per line>"}`: Record all the hunt's queries in one page right before ending, so a future ticket skips them. A write per query wastes turns better spent searching.
+  - `{"action":"write","slug":"<threat>-search","description":"<one line>","content":"<one query per line>"}`: Record all the ticket's queries in one page right before ending, so a future ticket skips them. A write per query wastes turns better spent searching.
 
 - **`finish`**: Ends the ticket, your only way to end one, and always alone in its reply: a
   search batched beside it runs unread, since the ticket is already closed.
-  - **A hit**: pass `handover: "scouting"` so a scout traces how the match is reached. Without
-    the handover the hit ends here and nobody traces it.
-  - **A dry hunt**: finish with a one-line `result` and no `handover` when every search came
+  - **A hit**: pass `handover: "tracing"` so a tracer establishes how the match is reached.
+    Without the handover the hit ends here and nobody traces it.
+  - **A dry ticket**: finish with a one-line `result` and no `handover` when every search came
     back empty.
 
 
@@ -128,19 +129,19 @@ Call patterns for `"syntax": "code"`:
 
 ## Ending the Ticket
 
-Every hunt ends with **exactly one** closing call, always its own reply—a search batched
+Every ticket ends with **exactly one** closing call, always its own reply—a search batched
 beside it runs unread. You do not judge the results.
 
 - **As soon as a search returns a match**, stop and hand it over. Do not run another search
   first, and do not wait for the budget to run out.
   ```json
   finish({
-    "handover": "scouting",
+    "handover": "tracing",
     "result": "<path:line, matched text, one line on why it is worth tracing>"
   })
   ```
 
-- **If the hunt is dry**—the budget is spent (or widening yields no new pattern) and **every
+- **If the ticket is dry**—the budget is spent (or widening yields no new pattern) and **every
   search came back empty**—finish quietly:
   ```json
   finish({"result": "<technology/pattern>: nothing found"})

--- a/crates/use-cases/src/malware_scanner/agents/tracer.md
+++ b/crates/use-cases/src/malware_scanner/agents/tracer.md
@@ -1,4 +1,4 @@
-# Scout
+# Tracer
 
 ## Role
 

--- a/crates/use-cases/src/malware_scanner/attack_patterns.rs
+++ b/crates/use-cases/src/malware_scanner/attack_patterns.rs
@@ -1,6 +1,6 @@
 //! Seeds a `Knowledge` store from the checked-in attack-pattern OKF pages
 //! under `knowledge/attack_patterns/`, real supply-chain hiding techniques
-//! (see agents/sniper.md, agents/scout.md).
+//! (see agents/seeker.md, agents/tracer.md).
 
 use std::io;
 use std::path::Path;
@@ -14,7 +14,7 @@ pub(crate) const SOURCE_DIR: &str = concat!(
 
 /// Copy every checked-in attack-pattern page into `<dir>/knowledge/pages/`, so
 /// a subsequent `Knowledge::load(dir)` indexes them like any other seeded OKF
-/// bundle. Both the Scout's and the Sniper's stores are wiped and rebuilt
+/// bundle. Both the Tracer's and the Seeker's stores are wiped and rebuilt
 /// from this source each run.
 pub(crate) fn copy_seed_into(dir: &Path) -> io::Result<()> {
     let dest = dir.join("knowledge").join("pages");

--- a/crates/use-cases/src/malware_scanner/cli.rs
+++ b/crates/use-cases/src/malware_scanner/cli.rs
@@ -96,7 +96,7 @@ impl CliArgs {
     fn print_help() {
         eprintln!(
             "Malware scanner. Identifies the project's purpose, scans for threat indicators\n\
-             (from a curated catalogue or via a Sniper hunting threats the Scout surfaces),\n\
+             (from a curated catalogue or via a Seeker searching the tree for threats),\n\
              and dispatches suspect matches to an Analyst pool for deeper investigation.\n"
         );
         eprintln!("Usage: malware-scanner <DIR> [OPTIONS]\n");
@@ -111,7 +111,7 @@ impl CliArgs {
         );
         eprintln!("      --fail-fast              Cancel the scan on the first malicious finding");
         eprintln!(
-            "      --instruction <TEXT>     Append a custom instruction to the Scout, Sniper, and Analyst prompts"
+            "      --instruction <TEXT>     Append a custom instruction to the Tracer, Seeker, and Analyst prompts"
         );
         eprintln!("  -h, --help                   Show this help\n");
         eprintln!("Example:");

--- a/crates/use-cases/src/malware_scanner/knowledge/attack_patterns/buildrunner-dev-png-steganography.md
+++ b/crates/use-cases/src/malware_scanner/knowledge/attack_patterns/buildrunner-dev-png-steganography.md
@@ -16,6 +16,6 @@ fodhelper.exe UAC bypass, then payload hidden in PNG pixel data: size in the fir
 ## Payload/effect
 decodes and runs a .NET Pulsar RAT
 
-## Huntable signal
+## Detectable signal
 postinstall/init script fetching from a non-registry host; the string `fodhelper`; any
 image file read byte-by-byte with per-channel bit math instead of as an asset

--- a/crates/use-cases/src/malware_scanner/knowledge/attack_patterns/event-stream-flatmap-stream.md
+++ b/crates/use-cases/src/malware_scanner/knowledge/attack_patterns/event-stream-flatmap-stream.md
@@ -16,6 +16,6 @@ as the key: inert everywhere else, evading generic sandboxes
 ## Payload/effect
 targeted the Copay Bitcoin wallet specifically
 
-## Huntable signal
+## Detectable signal
 a dependency that decrypts a blob using a key derived from local package.json fields at
 runtime, not a constant

--- a/crates/use-cases/src/malware_scanner/knowledge/attack_patterns/gootloader-font-trick.md
+++ b/crates/use-cases/src/malware_scanner/knowledge/attack_patterns/gootloader-font-trick.md
@@ -15,6 +15,6 @@ character map hides loader logic
 ## Payload/effect
 malware loader (reported on compromised WordPress sites)
 
-## Huntable signal
+## Detectable signal
 a `.woff2`/`.woff` file, or inline font data, that is readable text/JS; a custom
 glyph-remap table or base85-style alphabet sitting beside a font blob

--- a/crates/use-cases/src/malware_scanner/knowledge/attack_patterns/mut-8694-mut-8964-campaign.md
+++ b/crates/use-cases/src/malware_scanner/knowledge/attack_patterns/mut-8694-mut-8964-campaign.md
@@ -17,6 +17,6 @@ asymmetric effort within the same campaign
 setup.py invokes PowerShell directly to fetch a second-stage infostealer (Blank Grabber,
 Skuld Stealer), disables Windows Defender
 
-## Huntable signal
+## Detectable signal
 setup.py/cfg.py calling subprocess or os.system with powershell, -enc, iwr, or iex; an npm
 bundle unusually flattened or string-encoded for its stated purpose

--- a/crates/use-cases/src/malware_scanner/knowledge/attack_patterns/node-ipc-protestware.md
+++ b/crates/use-cases/src/malware_scanner/knowledge/attack_patterns/node-ipc-protestware.md
@@ -14,6 +14,6 @@ geolocates the running machine's IP address
 ## Payload/effect
 wipes files if the IP geolocates to Russia or Belarus
 
-## Huntable signal
+## Detectable signal
 an IP-geolocation call followed by a branch into destructive filesystem calls (unlink, rm,
 overwrite) conditioned on the result

--- a/crates/use-cases/src/malware_scanner/knowledge/attack_patterns/polyfill-io-cdn-takeover.md
+++ b/crates/use-cases/src/malware_scanner/knowledge/attack_patterns/polyfill-io-cdn-takeover.md
@@ -16,6 +16,6 @@ user-agent: targeted, not blanket
 ## Payload/effect
 malicious redirects for specific mobile visitors
 
-## Huntable signal
+## Detectable signal
 a script src pointing at a third-party CDN domain outside the project's own origin or
 allowlist, serving dynamically generated JS per request

--- a/crates/use-cases/src/malware_scanner/knowledge/attack_patterns/shai-hulud-2-maintainer-compromise.md
+++ b/crates/use-cases/src/malware_scanner/knowledge/attack_patterns/shai-hulud-2-maintainer-compromise.md
@@ -17,6 +17,6 @@ open question rather than a fixed pattern
 ## Payload/effect
 unconfirmed; flag for extra scrutiny rather than pattern-match a mechanism
 
-## Huntable signal
+## Detectable signal
 a lockfile bump to a widely-used package with no matching upstream changelog or release
 notes

--- a/crates/use-cases/src/malware_scanner/knowledge/attack_patterns/solana-fakefix.md
+++ b/crates/use-cases/src/malware_scanner/knowledge/attack_patterns/solana-fakefix.md
@@ -17,6 +17,6 @@ harvests Solana keypairs, SSH keys, AWS credentials, and environment variables m
 KEY/SECRET/MNEMONIC/PRIVATE/TOKEN/PASSWORD; advanced variants add Telegram-bot
 command-and-control
 
-## Huntable signal
+## Detectable signal
 code appended after `//# sourceMappingURL=` or after a package's real module.exports;
 environment reads matching that name list combined with an outbound POST

--- a/crates/use-cases/src/malware_scanner/knowledge/attack_patterns/tj-actions-changed-files-compromise.md
+++ b/crates/use-cases/src/malware_scanner/knowledge/attack_patterns/tj-actions-changed-files-compromise.md
@@ -18,6 +18,6 @@ base64 Node.js snippet that runs a Python dumper reading /proc/[pid]/cmdline,
 /proc/[pid]/maps, and /proc/[pid]/mem of the CI runner process; credentials printed,
 lightly encoded, into the workflow's own public build logs
 
-## Huntable signal
+## Detectable signal
 `.github/workflows/*.yml` pinning a third-party Action by tag or branch instead of a
 commit hash; a dist/ bundle whose base64 blobs decode to /proc/ reads

--- a/crates/use-cases/src/malware_scanner/knowledge/attack_patterns/ua-parser-js-hijack.md
+++ b/crates/use-cases/src/malware_scanner/knowledge/attack_patterns/ua-parser-js-hijack.md
@@ -14,6 +14,6 @@ a preinstall script runs unconditionally on npm install
 ## Payload/effect
 a platform-specific binary: cryptominer plus password stealer
 
-## Huntable signal
+## Detectable signal
 package.json preinstall/postinstall that branches on process.platform then fetches and
 executes a binary

--- a/crates/use-cases/src/malware_scanner/knowledge/attack_patterns/xz-utils-liblzma-backdoor.md
+++ b/crates/use-cases/src/malware_scanner/knowledge/attack_patterns/xz-utils-liblzma-backdoor.md
@@ -17,6 +17,6 @@ and links the result into liblzma, hijacking glibc IFUNC resolution
 ## Payload/effect
 pre-auth unauthenticated RCE in OpenSSH via a hardcoded ED448 key
 
-## Huntable signal
+## Detectable signal
 build scripts (.m4, configure.ac, Makefile.am) piping a "test"/"fixture" file through a
 decoder into the link step; a fixture whose size or entropy is off

--- a/crates/use-cases/src/malware_scanner/main.rs
+++ b/crates/use-cases/src/malware_scanner/main.rs
@@ -1,11 +1,11 @@
 //! Malware scanner: finds IoC matches and routes each through reachability
 //! analysis to an Analyst. Curated extensions scan synchronously against their
-//! catalogues and hand their matches to a Scout. In parallel, Snipers hunt the
-//! tree continuously with regex `grep` queries; an interesting hit also hands
-//! over to a Scout. The Scout traces how the flagged code could be reached and
-//! hands that reachability analysis to an Analyst for the verdict. A pool of
+//! catalogues and hand their matches to a Tracer. In parallel, Seekers search
+//! the tree continuously with regex `grep` queries; an interesting hit also
+//! hands over to a Tracer. The Tracer establishes how the flagged code could be
+//! reached and hands that analysis to an Analyst for the verdict. A pool of
 //! Explorers captures the project's intent alongside, so analysis has that context.
-//! Explorers, Snipers, Scouts, and Analysts share one `TicketSystem`; once the
+//! Explorers, Seekers, Tracers, and Analysts share one `TicketSystem`; once the
 //! pools drain, the Reporter phrases the verdict on its own uncapped system, so
 //! a `--max-time` stop never cuts the summary.
 
@@ -32,12 +32,12 @@ use report::{
     analyst_result_schema, build_analysis, log_event, print_summary, render_findings_table,
     reporter_result_schema,
 };
-use scan::{ScanTree, Scanner, ANALYSIS_LABEL, EXPLORER_LABEL, SCOUT_LABEL, SNIPER_LABEL};
+use scan::{ScanTree, Scanner, ANALYSIS_LABEL, EXPLORER_LABEL, SEEKER_LABEL, TRACER_LABEL};
 
-const SNIPER_AGENT: &str = include_str!("agents/sniper.md");
+const SEEKER_AGENT: &str = include_str!("agents/seeker.md");
 const ANALYST_AGENT: &str = include_str!("agents/analyst.md");
 const ANALYST_VERDICTS: &str = include_str!("agents/verdicts.md");
-const SCOUT_AGENT: &str = include_str!("agents/scout.md");
+const TRACER_AGENT: &str = include_str!("agents/tracer.md");
 const EXPLORER_AGENT: &str = include_str!("agents/explorer.md");
 const REPORTER_AGENT: &str = include_str!("agents/reporter.md");
 const REPORTER_LABEL: &str = "reporter";
@@ -49,9 +49,9 @@ const REPORTER_LABEL: &str = "reporter";
 /// a native array or object) fails schema validation.
 const OUTPUT_CONTRACT: &str = "Call `finish` exactly once with the result fields as its top-level arguments. Emit each field as its native JSON type, never as a JSON-encoded string: an array field is a JSON array, not a string containing array syntax; a text field is plain text, not a string containing escaped JSON.";
 
-/// Distinct searches a Sniper aims for per hunt before the pool refills it.
+/// Distinct searches a Seeker aims for per ticket before the pool refills it.
 /// Injected into the prompt so the target lives in one place.
-const SEARCHES_PER_HUNT: u32 = 10;
+const SEARCHES_PER_TICKET: u32 = 10;
 
 /// The scanner's working folder: tickets, knowledge stores, and the analysis
 /// output all live here. Named for the project and wiped at the start of every
@@ -114,22 +114,22 @@ async fn main() {
     });
 
     // Run-scoped writable store, seeded with the same attack-pattern pages the
-    // Scout gets. The Sniper records each query it runs here, so a refilled hunt
+    // Tracer gets. The Seeker records each query it runs here, so a refilled ticket
     // reads the index and skips shapes already tried.
-    let hunts_dir = format!("{WORK_DIR}/hunts");
-    if let Err(e) = attack_patterns::copy_seed_into(std::path::Path::new(&hunts_dir)) {
-        eprintln!("cannot seed hunt knowledge: {e}");
+    let searches_dir = format!("{WORK_DIR}/searches");
+    if let Err(e) = attack_patterns::copy_seed_into(std::path::Path::new(&searches_dir)) {
+        eprintln!("cannot seed search knowledge: {e}");
         std::process::exit(1);
     }
-    let sniper_knowledge = Knowledge::load(&hunts_dir).unwrap_or_else(|e| {
-        eprintln!("cannot open hunt knowledge: {e}");
+    let seeker_knowledge = Knowledge::load(&searches_dir).unwrap_or_else(|e| {
+        eprintln!("cannot open search knowledge: {e}");
         std::process::exit(1);
     });
 
     // Write the tree's files into both worker stores as a paginated map, before
-    // any agent starts, so Scouts and Snipers read it instead of re-globbing.
+    // any agent starts, so Tracers and Seekers read it instead of re-globbing.
     scan::write_file_map(&exploration_knowledge, &scan.files_by_ext);
-    scan::write_file_map(&sniper_knowledge, &scan.files_by_ext);
+    scan::write_file_map(&seeker_knowledge, &scan.files_by_ext);
 
     eprintln!("malware scan: {}\n", scan_dir.display());
 
@@ -185,8 +185,8 @@ async fn main() {
         }
     });
 
-    // Fail-fast records the first malicious verdict and calls off the Sniper,
-    // Scout, and Analyst pools; the Explorer and Reporter still run so the
+    // Fail-fast records the first malicious verdict and calls off the Seeker,
+    // Tracer, and Analyst pools; the Explorer and Reporter still run so the
     // report is whole.
     let malicious_found = Arc::new(AtomicBool::new(false));
     if args.fail_fast {
@@ -197,12 +197,14 @@ async fn main() {
                 trip.store(true, Ordering::Relaxed);
             }
         });
-        let sniper_system = Arc::clone(&tickets);
-        tickets.cancel_label_on_event(SNIPER_LABEL, move |e| {
-            is_malicious_finish(&e, &sniper_system)
+        let seeker_system = Arc::clone(&tickets);
+        tickets.cancel_label_on_event(SEEKER_LABEL, move |e| {
+            is_malicious_finish(&e, &seeker_system)
         });
-        let scout_system = Arc::clone(&tickets);
-        tickets.cancel_label_on_event(SCOUT_LABEL, move |e| is_malicious_finish(&e, &scout_system));
+        let tracer_system = Arc::clone(&tickets);
+        tickets.cancel_label_on_event(TRACER_LABEL, move |e| {
+            is_malicious_finish(&e, &tracer_system)
+        });
         let analyst_system = Arc::clone(&tickets);
         tickets.cancel_label_on_event(ANALYSIS_LABEL, move |e| {
             is_malicious_finish(&e, &analyst_system)
@@ -256,17 +258,17 @@ async fn main() {
     // Continuous discovery, refilled after every ticket.
     for i in 0..concurrency {
         tickets.agent(
-            // Every hunt ends in a handover; sniper.md is what enforces it.
+            // Every ticket ends in a handover; seeker.md is what enforces it.
             Agent::new()
-                .name(format!("Sniper {}", i + 1))
+                .name(format!("Seeker {}", i + 1))
                 .provider(Arc::clone(&provider))
                 .model(&model)
-                .role(SNIPER_AGENT.trim())
+                .role(SEEKER_AGENT.trim())
                 .template_variable("instruction", &instruction_section)
-                .template_variable("searches_per_hunt", SEARCHES_PER_HUNT.to_string())
-                .label(SNIPER_LABEL)
+                .template_variable("searches_per_ticket", SEARCHES_PER_TICKET.to_string())
+                .label(SEEKER_LABEL)
                 .dir(scan_dir.to_path_buf())
-                .knowledge(&sniper_knowledge)
+                .knowledge(&seeker_knowledge)
                 .tool(GrepTool)
                 .build(),
         );
@@ -276,14 +278,14 @@ async fn main() {
     // Explorer's pages and record its own alongside.
     for i in 0..concurrency {
         tickets.agent(
-            // Every ticket ends in a handover; scout.md is what enforces it.
+            // Every ticket ends in a handover; tracer.md is what enforces it.
             Agent::empty()
-                .name(format!("Scout {}", i + 1))
+                .name(format!("Tracer {}", i + 1))
                 .provider(Arc::clone(&provider))
                 .model(&model)
-                .role(SCOUT_AGENT.trim())
+                .role(TRACER_AGENT.trim())
                 .template_variable("instruction", &instruction_section)
-                .label(SCOUT_LABEL)
+                .label(TRACER_LABEL)
                 .dir(scan_dir.to_path_buf())
                 .knowledge(&exploration_knowledge)
                 .tool(ReadFileTool)
@@ -321,16 +323,16 @@ async fn main() {
         tickets.ticket(Ticket::new(exploration_body).label(EXPLORER_LABEL));
     }
 
-    // Seed the discovery pool so the Sniper hunts from the start.
-    let hunt_body = "Choose an untested pattern and search for it: a past-incident technique \
+    // Seed the discovery pool so the Seeker searches from the start.
+    let search_body = "Choose an untested pattern and search for it: a past-incident technique \
          whose file type appears in the file map (open its page for the marker and grep it), or a \
          common dangerous call for a language in the tree. Skip patterns already recorded in knowledge.";
     for _ in 0..concurrency {
-        tickets.ticket(Ticket::new(hunt_body).label(SNIPER_LABEL));
+        tickets.ticket(Ticket::new(search_body).label(SEEKER_LABEL));
     }
 
-    // Refill the Sniper pool only, deduped by the queries in shared knowledge. The
-    // Explorer's overview is bounded to its seed tickets and the Scout is
+    // Refill the Seeker pool only, deduped by the queries in shared knowledge. The
+    // Explorer's overview is bounded to its seed tickets and the Tracer is
     // demand-driven, so neither is refilled. Under --max-time a drain-reserve closes
     // refill before the cap so the backlog drains inside it; with no cap it runs
     // until ctrl-c winds it down.
@@ -346,7 +348,7 @@ async fn main() {
         let weak = Arc::downgrade(&tickets);
         let malicious_found = Arc::clone(&malicious_found);
         let winding_down = Arc::clone(&winding_down);
-        let hunt_body = hunt_body.to_string();
+        let search_body = search_body.to_string();
         tickets.create_ticket_on_result(move |done| {
             if winding_down.load(Ordering::Relaxed) {
                 return None;
@@ -362,8 +364,8 @@ async fn main() {
             if weak.upgrade().is_some_and(|sys| sys.is_cancelled()) {
                 return None;
             }
-            if done.has_label(SNIPER_LABEL) {
-                return Some(Ticket::new(hunt_body.clone()).label(SNIPER_LABEL));
+            if done.has_label(SEEKER_LABEL) {
+                return Some(Ticket::new(search_body.clone()).label(SEEKER_LABEL));
             }
             None
         });
@@ -373,7 +375,7 @@ async fn main() {
 
     let scanner = Scanner::new(&scan_dir);
 
-    // One run, kept live across both phases: Explorers, Snipers, Scouts, and
+    // One run, kept live across both phases: Explorers, Seekers, Tracers, and
     // Analysts work concurrently while the Reporter waits idle for its ticket.
     tickets.start();
     let per_tech = scanner.discover(&tickets, &scan).await;
@@ -388,7 +390,7 @@ async fn main() {
         ));
     }
 
-    // Wait for the findings, the project summary, and any Sniper hunt to finish.
+    // Wait for the findings, the project summary, and any Seeker ticket to finish.
     // The pools drain on their own; under --max-time the cap is the backstop.
     wait_for_report_inputs(&tickets, &malicious_found, &winding_down).await;
     // A hard second-press ctrl-c aborts; a policy stop (time/turns/tokens) and a
@@ -400,7 +402,7 @@ async fn main() {
 
     let mut analysis = build_analysis(&tickets, &scan_dir, files_walked);
 
-    // Stop every pool, including any Sniper still hunting, before the report
+    // Stop every pool, including any Seeker still searching, before the report
     // phase: the Reporter runs on its own system, out of the cap's reach.
     tickets.cancel();
     tickets.finish().await;
@@ -477,16 +479,16 @@ async fn wait_for_report_inputs(
         if tickets.is_cancelled() || malicious_found.load(Ordering::Relaxed) {
             return;
         }
-        // Once winding down, the Explorer and Sniper labels are cancelled and
-        // their Todo tickets stay pending forever, so wait only for the Scout
+        // Once winding down, the Explorer and Seeker labels are cancelled and
+        // their Todo tickets stay pending forever, so wait only for the Tracer
         // reachability and Analyst backlog to drain.
         let winding = winding_down.load(Ordering::Relaxed);
         let pending = !tickets
             .find_tickets(|t| {
                 t.is_pending()
                     && (t.has_label(ANALYSIS_LABEL)
-                        || t.has_label(SCOUT_LABEL)
-                        || (!winding && (t.has_label(EXPLORER_LABEL) || t.has_label(SNIPER_LABEL))))
+                        || t.has_label(TRACER_LABEL)
+                        || (!winding && (t.has_label(EXPLORER_LABEL) || t.has_label(SEEKER_LABEL))))
             })
             .is_empty();
         if !pending {
@@ -539,8 +541,8 @@ async fn run_report_phase(
     report_tickets
 }
 
-/// Wind down on the first ctrl-c: stop minting new Explorer/Sniper work and let
-/// the in-flight Scout reachability and Analyst backlog drain into a report. A
+/// Wind down on the first ctrl-c: stop minting new Explorer/Seeker work and let
+/// the in-flight Tracer reachability and Analyst backlog drain into a report. A
 /// second press forces an immediate exit in case the drain itself wedges.
 fn install_ctrl_c_handler(tickets: Arc<TicketSystem>, winding_down: Arc<AtomicBool>) {
     tokio::spawn(async move {
@@ -553,7 +555,7 @@ fn install_ctrl_c_handler(tickets: Arc<TicketSystem>, winding_down: Arc<AtomicBo
         );
         winding_down.store(true, Ordering::Relaxed);
         tickets.cancel_label(EXPLORER_LABEL);
-        tickets.cancel_label(SNIPER_LABEL);
+        tickets.cancel_label(SEEKER_LABEL);
         if tokio::signal::ctrl_c().await.is_err() {
             return;
         }

--- a/crates/use-cases/src/malware_scanner/report.rs
+++ b/crates/use-cases/src/malware_scanner/report.rs
@@ -7,7 +7,7 @@ use agentwerk::schemas::Schema;
 use agentwerk::{Stats, TicketSystem};
 use serde_json::{json, Value};
 
-use crate::scan::{ScanTree, ANALYSIS_LABEL, EXPLORER_LABEL, SCOUT_LABEL, SNIPER_LABEL};
+use crate::scan::{ScanTree, ANALYSIS_LABEL, EXPLORER_LABEL, SEEKER_LABEL, TRACER_LABEL};
 
 /// Build the analysis JSON from completed analyst tickets. Top-level
 /// `status` is the worst across findings (`malicious` > `exploitable`
@@ -46,7 +46,7 @@ pub(crate) fn build_analysis(tickets: &TicketSystem, scan_dir: &Path, total_file
             .unwrap_or("")
             .to_string();
 
-        // A refilled Sniper can re-hand the same hit; keep one finding per
+        // A refilled Seeker can re-hand the same hit; keep one finding per
         // (path, line, column), upgrading to the more severe status if it recurs.
         let new_severity = severity(&status);
         let key = (path.clone(), line, column);
@@ -278,8 +278,8 @@ pub(crate) fn print_summary(
     eprintln!("  {}", rule("pipeline"));
     let display_labels: &[(&str, &str)] = &[
         (EXPLORER_LABEL, "exploring"),
-        (SNIPER_LABEL, "sniping"),
-        (SCOUT_LABEL, "reachability"),
+        (SEEKER_LABEL, "seeking"),
+        (TRACER_LABEL, "tracing"),
         (ANALYSIS_LABEL, "analysis"),
     ];
     for (label, display) in display_labels {
@@ -374,7 +374,7 @@ fn progress_bar(done: u64, total: u64) -> String {
 
 /// Count scannable files the run opened, as `(opened, scannable)`. Candidate
 /// paths are relative to `scan_dir`; opened paths arrive in mixed forms
-/// (relative from the Scout's file map, absolute from the analyst ticket), so
+/// (relative from the Tracer's file map, absolute from the analyst ticket), so
 /// both sides are canonicalized to one absolute key before intersecting.
 fn file_coverage<'a>(
     scan_dir: &Path,
@@ -404,10 +404,10 @@ pub(crate) fn log_event(event: &Event, tickets: &TicketSystem) {
     let r = "\x1b[0m";
     match &event.kind {
         EventKind::TicketStarted => {
-            let verb = if agent.starts_with("Sniper") {
-                "hunting threats..."
-            } else if agent.starts_with("Scout") {
-                "tracing reachability..."
+            let verb = if agent.starts_with("Seeker") {
+                "searching for threats..."
+            } else if agent.starts_with("Tracer") {
+                "tracing callers..."
             } else if agent.starts_with("Explorer") {
                 "exploring project..."
             } else {
@@ -628,9 +628,9 @@ fn finish_summary(result: &Value) -> String {
 /// ANSI color code for an agent name. Each pool gets its own color so
 /// interleaved output from concurrent agents is easy to follow.
 fn agent_color(name: &str) -> &'static str {
-    if name.starts_with("Sniper") {
+    if name.starts_with("Seeker") {
         "\x1b[35m" // magenta
-    } else if name.starts_with("Scout") {
+    } else if name.starts_with("Tracer") {
         "\x1b[36m" // cyan
     } else if name.starts_with("Explorer") {
         "\x1b[34m" // blue
@@ -757,7 +757,7 @@ mod tests {
 
     #[test]
     fn coverage_counts_files_opened_by_relative_or_absolute_path() {
-        // The Scout opens files by relative path; the analyst opens the same
+        // The Tracer opens files by relative path; the analyst opens the same
         // tree by absolute path. Both forms must count against the relative
         // candidate list. Absolute-only matching regressed this to 0.
         let dir = std::env::temp_dir().join(format!("coverage_{}", std::process::id()));

--- a/crates/use-cases/src/malware_scanner/scan.rs
+++ b/crates/use-cases/src/malware_scanner/scan.rs
@@ -18,9 +18,9 @@ const IOC_CPP: &str = include_str!("threats/cpp.json");
 const IOC_GO: &str = include_str!("threats/go.json");
 const IOC_HASKELL: &str = include_str!("threats/haskell.json");
 
-pub(crate) const SNIPER_LABEL: &str = "sniper_hunt";
+pub(crate) const SEEKER_LABEL: &str = "seeking";
 pub(crate) const ANALYSIS_LABEL: &str = "security_analysis";
-pub(crate) const SCOUT_LABEL: &str = "scouting";
+pub(crate) const TRACER_LABEL: &str = "tracing";
 pub(crate) const EXPLORER_LABEL: &str = "exploration";
 
 /// Size limit on files entering the grep sweep; skips bundles,
@@ -90,7 +90,7 @@ pub(crate) struct ScanTree {
     pub files: usize,
     pub extensions: Vec<String>,
     /// Relative paths grouped by dotted extension (`.go`), each list sorted.
-    /// Written into the Scout's knowledge as a file map so it need not glob.
+    /// Written into the Tracer's knowledge as a file map so it need not glob.
     pub files_by_ext: BTreeMap<String, Vec<String>>,
 }
 
@@ -150,7 +150,7 @@ impl ScanTree {
 }
 
 /// Write the tree's files into `store` as numbered `file-map-NN` pages,
-/// `FILE_MAP_PAGE_SIZE` paths each, grouped by extension so a Scout reads the map
+/// `FILE_MAP_PAGE_SIZE` paths each, grouped by extension so a Tracer reads the map
 /// instead of globbing. Capped at `FILE_MAP_MAX_PAGES`; a larger tree is logged as
 /// truncated. Returns the number of pages written.
 pub(crate) fn write_file_map(
@@ -208,7 +208,7 @@ pub(crate) fn write_file_map(
 
 /// Map a file extension to a curated IoC catalogue (technology name +
 /// JSON). Extensions not in the table are covered only indirectly,
-/// through whatever threats a Scout forwards to the Sniper pool.
+/// through whatever threats the Seeker pool turns up.
 pub(crate) fn known_extension_to_catalogue(ext: &str) -> Option<(&'static str, &'static str)> {
     match ext {
         ".js" | ".jsx" | ".ts" | ".tsx" | ".mjs" | ".cjs" | ".mts" | ".cts" => {
@@ -801,7 +801,7 @@ impl<'a> Scanner<'a> {
             .unwrap();
         clusters.sort_by_key(|(priority, _)| *priority);
         for (_, body) in clusters {
-            tickets.ticket(Ticket::new(body).label(SCOUT_LABEL));
+            tickets.ticket(Ticket::new(body).label(TRACER_LABEL));
         }
 
         per_tech.into_iter().filter(|(_, n)| *n > 0).collect()

--- a/crates/use-cases/src/malware_scanner/threats/haskell.json
+++ b/crates/use-cases/src/malware_scanner/threats/haskell.json
@@ -3,7 +3,7 @@
     "category": "RTS entry-point symbols",
     "query": "hs_main",
     "type": "pattern",
-    "reason": "The C-callable wrapper that GHC inserts to bootstrap the Haskell runtime and call `Main.main`. Every GHC-compiled executable contains this symbol; absence in a stripped binary that otherwise looks Haskell-like indicates aggressive symbol stripping. A hit confirms the binary is Haskell, which on a finance workstation or similar non-developer host is a strong hunt lead in itself because Haskell binaries in enterprise environments are statistically rare.",
+    "reason": "The C-callable wrapper that GHC inserts to bootstrap the Haskell runtime and call `Main.main`. Every GHC-compiled executable contains this symbol; absence in a stripped binary that otherwise looks Haskell-like indicates aggressive symbol stripping. A hit confirms the binary is Haskell, which on a finance workstation or similar non-developer host is a strong lead in itself because Haskell binaries in enterprise environments are statistically rare.",
     "rank": 0
   },
   {


### PR DESCRIPTION
## Name the malware-scanner pools for the work they do

### Purpose

- `Scout` and `Sniper` named a metaphor rather than a job, so the pipeline output told an operator nothing about what each pool was doing
- The work is tracing reachability and searching the tree, which the new names say directly
- "hunt" carried the same metaphor through labels, the work directory, prompts, and the summary row, so it goes with them
- Two prompts described their own job vaguely enough to mislead the model: the Seeker searched for "problems", and the Analyst was offered a choice between two names for one thing

### What changed

- `Scout` is now `Tracer` and `Sniper` is now `Seeker`, in agent names, log lines, and `--help`
- Ticket labels follow: `scouting` and `sniper_hunt` become `tracing` and `seeking`, and the seeker prompt hands over to `tracing`
- Search knowledge moves from `.malware-scanner/hunts` to `.malware-scanner/searches`, and every pipeline row is named for the pool that fills it
- The Seeker prompt names the six classes it looks for instead of "problems", and the Analyst's first task step states what its ticket actually carries

### Examples

```text
[Seeker 1] searching for threats...
[Tracer 1] tracing callers...
```

```text
exploring    ████░░░░░░  2/5 ·  4 req
seeking      ██████░░░░  3/5 · 11 req
tracing      ██████████  2/2 ·  6 req
```

```json
{ "handover": "tracing", "result": "<path:line, matched text, why it is worth tracing>" }
```
