### PR TITLE
tickets: read back whether a label's pool was called off

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ tickets.on_ticket(move |event, ticket| {
 | `cancel_on_result(p)` | End the run when a finished result matches. |
 | `cancel_label(l)` | Call off one label's agents. |
 | `cancel_label_on_event(l, p)` | Call off one label's agents while the rest keep working. |
+| `label_cancelled(l)` | Report whether one label's agents have been called off. |
 | `create_ticket_on_result(make)` | Enqueue a follow-up ticket from a finished ticket. |
 | `on_ticket(h)` | Read a ticket as it starts, finishes, or fails. |
 | `wait_for_ticket(p)` | Wait for one matching ticket instead of draining the queue. |

--- a/crates/agentwerk-py/DIFFS.md
+++ b/crates/agentwerk-py/DIFFS.md
@@ -71,6 +71,7 @@ Seven rules the surface table below never repeats.
 | `TicketSystem::cancel_on_result(predicate)` | `TicketSystem.cancel_on_result(predicate)` |
 | `TicketSystem::cancel_label(label)` | `TicketSystem.cancel_label(label)` |
 | `TicketSystem::cancel_label_on_event(label, predicate)` | `TicketSystem.cancel_label_on_event(label, predicate)` |
+| `TicketSystem::label_cancelled(label)` | `TicketSystem.label_cancelled(label)` |
 | `TicketSystem::create_ticket_on_result(make)` | `TicketSystem.create_ticket_on_result(make)` |
 | `TicketSystem::edit_replies(key, edit)` | `TicketSystem.edit_replies(key, editor)`: the editor returns the new list, or `None` to keep the old one, where Rust mutates in place. An editor that raises, or returns anything but `Reply` objects, raises here. |
 | `TicketSystem::edit_replies_on_event(editor)` | `TicketSystem.edit_replies_on_event(editor)`: same return-instead-of-mutate shape. An editor that raises prints its traceback and changes nothing: it runs on an agent thread with no Python frame to raise into. |

--- a/crates/agentwerk-py/README.md
+++ b/crates/agentwerk-py/README.md
@@ -257,6 +257,7 @@ tickets.on_ticket(capture)
 | `cancel_on(awaitable)` | End the run when an awaitable resolves. |
 | `cancel_label(l)` | Call off one label's agents. |
 | `cancel_label_on_event(l, p)` | Call off one label's agents when an event matches. |
+| `label_cancelled(l)` | Report whether one label's agents have been called off. |
 | `create_ticket_on_result(make)` | Enqueue a follow-up ticket from a finished ticket. |
 | `on_ticket(h)` | Read a ticket when it starts, finishes, or fails. |
 | `await wait_for_ticket(p)` | Wait for one matching ticket instead of draining the queue. |

--- a/crates/agentwerk-py/src/ticket_system.rs
+++ b/crates/agentwerk-py/src/ticket_system.rs
@@ -207,6 +207,13 @@ impl PyTicketSystem {
         slf
     }
 
+    /// True when `label` names a pool called off via `cancel_label`. Ask before
+    /// minting follow-up work: a ticket carrying a cancelled label is never
+    /// claimed.
+    fn label_cancelled(&self, label: &str) -> bool {
+        self.inner.label_cancelled(label)
+    }
+
     /// Call off `label`'s agents when `predicate(event)` first returns
     /// truthy. Only that pool stops; other labels keep going.
     fn cancel_label_on_event<'py>(

--- a/crates/agentwerk/src/agents/tickets/ticket_system.rs
+++ b/crates/agentwerk/src/agents/tickets/ticket_system.rs
@@ -726,6 +726,26 @@ impl TicketSystem {
         self
     }
 
+    /// True when `label` names a pool called off via [`Self::cancel_label`]. Ask
+    /// before minting follow-up work: a ticket carrying a cancelled label is
+    /// never claimed. Locks only `cancelled_labels`, so it is safe to call from
+    /// a predicate that already holds the `tickets` lock.
+    ///
+    /// ```no_run
+    /// # use agentwerk::{Ticket, TicketSystem};
+    /// let tickets = TicketSystem::new();
+    /// let system = std::sync::Arc::downgrade(&tickets);
+    /// tickets.create_ticket_on_result(move |done| {
+    ///     if !done.has_label("research") || system.upgrade()?.label_cancelled("research") {
+    ///         return None;
+    ///     }
+    ///     Some(Ticket::new("search again").label("research"))
+    /// });
+    /// ```
+    pub fn label_cancelled(&self, label: &str) -> bool {
+        self.cancelled_labels.lock().unwrap().contains(label)
+    }
+
     /// True when any of `labels` names a pool called off via [`Self::cancel_label`].
     /// The loop's claim/resume path reads this to keep a cancelled pool's tickets
     /// off the queue. Locks only `cancelled_labels`, so it is safe to call from a
@@ -1114,6 +1134,18 @@ mod tests {
             "other pools are untouched",
         );
         assert!(!sys.labels_cancelled(&[]));
+    }
+
+    #[test]
+    fn label_cancelled_reads_back_the_pool_cancel_label_called_off() {
+        let (sys, _tmp) = test_system();
+        assert!(!sys.label_cancelled("research"));
+        sys.cancel_label("research");
+        assert!(sys.label_cancelled("research"));
+        assert!(
+            !sys.label_cancelled("analysis"),
+            "other pools stay claimable",
+        );
     }
 
     #[test]

--- a/crates/use-cases/src/malware_scanner/main.rs
+++ b/crates/use-cases/src/malware_scanner/main.rs
@@ -18,7 +18,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use agentwerk::agents::Trajectory;
 use agentwerk::event::{Event, EventKind, PolicyKind};
@@ -41,6 +41,8 @@ const TRACER_AGENT: &str = include_str!("agents/tracer.md");
 const EXPLORER_AGENT: &str = include_str!("agents/explorer.md");
 const REPORTER_AGENT: &str = include_str!("agents/reporter.md");
 const REPORTER_LABEL: &str = "reporter";
+
+const REPORT_INPUT_LABELS: [&str; 4] = [ANALYSIS_LABEL, TRACER_LABEL, EXPLORER_LABEL, SEEKER_LABEL];
 
 /// Shared `finish` calling convention, substituted into every agent
 /// whose ticket carries a `Schema`. One source of truth instead of each
@@ -191,23 +193,18 @@ async fn main() {
     let malicious_found = Arc::new(AtomicBool::new(false));
     if args.fail_fast {
         let trip = Arc::clone(&malicious_found);
-        let verdict_system = Arc::clone(&tickets);
-        tickets.on_event(move |e| {
-            if is_malicious_finish(&e, &verdict_system) {
-                trip.store(true, Ordering::Relaxed);
+        let system = Arc::clone(&tickets);
+        tickets.on_ticket(move |event, ticket| {
+            if !matches!(event.kind, EventKind::TicketFinished)
+                || !ticket.result.as_ref().is_some_and(is_malicious_verdict)
+            {
+                return;
             }
-        });
-        let seeker_system = Arc::clone(&tickets);
-        tickets.cancel_label_on_event(SEEKER_LABEL, move |e| {
-            is_malicious_finish(&e, &seeker_system)
-        });
-        let tracer_system = Arc::clone(&tickets);
-        tickets.cancel_label_on_event(TRACER_LABEL, move |e| {
-            is_malicious_finish(&e, &tracer_system)
-        });
-        let analyst_system = Arc::clone(&tickets);
-        tickets.cancel_label_on_event(ANALYSIS_LABEL, move |e| {
-            is_malicious_finish(&e, &analyst_system)
+            trip.store(true, Ordering::Relaxed);
+            system
+                .cancel_label(SEEKER_LABEL)
+                .cancel_label(TRACER_LABEL)
+                .cancel_label(ANALYSIS_LABEL);
         });
     }
 
@@ -331,47 +328,24 @@ async fn main() {
         tickets.ticket(Ticket::new(search_body).label(SEEKER_LABEL));
     }
 
-    // Refill the Seeker pool only, deduped by the queries in shared knowledge. The
-    // Explorer's overview is bounded to its seed tickets and the Tracer is
-    // demand-driven, so neither is refilled. Under --max-time a drain-reserve closes
-    // refill before the cap so the backlog drains inside it; with no cap it runs
-    // until ctrl-c winds it down.
-    let winding_down = Arc::new(AtomicBool::new(false));
-    let refill_deadline: Option<Instant> = args.max_time.map(|max| {
-        let drain_reserve = max
-            .mul_f64(0.25)
-            .max(Duration::from_secs(60))
-            .min(max.mul_f64(0.5));
-        Instant::now() + max.saturating_sub(drain_reserve)
-    });
+    // Only the Seeker refills: the Explorer's overview is bounded to its seed
+    // tickets and the Tracer is demand-driven.
     {
         let weak = Arc::downgrade(&tickets);
-        let malicious_found = Arc::clone(&malicious_found);
-        let winding_down = Arc::clone(&winding_down);
         let search_body = search_body.to_string();
         tickets.create_ticket_on_result(move |done| {
-            if winding_down.load(Ordering::Relaxed) {
+            if !done.has_label(SEEKER_LABEL) {
                 return None;
             }
-            if refill_deadline.is_some_and(|d| Instant::now() >= d) {
+            // A ticket carrying a cancelled label is never claimed.
+            if weak.upgrade()?.label_cancelled(SEEKER_LABEL) {
                 return None;
             }
-            // A fail-fast stop cancels labels without flipping is_cancelled, but it
-            // sets malicious_found through the same trigger, so this catches it.
-            if malicious_found.load(Ordering::Relaxed) {
-                return None;
-            }
-            if weak.upgrade().is_some_and(|sys| sys.is_cancelled()) {
-                return None;
-            }
-            if done.has_label(SEEKER_LABEL) {
-                return Some(Ticket::new(search_body.clone()).label(SEEKER_LABEL));
-            }
-            None
+            Some(Ticket::new(search_body.clone()).label(SEEKER_LABEL))
         });
     }
 
-    install_ctrl_c_handler(Arc::clone(&tickets), Arc::clone(&winding_down));
+    install_ctrl_c_handler(Arc::clone(&tickets));
 
     let scanner = Scanner::new(&scan_dir);
 
@@ -392,7 +366,7 @@ async fn main() {
 
     // Wait for the findings, the project summary, and any Seeker ticket to finish.
     // The pools drain on their own; under --max-time the cap is the backstop.
-    wait_for_report_inputs(&tickets, &malicious_found, &winding_down).await;
+    wait_for_report_inputs(&tickets).await;
     // A hard second-press ctrl-c aborts; a policy stop (time/turns/tokens) and a
     // wind-down are graceful and fall through to write the report below.
     if tickets.is_cancelled() && !policy_stopped.load(Ordering::Relaxed) {
@@ -416,9 +390,8 @@ async fn main() {
     // Coverage is partial when the pools were called off early (time cap,
     // ctrl-c, fail-fast) rather than drained; the Reporter scopes an
     // all-clear accordingly.
-    let partial_coverage = policy_stopped.load(Ordering::Relaxed)
-        || winding_down.load(Ordering::Relaxed)
-        || malicious_found.load(Ordering::Relaxed);
+    let partial_coverage =
+        policy_stopped.load(Ordering::Relaxed) || tickets.label_cancelled(SEEKER_LABEL);
     let report_tickets = if has_findings || has_exploration {
         let report_tickets = run_report_phase(
             Arc::clone(&provider),
@@ -466,30 +439,20 @@ async fn main() {
     }
 }
 
-/// Block until the Reporter's inputs are ready, polling
-/// [`TicketSystem::find_tickets`] rather than [`TicketSystem::finish`] so the
-/// report never waits on the entire queue. Every worker pool drains on its own;
-/// under `--max-time` the refill window closes before the cap, and the cap
-/// itself is the backstop for a stuck run, flipping `is_cancelled()`.
-async fn wait_for_report_inputs(
-    tickets: &TicketSystem,
-    malicious_found: &AtomicBool,
-    winding_down: &AtomicBool,
-) {
+/// Block until the Reporter's inputs are ready. Polls rather than calling
+/// [`TicketSystem::finish`], which would wait on the entire queue. A called-off
+/// pool's tickets stay pending forever, so they are skipped.
+async fn wait_for_report_inputs(tickets: &TicketSystem) {
     loop {
-        if tickets.is_cancelled() || malicious_found.load(Ordering::Relaxed) {
+        if tickets.is_cancelled() {
             return;
         }
-        // Once winding down, the Explorer and Seeker labels are cancelled and
-        // their Todo tickets stay pending forever, so wait only for the Tracer
-        // reachability and Analyst backlog to drain.
-        let winding = winding_down.load(Ordering::Relaxed);
         let pending = !tickets
             .find_tickets(|t| {
                 t.is_pending()
-                    && (t.has_label(ANALYSIS_LABEL)
-                        || t.has_label(TRACER_LABEL)
-                        || (!winding && (t.has_label(EXPLORER_LABEL) || t.has_label(SEEKER_LABEL))))
+                    && REPORT_INPUT_LABELS
+                        .iter()
+                        .any(|label| t.has_label(label) && !tickets.label_cancelled(label))
             })
             .is_empty();
         if !pending {
@@ -544,10 +507,10 @@ async fn run_report_phase(
     report_tickets
 }
 
-/// Wind down on the first ctrl-c: stop minting new Explorer/Seeker work and let
-/// the in-flight Tracer reachability and Analyst backlog drain into a report. A
-/// second press forces an immediate exit in case the drain itself wedges.
-fn install_ctrl_c_handler(tickets: Arc<TicketSystem>, winding_down: Arc<AtomicBool>) {
+/// Call off the Explorer and Seeker pools on the first ctrl-c, letting the
+/// in-flight backlog drain into a report. A second press forces an exit in case
+/// the drain itself wedges.
+fn install_ctrl_c_handler(tickets: Arc<TicketSystem>) {
     tokio::spawn(async move {
         if tokio::signal::ctrl_c().await.is_err() {
             return;
@@ -556,7 +519,6 @@ fn install_ctrl_c_handler(tickets: Arc<TicketSystem>, winding_down: Arc<AtomicBo
             "\n[ctrl-c] winding down: no new work, finishing in-flight analysis then reporting. \
              Press again to force exit."
         );
-        winding_down.store(true, Ordering::Relaxed);
         tickets.cancel_label(EXPLORER_LABEL);
         tickets.cancel_label(SEEKER_LABEL);
         if tokio::signal::ctrl_c().await.is_err() {
@@ -580,28 +542,6 @@ fn merge_reporter_verdict(tickets: &TicketSystem, analysis: &mut Value) {
     if let Some(d) = result.get("details") {
         analysis["details"] = d.clone();
     }
-}
-
-/// True when `event` is a ticket finishing with a stored verdict that satisfies
-/// `predicate`. Reads the schema-validated result, so a verdict the analyst
-/// JSON-encoded as a string is already decoded.
-fn is_verdict_finish(
-    event: &Event,
-    tickets: &TicketSystem,
-    predicate: impl Fn(&Value) -> bool,
-) -> bool {
-    if !matches!(event.kind, EventKind::TicketFinished) {
-        return false;
-    }
-    tickets
-        .get_ticket(&event.ticket_key)
-        .and_then(|t| t.result)
-        .is_some_and(|result| predicate(&result))
-}
-
-/// True when a ticket just finished with a malicious verdict.
-fn is_malicious_finish(event: &Event, tickets: &TicketSystem) -> bool {
-    is_verdict_finish(event, tickets, is_malicious_verdict)
 }
 
 /// True when `ticket` just finished with a finding worth keeping as a training


### PR DESCRIPTION
## Read back whether a label's pool was called off

### Purpose

- `cancel_label` was public with no matching read: a caller could stop a pool but never ask whether one was stopped.
- Every consumer had to mirror that fact in its own flag and keep it in step with each cancel site, which is what made the malware scanner's refill logic accrete four overlapping guards.
- One query replaces those flags, so ticket creation reacts to system state instead of to bookkeeping the caller maintains by hand.
- It also fixes a latent bug in the scanner where `--fail-fast` called off three pools without setting the flag the report wait consulted.

### What changed

- New `TicketSystem::label_cancelled(label)`, bound in Python as `TicketSystem.label_cancelled(label)`.
- Safe to call from a `find_tickets` predicate or a `create_ticket_on_result` handler: it locks only the cancelled-label set, never the ticket store.
- The malware scanner's Seeker refill drops its winding-down flag, drain deadline, malicious-verdict flag, and `is_cancelled` check in favour of one `label_cancelled` call.
- Scanner fail-fast installs one `on_ticket` handler in place of one `on_event` plus three `cancel_label_on_event`, each of which re-read the finished ticket and cloned its full reply history.
- Behaviour change: the scanner's drain reserve is gone, so a `--max-time` stop can now abandon in-flight Tracer and Analyst work rather than reserving the tail of the budget for the backlog.

### Examples

```rust
tickets.create_ticket_on_result(move |done| {
    if !done.has_label("research") || system.upgrade()?.label_cancelled("research") {
        return None;
    }
    Some(Ticket::new("search again").label("research"))
});
```

```python
tickets.cancel_label("research")
assert tickets.label_cancelled("research")
```
