### PR TITLE
Apply the README's style to agentdocs and every doc comment

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,6 @@ The project's conventions are split across the following files. Read the one mat
 - [agentdocs/workflow.md](agentdocs/workflow.md): build, test, release commands.
 - [agentdocs/layout.md](agentdocs/layout.md): where code lives.
 - [agentdocs/architecture.md](agentdocs/architecture.md): rules that shape how code is organized.
-- [agentdocs/style.md](agentdocs/style.md): naming, comment, and README style.
+- [agentdocs/style.md](agentdocs/style.md): naming, comment, and prose style, plus README structure.
 - [agentdocs/testing.md](agentdocs/testing.md): how tests are organized and written.
 - [agentdocs/this.md](agentdocs/this.md): how the agentdocs files themselves are written.

--- a/README.md
+++ b/README.md
@@ -566,7 +566,7 @@ See [`EventKind`](https://docs.rs/agentwerk/latest/agentwerk/event/enum.EventKin
 | | `on_result(handler)` | Read every finished ticket together with its result. |
 | | `on_failure(handler)` | Read every failure together with the ticket it happened in. |
 | | `on_ticket(handler)` | Read a ticket as it starts, finishes, or fails. |
-| **Stop the run** | `cancel_on(trigger)` | Stop execution when the given future completes. |
+| **Stop the run** | `cancel_on(trigger)` | Stop execution when another task you supply finishes. |
 | | `cancel_on_event(condition)` | Stop execution when an event matches. |
 | | `cancel_on_result(condition)` | Stop execution when a finished result matches. |
 | | `cancel_on_failure(condition)` | Stop execution when a failure matches. |

--- a/agentdocs/architecture.md
+++ b/agentdocs/architecture.md
@@ -1,138 +1,177 @@
 # Architecture
 
-The invariants that shape how code fits together. Layout says where code lives; this file says why the seams are where they are.
+The invariants that shape how code fits together. Layout says where code lives; this file says why the boundaries are where they are.
 
-## Builder, system, loop
+## Builder, System, Loop
 
 **A run has three stages: build the `Agent`, bind it to a `TicketSystem`, drive the system with `start` (long-lived) or `finish` (process a fixed batch and return).**
 
-- The `Agent` builder carries identity, prompt parts, provider/model, tools, working dir, event handler, and a `Weak<TicketSystem>` (dangling by default).
-- `TicketSystem::agent(a)` (or `agent.ticket_system(&shared)`) sets the system's `Weak<Self>` on the agent, drains any tickets the agent had queued in its private default system into the shared one, and pushes a clone of the agent onto the system's agents list.
-- `TicketSystem::start` / `finish` spawn one tokio task per registered agent; each task upgrades its `Weak` once at the start and reads the shared store, policies, stats, and stop signal from the resulting `Arc<TicketSystem>`.
-- `tickets.task(value)` creates a new ticket and returns its key as `String`. `tickets.reply(&key, content)` appends a user-side text reply to an existing ticket: the agent loop's wait-for-input branch picks the reply up and drives the next turn on the same transcript. Use `task` to start a conversation, `reply` to continue it; this is how multi-turn chat is built on top of one ticket.
+```rust
+let agent = Agent::new().from_env().build();
+tickets.agent(agent);
+tickets.finish().await;
+```
 
-## Shared system, per-agent task
+- The `Agent` builder carries identity, prompt parts, provider and model, tools, working directory, event handler, and a `Weak<TicketSystem>` (dangling by default).
+- `TicketSystem::new` captures its own `Weak<Self>` through `Arc::new_cyclic`, so binding can hand every agent the back-reference it needs at run time.
+- `TicketSystem::agent(a)` (or `agent.ticket_system(&shared)`) sets that `Weak<Self>` on the agent, drains any tickets the agent had queued in its private default system into the shared one, and pushes a clone of the agent onto the system's agents list.
+- `TicketSystem::start` and `finish` spawn one tokio task per registered agent. Each task upgrades its `Weak` once at the start and reads the shared store, policies, stats, and stop signal from the resulting `Arc<TicketSystem>`.
+- `tickets.task(value)` creates a new ticket and returns its key as `String`. `tickets.reply(&key, content)` appends a text reply to an existing ticket, and the loop's wait-for-input branch picks it up and drives the next turn on the same replies.
+- Use `task` to start a conversation and `reply` to continue it. That is how multi-turn chat is built on top of one ticket.
+
+## Shared System, Per-Agent Task
 
 **Agents read shared state through one `Arc<TicketSystem>`. Locks are held only around queue and metric operations, never across `provider.respond().await`.**
 
 - The ticket store, policies, stats, stop and cancel signals, and registered-agent list live on `TicketSystem`.
-- The per-agent loop in `agents/loop.rs` claims one ticket, drives it through one or more provider/tool turns, and releases locks before each await.
+- The per-agent loop in `agents/loop.rs` claims one ticket, drives it through one or more provider and tool turns, and releases locks before each await.
 - Multiple agents share one queue; a ticket is claimed exactly once.
 - Sub-systems are not nested: a single `TicketSystem` is the unit of orchestration.
 
-## Assignment is labels, and a name is a label
+## Assignment Is Labels, and a Name Is a Label
 
 **Labels are the only assignment mechanism. An agent's own name counts as one of its labels, which is what makes direct assignment a special case of label scope rather than a second path.**
 
-- `Agent::handles_labels` answers three ways, in order: a ticket label equal to the agent's name matches; otherwise a labelled agent matches when its labels intersect the ticket's; otherwise an agent with no labels matches only tickets with no labels, which is the "default scope".
+```rust
+tickets.ticket(Ticket::new("Audit src/db.").label("scout_0"));  // direct
+tickets.ticket(Ticket::new("Audit src/db.").label("scan"));     // by scope
+```
+
+- `Agent::handles_labels` answers three ways, in order: a ticket label equal to the agent's name matches; otherwise a labelled agent matches when its labels intersect the ticket's; otherwise an agent with no labels matches only tickets with no labels, which is the default scope.
 - Direct assignment is therefore `Ticket::new(...).label(agent_name)`. The ticket is born `Status::Todo` like any other; nothing is born `InProgress`.
-- `TicketSystem::claim` pushes the claiming agent's name onto the ticket's labels. That is what pins a resumed ticket: the `resumable` predicate in `loop/agent.rs` requires a label equal to the agent's name, so no other agent picks up work already started.
+- `TicketSystem::claim` pushes the claiming agent's name onto the ticket's labels. That is what pins a resumed ticket: the `resumable` check in `loop/agent.rs` requires a label equal to the agent's name, so no other agent picks up work already started.
 - The system never auto-resolves a name against the registered-agent set. A label naming an agent that was never registered simply never matches.
 
-## A tool call resolves by exact name, then by folded key
+## A Tool Call Resolves by Exact Name, Then by Folded Key
 
 **`ToolRegistry::get` matches the name the model sent exactly. Failing that, it folds both sides onto a lookup key (lowercase, hyphens to underscores, one trailing `_tool` removed) and resolves to the tool that key matches. A key two registered tools share resolves to nothing.**
 
 - The fold only removes information, so it cannot reach a tool the model did not name. That is what separates it from repairing a malformed argument, which agentwerk never does: the argument payload still reaches the tool untouched and is still rejected by the tool's own schema when wrong.
 - Refusing on ambiguity is the load-bearing half. A host registering `grep_tool` beside the built-in `grep` keeps both reachable under their own names, and a third spelling resolves to neither rather than to an arbitrary winner.
-- `get` is the only seam: dispatch, the read-only batching decision in `partition_tool_calls`, and the `opened_paths` lookup all go through it, so they cannot disagree about which tool a call names.
+- `get` is the only entry point: dispatch, the read-only batching decision in `partition_tool_calls`, and the `opened_paths` lookup all go through it, so they cannot disagree about which tool a call names.
 - The loop rewrites each call to the registered name before emitting `ToolCallStarted`, so `Event` and `Stats` never split one tool across spellings. No event reports the fold; it is a lookup detail, not a state the run reached.
 - A name that resolves to nothing returns `ToolNotFound`, whose model-visible message names every registered tool. Without that list the model has nothing to correct against, and each retry spends `max_schema_retries` budget until the ticket fails.
 - `ToolChoice::Specific` is not folded: it travels outbound and is written by agentwerk or the host, never by the model.
 
-## Finishing is a tool call
+## Finishing Is a Tool Call
 
-**Agents finish tickets through one tool, `finish`. It records the result through `TicketSystem::set_result`, which owns the result-validation-and-logging contract, then transitions the ticket to `Finished`. An optional `handover` argument additionally spawns a child ticket; its presence is the only discriminator, so there is no second tool and no mode field. The loop enforces the rule: a turn that ends without a `finish` call is rejected and retried.**
+**Agents finish tickets through one tool, `finish`. An optional `handover` argument additionally creates a child ticket; its presence is the only discriminator, so there is no second tool and no mode field.**
 
-- Without `handover`, `finish` writes a `result`, attaches it to the current ticket, and transitions to `Finished` via the `write_result` helper. This is terminal work.
-- With `handover`, it does the same and then inserts a child ticket pinned to that agent or label with the current ticket recorded as its `parent`. It inserts the child BEFORE finishing the parent, so the child is already `Todo` when the parent leaves the queue: a concurrent `pending_count()` poll can never see an empty queue between them and `finish()` cannot drain the chain early. `TicketFinished` / `TicketFailed` are emitted synchronously from the status transition itself, and an in-flight transition counter holds the drain open until every handler returns, so a `create_ticket_on_result` follow-up is inserted before `finish()` can observe an empty queue. The alternative — a plain `finish` followed by `manage_tickets::create` — is order-sensitive the other way and leaves the current ticket re-picked when the order is wrong.
+`finish` records the result through `TicketSystem::set_result`, which owns the result-validation-and-logging contract, then transitions the ticket to `Finished`. The loop enforces the rule: a turn that ends without a `finish` call is rejected and retried.
+
+- Without `handover`, `finish` writes a `result`, attaches it to the current ticket, and transitions to `Finished` through the `write_result` helper. This is terminal work.
+- With `handover`, it does the same and then inserts a child ticket pinned to that agent or label, with the current ticket recorded as its `parent`.
+- The child is inserted BEFORE the parent finishes, so it is already `Todo` when the parent leaves the queue. A concurrent `pending_count()` poll can never see an empty queue between them, and `finish()` cannot drain the chain early.
+- `TicketFinished` and `TicketFailed` are emitted synchronously from the status transition itself, and a count of in-flight transitions holds the drain open until every handler returns, so a `create_ticket_on_result` follow-up is inserted before `finish()` can observe an empty queue.
+- The alternative, a plain `finish` followed by `manage_tickets::create`, is order-sensitive the other way and leaves the current ticket re-claimed when the order is wrong.
 - An agent that must always chain can no longer be forced to by its tool registry, since every `finish` accepts an optional `handover`. Its role prompt carries that requirement instead, which makes those prompt lines load-bearing.
 - When a turn ends without a `finish` call and no result attached, the loop pushes a corrective directive and retries. This is the same retry path used for schema-validation failures, bounded by `max_schema_retries`; exhaustion emits `PolicyViolated { MaxSchemaRetries, .. }` and `TicketFailed`.
-- `Status` transitions go through tickets-side helpers; the agent never writes status directly. `Failed` is reserved for system-driven outcomes (schema-retry trip, missing-`finish` exhaustion, policy violations).
-- `Ticket::schema(...)` attaches a `Schema` to the ticket; `finish` validates the result and the loop applies `max_schema_retries` on mismatch. A schema can also be registered as a per-label default via `TicketSystem::schema_for_label`, stamped onto a schemaless ticket at creation, so a result contract follows its label however the ticket was created (direct, labeled, or a handover child). A handover validates its `result` against the parent ticket's own schema, exactly as a plain finish does; it carries no schema for the child, which inherits one only through its label. A schema mismatch aborts before the child is inserted, so neither the parent's finish nor the child happens: the operation stays atomic.
+- `Status` transitions go through tickets-side helpers; the agent never writes status directly. `Failed` is reserved for system-driven outcomes: exhausted schema retries, exhausted missing-`finish` retries, and policy violations.
+
+Schemas and results:
+
+- `Ticket::schema(...)` attaches a `Schema` to the ticket; `finish` validates the result and the loop applies `max_schema_retries` on mismatch.
+- A schema can also be registered as a per-label default through `TicketSystem::schema_for_label`, applied to a schemaless ticket at creation, so a result contract follows its label however the ticket was created: direct, labelled, or as a handover child.
+- A handover validates its `result` against the parent ticket's own schema, exactly as a plain finish does. It carries no schema for the child, which inherits one only through its label. A schema mismatch aborts before the child is inserted, so neither the parent's finish nor the child happens and the operation stays atomic.
 - `handover` and `task` are reserved argument names for `finish`. A ticket whose schema is an object has its fields passed as `finish`'s top-level arguments, so such a schema must not declare a `handover` or `task` property: those names are stripped as control keys before the result is recovered.
-- A successful finish appends one NDJSON record `{ticket, result}` to `<dir>/results.jsonl` (configured via `TicketSystem::dir(d)`; defaults to `./.agentwerk`) and attaches the same `result` value to the ticket. The value is surfaced through `Ticket::result()`; `last_result()` returns its serialized form for the most recent `Finished` ticket.
+- A successful finish appends one NDJSON record `{ticket, result}` to `<dir>/results.jsonl` (configured through `TicketSystem::dir(d)`, default `./.agentwerk`) and attaches the same `result` value to the ticket. The value is surfaced through `Ticket::result()`; `last_result()` returns its serialized form for the most recent `Finished` ticket.
 - The system also appends one JSON line to `<dir>/tickets.jsonl` per lifecycle event (`created`, `started`, `done`, `failed`) and writes the full ticket state to `<dir>/tickets/<key>/ticket.json`. The `created` event carries the optional `parent` key when set, giving the log a complete handover audit trail. The log is observational: errors are swallowed. The result payload stays in `results.jsonl`; `tickets.jsonl` carries only the transition.
 
-## Knowledge is opt-in and shareable across agents
+## Knowledge Is Opt-In and Shareable Across Agents
 
-**An agent can carry durable facts across every ticket it handles via `Agent::knowledge(&store)`, including across separate `start` / `finish` calls and across process restarts. Off by default; each ticket starts without a knowledge section.**
+**An agent can carry durable facts across every ticket it handles through `Agent::knowledge(&store)`, including across separate `start` and `finish` calls and across process restarts. Off by default; each ticket starts without a knowledge section.**
 
-Two layers of state exist. The per-ticket transcript lives on `Ticket::replies`: every message the loop sends to the provider is appended as a `Reply`, and the loop derives the request's `Vec<Message>` from those replies via `Ticket::to_messages` each turn. `Agent::knowledge(&store)` adds a separate cross-ticket layer: a `Knowledge` store rooted at a caller-supplied directory, surfaced to the model through `ManageKnowledgeTool` and rendered into the system prompt under `## Knowledge`.
+Two layers of state exist. The per-ticket replies live on `Ticket::replies`: every message the loop sends to the provider is appended as a `Reply`, and the loop derives the request's `Vec<Message>` from those replies through `Ticket::to_messages` each turn. `Agent::knowledge(&store)` adds a separate cross-ticket layer: a `Knowledge` store rooted at a caller-supplied directory, surfaced to the model through `ManageKnowledgeTool` and rendered into the system prompt.
 
-- The store is constructed via `Knowledge::load(store_dir)` and passed to one or more agents through `Agent::knowledge(&store)`. Two agents bound to the same `Arc<Knowledge>` share the same `index.md` and `pages/` directory; two agents bound to different stores see independent knowledge. The pattern mirrors `Agent::ticket_system(&Arc<TicketSystem>)`. Pointing `Knowledge::load` at the same directory as `TicketSystem::dir` co-locates the `knowledge/` bundle with `results.jsonl` and `tickets.jsonl`.
-- The store is an Open Knowledge Format (OKF) v0.1 bundle held in `<dir>/knowledge/` (`BUNDLE_DIR`), which keeps it out of a co-located `TicketSystem`'s files and keeps the recursive page walk inside the bundle. `<dir>/knowledge/pages/<slug>.md` holds each concept with `type` / `description` / `timestamp` frontmatter, and pages cross-link with standard markdown links (`[text](/pages/slug.md)`). `<dir>/knowledge/index.md` is a derived progressive-disclosure view with a clickable link per page. Only the compact index is injected into the system prompt; the agent reads full pages on demand via the `read` action. `index.md` is written but never parsed back: on load the in-memory index is rebuilt by walking the page frontmatter (`rebuild_index_from_pages`), so an OKF bundle placed in `<dir>/knowledge/` seeds the store from it.
+- The store is constructed through `Knowledge::load(store_dir)` and passed to one or more agents through `Agent::knowledge(&store)`. Two agents bound to the same `Arc<Knowledge>` share the same `index.md` and `pages/` directory; two agents bound to different stores see independent knowledge.
+- The pattern mirrors `Agent::ticket_system(&Arc<TicketSystem>)`. Pointing `Knowledge::load` at the same directory as `TicketSystem::dir` co-locates the `knowledge/` bundle with `results.jsonl` and `tickets.jsonl`.
+- The store is an Open Knowledge Format (OKF) v0.1 bundle held in `<dir>/knowledge/` (`BUNDLE_DIR`), which keeps it out of a co-located `TicketSystem`'s files and keeps the recursive page walk inside the bundle.
+- `<dir>/knowledge/pages/<slug>.md` holds each concept with `type`, `description`, and `timestamp` frontmatter, and pages cross-link with standard markdown links (`[text](/pages/slug.md)`). `<dir>/knowledge/index.md` is a derived progressive-disclosure view with a clickable link per page.
+- Only the compact index is injected into the system prompt; the agent reads full pages on demand through the `read` action. `index.md` is written but never parsed back: on load the in-memory index is rebuilt by walking the page frontmatter (`rebuild_index_from_pages`), so an OKF bundle placed in `<dir>/knowledge/` seeds the store from it.
 - The loop reads `Knowledge::index()` once at the top of `process_ticket` and feeds the result to `Agent::system_prompt(knowledge: Option<&str>)`. The system prompt stays byte-stable across every turn of the ticket so the provider's prefix cache survives mid-ticket knowledge writes; cross-ticket and cross-agent writes become visible at the top of the next ticket.
-- Knowledge is purely model-driven. The model calls `manage_knowledge` with `write` / `read` / `remove` / `list`; the tool description carries the policy (durable facts only, do NOT save task progress / TODOs). A page's `type` and `tags` are host-side concerns set through the `Page` API, not tool parameters. A hard char limit on the rendered index rejects writes that would push the prompt section past the cap and tells the model to consolidate first. The limit defaults to 12 000 and is configurable via `Knowledge::index_char_limit(n)` on the loaded store.
+- Knowledge is purely model-driven. The model calls `manage_knowledge` with `write`, `read`, `remove`, or `list`; the tool description carries the policy (durable facts only, do NOT save task progress or TODOs). A page's `type` and `tags` are host-side concerns set through the `Page` API, not tool parameters.
+- A hard character limit on the rendered index rejects writes that would push the prompt section past the limit and tells the model to consolidate first. It defaults to 12 000 and is configurable through `Knowledge::index_char_limit(n)` on the loaded store.
 
-## Observer chain, one error path
+## Observer Chain, One Error Path
 
 **`Event` reports state. `ProviderError` and `ToolError` report failed contracts. The two channels carry independent information.**
 
-- State transitions exist only as `Event` (`TicketClaimed`, `TicketFinished`, `RequestStarted`, `RequestFinished`, `TextChunkReceived`).
+- State transitions exist only as `Event`: `TicketClaimed`, `TicketFinished`, `RequestStarted`, `RequestFinished`, `TextChunkReceived`.
 - An observable failure fires both the typed error (`ProviderError`, `ToolError`) and a matching `Event` (`RequestFailed`, `ToolCallFailed`, `PolicyViolated`).
-- A model-fixable failure (wrong arguments, schema mismatch, missing file) goes back to the model as a `ToolResult::Error` content block; it still fires `ToolCallFailed` but does not stop the run.
-- Handlers MUST be cheap, non-blocking closures; the loop does not await them.
-- `TicketSystem::on_event(h)` pushes a handler onto an ordered chain — every installed handler fires on every event, in installation order, and each is handed the same `&Event` rather than its own copy. When no handler is installed, `default_logger` runs in its place. This composition is what `cancel_on_event(predicate)` is built on: it pushes a handler that calls `cancel()` when the predicate matches, so the user's logger and the cancel trigger coexist. Every other hook is one more entry on this chain. `on_result` filters to `TicketFinished` and unwraps the stored result, `on_failure` filters on `EventKind::is_failure`, and `on_ticket` filters to the three lifecycle kinds; each resolves `event.ticket_key` to a cloned `Ticket` first, which is why none of them fires on every kind: resolving on `TextChunkReceived` would copy a transcript once per streamed chunk. The `_on_result` and `_on_failure` reactors are in turn built on `on_result` and `on_failure`, so the resolve happens in one place. `EventKind::RunStarted` and `EventKind::RunFinished { reason }` ride the same chain; they are emitted by the `TicketSystem` itself and arrive with an empty `agent_name`, as does `TicketFailed` from a host-driven `set_failed`.
+- A model-fixable failure (wrong arguments, schema mismatch, missing file) goes back to the model as a `ToolResult::Error` content block. It still fires `ToolCallFailed` but does not stop the run.
+- Handlers MUST be cheap and non-blocking; the loop does not await them.
 
-## New observables pick a channel
+`TicketSystem::on_event(h)` pushes a handler onto an ordered chain. Every installed handler fires on every event, in installation order, and each is handed the same `&Event` rather than its own copy. When no handler is installed, `default_logger` runs in its place.
+
+- That composition is what `cancel_on_event(condition)` is built on: it pushes a handler that calls `cancel()` when the condition matches, so a host's logger and the cancel trigger coexist. Every other hook is one more entry on this chain.
+- `on_result` filters to `TicketFinished` and unwraps the stored result, `on_failure` filters on `EventKind::is_failure`, and `on_ticket` filters to the three lifecycle kinds.
+- Each of those three resolves `event.ticket_key` to a cloned `Ticket` first, which is why none of them fires on every kind: resolving on `TextChunkReceived` would copy a ticket's whole replies once per chunk.
+- The `_on_result` and `_on_failure` reactors are in turn built on `on_result` and `on_failure`, so the resolve happens in one place.
+- `EventKind::RunStarted` and `EventKind::RunFinished { reason }` ride the same chain. They are emitted by the `TicketSystem` itself and arrive with an empty `agent_name`, as does `TicketFailed` from a host-driven `set_failed`.
+
+## New Observables Pick a Channel
 
 **Each new signal goes on `Event`, on a typed error, or on both. Pick by what the signal describes.**
 
 - Reached a state: `Event` only.
 - Could not fulfil a contract: typed error in the matching domain.
-- Both at once (terminal request failure, policy trip): define both. Share the payload type when observer-friendly (`PolicyKind`); introduce a stripped `Kind` enum when the error carries observer-hostile detail (`RequestErrorKind`, `ToolFailureKind`).
+- Both at once (terminal request failure, policy violation): define both. Share the payload type when observer-friendly (`PolicyKind`); introduce a stripped `Kind` enum when the error carries observer-hostile detail (`RequestErrorKind`, `ToolFailureKind`).
 - Model-fixable failure: `ToolResult::Error(String)`; still fires `ToolCallFailed` but is recoverable.
 - A public error enum carries `#[non_exhaustive]`, so a later variant is not a breaking change for callers that match on it. `ProviderError` and `ToolError` both do. The attribute covers new variants only: adding a field to an existing struct variant still breaks a caller that matches it without `..`, so prefer a new variant to widening an old one.
 
-## Providers own their client
+## Providers Own Their Client
 
 **Each concrete provider owns a `reqwest::Client` directly. There is no transport abstraction.**
 
 - The `Provider` trait fulfils one contract: `respond` (drive one turn) plus per-vendor metadata.
 - `ModelRequest`, `Message`, `ContentBlock`, and `TokenUsage` are the request and response types every provider converts to and from.
-- Those types (plus `ModelResponse`, `StreamEvent`, `ResponseStatus`, `ToolChoice`, `ProviderToolDefinition`) are `pub` and documented: the `Provider` trait is a supported extension point, and its implementors name them.
-- HTTP error mapping is shared through `providers::map_http_errors` plus a provider-specific `classify` closure; SSE parsing lives in `providers::stream`.
+- Those types, plus `ModelResponse`, `StreamEvent`, `ResponseStatus`, `ToolChoice`, and `ProviderToolDefinition`, are `pub` and documented: the `Provider` trait is a supported extension point, and its implementors name them.
+- HTTP error mapping is shared through `providers::map_http_errors` plus a provider-specific `classify_error`; SSE parsing lives in `providers::stream`.
 - Retry happens at the request level using `Policies::max_request_retries` and `request_retry_delay`; vendor code does not retry.
 
-## Cancellation is cooperative, split into two signals
+## Cancellation Is Cooperative, Split Into Two Signals
 
-**Two `Arc<AtomicBool>` signals separate "stop the workers" from "external cancel was requested." Both flip on cancel; only the stop signal flips on policy or drain.**
+**Two `Arc<AtomicBool>` signals separate "stop the agent tasks" from "external cancel was requested". Both flip on cancel; only the stop signal flips on a policy violation or a clean drain.**
 
-- `TicketSystem::stop_signal` is what workers and tools poll. `finish()` flips it on cancel, on policy violation, and on clean drain so the worker loop, in-flight tools, and the join handle all wind down.
-- `TicketSystem::cancel_signal` is flipped only by `cancel()`, `cancel_on(trigger)`, and the three `cancel_on_*(predicate)` reactors. `is_cancelled()` reads it; a clean drain leaves it untouched so observers can tell the three exit paths apart. The `cancel_label_on_*` reactors leave it alone: they call off one pool, not the run.
+- `TicketSystem::stop_signal` is what the agent tasks and the tools poll. `finish()` flips it on cancel, on policy violation, and on clean drain so the per-agent loop, the in-flight tools, and the join handle all wind down.
+- `TicketSystem::cancel_signal` is flipped only by `cancel()`, `cancel_on(trigger)`, and the three `cancel_on_*` reactors. `is_cancelled()` reads it; a clean drain leaves it untouched so observers can tell the three exit paths apart.
+- The `cancel_label_on_*` reactors leave `cancel_signal` alone: they stop one pool, not the run. `TicketSystem::cancelled_labels` holds those labels, and the loop neither claims nor resumes a ticket carrying one.
 - `cancel()` flips both atomics in sync. `cancel_on*` route through `cancel()` so cancellation triggers compose with the rest of the run's lifecycle.
-- Tools observe the stop signal through `ToolContext::interrupt_signal` and `wait_for_cancel`; pair with `tokio::select!` so cancel drops the losing branch promptly.
-- Dropping the `TicketSystem` while agents still reference it via `Weak` is the public way to abort: the upgrade fails and each task panics out cleanly.
-- `finish()` announces its exit reason as `FinishReason::Drained`, `FinishReason::PolicyViolated(kind)`, or `FinishReason::Cancelled`, in that precedence. The reason is stashed for `TicketSystem::finish_reason()` and emitted as `EventKind::RunFinished { reason }`.
+- Tools observe the stop signal through `ToolContext::interrupt_signal` and `wait_for_cancel`; pair them with `tokio::select!` so cancel drops the losing branch promptly.
+- Dropping the `TicketSystem` while agents still reference it through `Weak` is the public way to abort: the upgrade fails and each task panics out cleanly.
+- `finish()` announces its exit reason as `FinishReason::Drained`, `FinishReason::PolicyViolated(kind)`, or `FinishReason::Cancelled`, in that precedence. The reason is kept for `TicketSystem::finish_reason()` and emitted as `EventKind::RunFinished { reason }`.
 
-## Stats are event-derived, one writer
+## Stats Are Event-Derived, One Writer
 
-**`Stats::record_event` is the single writer for event-derived stats: every `EventKind` is counted automatically by its name; only ticket lifecycle writes directly.**
+**`Stats::record_event` is the single writer for event-derived statistics: every `EventKind` is counted automatically by its name; only the ticket lifecycle writes directly.**
 
-- `TicketSystem::emit` forwards every event to `Stats::record_event(kind, key, labels)` before firing observers. The event's `EventKind::name()` keys a per-kind count map, so a new variant is counted the moment it names itself in that exhaustive match — no stats code to add.
+- `TicketSystem::emit` forwards every event to `Stats::record_event(kind, key, labels)` before firing observers. The event's `EventKind::name()` keys a per-kind count map, so a new variant is counted the moment it names itself in that exhaustive match, with no statistics code to add.
 - The named accessors are lookups into that map: `turns()` reads `turn_started`, `requests()` reads `request_finished`, `tool_calls()` reads `tool_call_started`, `errors()` reads `request_failed`. `event_counts()` exposes the whole map.
-- Payload-bearing measures keep explicit arms in `record_event`: token sums and usage history from `RequestFinished`, per-tool tallies from `ToolCallStarted`/`ToolCallFailed`, per-path tallies from `FileOpenFinished`/`FileOpenFailed`, knowledge tallies from `KnowledgeUsed`/`KnowledgeMissed`.
-- Ticket lifecycle (`record_created`, `record_started`, `record_finished`, `record_failed`) is written directly by the store: transitions carry durations events do not, and host-side mutations have no agent loop attached.
-- Reads happen on `Stats` directly through inherent accessors (`turns()`, `tickets_finished()`, `run_duration()`, `tickets_success_rate()`, ...).
-- `Stats::stats_for_label(label)` returns a nested `Stats` slice scoped to one label. `record_event` mirrors the count and token measures onto each slice the ticket carries; `run_duration()` is `None` on a slice (elapsed run duration stays global).
+- Payload-bearing measures keep explicit arms in `record_event`: token sums and usage history from `RequestFinished`, per-tool tallies from `ToolCallStarted` and `ToolCallFailed`, per-path tallies from `FileOpenFinished` and `FileOpenFailed`, knowledge tallies from `KnowledgeUsed` and `KnowledgeMissed`.
+- The ticket lifecycle (`record_created`, `record_started`, `record_finished`, `record_failed`) is written directly by the store: transitions carry durations that events do not, and host-side mutations have no agent loop attached.
+- Reads happen on `Stats` directly through inherent accessors such as `turns()`, `tickets_finished()`, `run_duration()`, and `tickets_success_rate()`.
+- `Stats::stats_for_label(label)` returns a nested `Stats` slice scoped to one label. `record_event` mirrors the count and token measures onto each slice the ticket carries; `run_duration()` is `None` on a slice, since elapsed run duration stays global.
 - The subject maps (`tool_stats()`, `file_stats()`, `knowledge_stats()`) are recorded global-only, like `usage_history`; per-label slices stay empty there.
 
-## Persistence routes through two traits
+## Persistence Routes Through Two Traits
 
 **Every read and write in the crate goes through `Persist` (state files) or `Append` (jsonl logs) in `persistence`. No domain module hand-rolls file IO; no module knows its file's name except the implementer.**
 
-- `Persist` defines `save(&self, dir) -> io::Result<()>` and `load(dir, &Self::Key) -> io::Result<Self>`. `Stats`, `Ticket`, `Replies`, `Page`, and `Trajectory` implement it; each owns its own path layout (`stats.json`, `tickets/<key>/ticket.json`, `tickets/<key>/replies.jsonl`, `pages/<slug>.md`, `trajectories/<key>.json`). A value type the caller stores itself reaches its file through an inherent method that delegates to its own impl, never by publishing the trait: `Trajectory::save(dir)` and `Knowledge::pages().save(page)` are the two. Service bootstrap (`TicketSystem::load`, `Knowledge::load`) uses the same `load` verb for its dir-to-`Arc<Self>` entry by convention.
+- `Persist` defines `save(&self, dir) -> io::Result<()>` and `load(dir, &Self::Key) -> io::Result<Self>`. `Stats`, `Ticket`, `Replies`, `Page`, and `Trajectory` implement it; each owns its own path layout (`stats.json`, `tickets/<key>/ticket.json`, `tickets/<key>/replies.jsonl`, `pages/<slug>.md`, `trajectories/<key>.json`).
+- A value type the caller stores itself reaches its file through an inherent method that delegates to its own impl, never by publishing the trait: `Trajectory::save(dir)` and `Knowledge::pages().save(page)` are the two. Service bootstrap (`TicketSystem::load`, `Knowledge::load`) uses the same `load` verb for its directory-to-`Arc<Self>` entry by convention.
 - `Append` defines `append(dir, &Self::Record) -> io::Result<()>`. `Results` writes `results.jsonl`; `TicketEvents` writes `tickets.jsonl`. The wrong type cannot reach the wrong file: each implementer's `append` body hardcodes the filename.
-- The per-ticket transcript is the one shape that does not fit either trait. `Replies` (in `agents::tickets`) is a free type with `append(dir, key, &Reply)` and `load(dir, key) -> Vec<Reply>`. It writes one JSON line per `Reply` to `tickets/<key>/replies.jsonl`; `load` reads that one file back, one `Reply` per line. `Replies` also implements `Persist`, whose `save` overwrites the file wholesale so a dropped or redacted reply leaves nothing behind. The `append` half is per-key, so the single-fixed-filename `Append` trait does not generalize cleanly; promote to a trait only when a second per-key transcript appears.
+- The per-ticket replies are the one shape that does not fit either trait. `Replies` (in `agents::tickets`) is a free type with `append(dir, key, &Reply)` and `load(dir, key) -> Vec<Reply>`, writing one JSON line per `Reply` to `tickets/<key>/replies.jsonl`.
+- `Replies` also implements `Persist`, whose `save` overwrites the file wholesale so a dropped or redacted reply leaves nothing behind. The `append` half is per-key, so the single-fixed-filename `Append` trait does not generalize cleanly; promote it to a trait only when a second per-key log appears.
+- `TICKET-<N>` keys are handed out in order. `load()` seeds the next key from the tickets it just read off disk; a system built with `new()` scans for the highest existing key at the first insert instead, since `new()` never reads the directory itself.
 - One agent processes one ticket at a time (claim is atomic), so `add_reply` and the rewrite for one key are sequential within a single loop task. No per-key lock is needed for either path.
-- Crate-internal helpers `write_atomic` (tmp+rename) and `append_line` (`O_APPEND` + newline) are the only places that touch the filesystem. They are `pub(crate)` so trait impls colocated with their types can call them; by convention nothing outside a `Persist` or `Append` impl reaches for them. Two documented exceptions: `TicketSystem::write_tool_output` writes single-shot flat files that don't fit either trait; `TicketSystem::summarize` (called from `agents::compaction::run`) writes two files rather than one, calling `Replies::save` and then `save_ticket`, because the pair is a two-file operation that no single in-memory value owns.
-- Vocabulary is fixed: `save`, `load`, `append`. Bootstrap verbs other than `load` (e.g. `open`) are not used. Domain words (`checkpoint`, `snapshot`, `counter`, `persist`) do not appear in identifiers or test names.
+- Crate-internal helpers `write_atomic` (tmp plus rename) and `append_line` (`O_APPEND` plus newline) are the only places that touch the filesystem. They are `pub(crate)` so trait impls colocated with their types can call them; by convention nothing outside a `Persist` or `Append` impl reaches for them.
+- Two documented exceptions: `TicketSystem::write_tool_output` writes single-shot flat files that fit neither trait, and `TicketSystem::summarize` (called from `agents::compaction::run`) writes two files rather than one, calling `Replies::save` and then `save_ticket`, because the pair is a two-file operation that no single in-memory value owns.
+- Vocabulary is fixed: `save`, `load`, `append`. Bootstrap verbs other than `load` (such as `open`) are not used. Domain words (`checkpoint`, `snapshot`, `counter`, `persist`) do not appear in identifiers or test names.
 
-## Policies are per-system, checked at turn boundaries
+## Policies Are Per-System, Checked at Turn Boundaries
 
-**A run stops cleanly when any limit on `Policies` trips. The check fires `EventKind::PolicyViolated` and exits the per-agent task.**
+**A run stops cleanly when any limit on `Policies` is breached. The check fires `EventKind::PolicyViolated` and exits the per-agent task.**
 
-- The loop calls `policy_violated_kind` at each iteration; a non-`None` return walks the agent off the queue.
+- The loop calls `policy_violated_kind` at each iteration; a non-`None` return takes the agent off the queue.
 - Token budgets read from `Stats`; `max_time` reads from `Policies` and from `Stats::run_duration()`. All limits, including `max_time`, route through `policy_violated_kind` and emit `PolicyViolated`; `finish()` carries the matching `FinishReason::PolicyViolated(kind)` back to the caller.
-- Schema-retry budget is applied per-ticket inside the result-writing path, not at the top of the loop.
+- The schema-retry budget is applied per-ticket inside the result-writing path, not at the top of the loop.

--- a/agentdocs/layout.md
+++ b/agentdocs/layout.md
@@ -6,58 +6,70 @@ Where code lives and the rules that govern placement.
 
 **Three crates: one library, one binding layer, one example set.**
 
-- `crates/agentwerk/` is the library.
-- `crates/agentwerk-py/` is the Python binding layer, described below.
-- `crates/use-cases/` holds runnable example binaries that depend on the library.
-- Nothing in `use-cases` is re-exported by the library.
+```
+crates/
+├── agentwerk/      the library
+├── agentwerk-py/   the Python bindings
+└── use-cases/      runnable example binaries
+```
 
-## The `agentwerk-py` crate
+- Nothing in `use-cases` is re-exported by the library.
+- `use-cases` depends on the library, never the other way round.
+
+## The `agentwerk-py` Crate
 
 **One file per bound concept, mirroring the library. Naming rules live in [style.md](style.md).**
 
-- `src/lib.rs` is the `#[pymodule]` and registers every class and function; `agent.rs`, `ticket.rs`, `ticket_system.rs`, `reply.rs`, `trajectory.rs`, `knowledge.rs`, `stats.rs`, `schema.rs`, `event.rs`, `providers.rs`, and `tools.rs` each bind the library module of the same name. `reply.rs` also owns the two reply converters the editors on `TicketSystem` use.
+- `src/lib.rs` is the `#[pymodule]` and registers every class and function.
+- `agent.rs`, `ticket.rs`, `ticket_system.rs`, `reply.rs`, `trajectory.rs`, `knowledge.rs`, `stats.rs`, `schema.rs`, `event.rs`, `providers.rs`, and `tools.rs` each bind the library module of the same name. `reply.rs` also owns the two reply converters the editors on `TicketSystem` use.
 - `src/convert.rs` holds the only JSON boundary: `py_to_value` and `value_to_py` over `pythonize`, plus `runtime_error`.
-- The compiled extension is `_agentwerk`; `python/agentwerk/__init__.py` re-exports it and holds the `@tool` decorator, the one piece of pure-Python logic. `__init__.pyi` declares the surface and MUST match the module, which `tests/test_parity.py` enforces.
+- The compiled extension is `_agentwerk`. `python/agentwerk/__init__.py` re-exports it and holds the `@tool` decorator, the one piece of pure-Python logic.
+- `__init__.pyi` declares the surface and MUST match the module, which `tests/test_parity.py` enforces.
 - `examples/` holds runnable Python scripts, the counterpart of `crates/use-cases/` on the Rust side.
 - `DIFFS.md` lists the whole public surface of both languages in one table, Rust next to Python. A public item missing from it, or a divergence its cells do not state, is a bug in one of the two.
 - The crate is a workspace member but not a default member: `cargo build` and `cargo test` skip it because it links against a Python interpreter. Its commands live in [workflow.md](workflow.md).
 
-## Top-level files
+## Top-Level Files
 
 **Each top-level source file is one concern the caller observes directly.**
 
-- `lib.rs` holds public re-exports only. The crate root lands the orchestration surface plus the types its own signatures hand to callers: `Agent`, `AgentBuilder`, `TicketSystem`, `Ticket`, `Status`, `Reply`, `Trajectory`, `Knowledge`, `Stats`, `Schema`, `Event`, `EventKind`, `FinishReason`. Extension types live in `tools::`; `default_logger` lives in `event::`. Callers reach into a sub-module when they need anything below the orchestration level.
+- `lib.rs` holds public re-exports only: `Agent`, `AgentBuilder`, `TicketSystem`, `Ticket`, `Status`, `Reply`, `Trajectory`, `Knowledge`, `Stats`, `Schema`, `Event`, `EventKind`, `FinishReason`.
+- Extension types live in `tools::` and `default_logger` in `event::`. Callers reach into a sub-module when they need anything below the orchestration level.
 - `event.rs` defines `Event`, `EventKind`, `PolicyKind`, `FinishReason`, `ToolFailureKind`, `CompactReason`, and `default_logger`.
-- `persistence.rs` holds the `Persist` and `Append` traits, the log types (`Results`, `TicketEvents`), and the shared `write_atomic` / `append_line` / `output_path` helpers. Every persistable type and the results-log writer (in `tools/tickets`) route through it. Internal (`pub(crate)`); not re-exported from `lib.rs`.
-- The `agents/`, `prompts/`, `providers/`, `schemas/`, and `tools/` modules each own their domain. The `agents/` and `tools/` modules also re-export their headline types so `use agentwerk::agents::{Agent, TicketSystem}` and `use agentwerk::tools::BashTool` work without descending into leaf files.
+- `persistence.rs` holds the `Persist` and `Append` traits, the log types (`Results`, `TicketEvents`), and the shared `write_atomic`, `append_line`, and `output_path` helpers. It is `pub(crate)` and not re-exported from `lib.rs`.
+- The `agents/`, `prompts/`, `providers/`, `schemas/`, and `tools/` modules each own their domain. `agents/` and `tools/` also re-export their headline types, so `use agentwerk::agents::{Agent, TicketSystem}` and `use agentwerk::tools::BashTool` work without descending into leaf files.
 
-## The `agents/` module
+## The `agents/` Module
 
 **Holds the per-agent builder, the ticket system, and the multi-agent loop.**
 
 - `agent.rs` holds the `Agent` builder and ticket-dispatch helpers; an `Agent` carries a `Weak<TicketSystem>` bound at `bind_agent` time.
-- `tickets/` holds the ticket value types and the orchestrator. `Reply` is the per-ticket transcript entry; `ReplyContent` mirrors `providers::ContentBlock` and carries the same serde tags, so both serialize alike and the ticket surface stays free of provider types. Split by concern:
-  - `tickets/mod.rs`: re-exports `Author`, `Reply`, `ReplyContent`, `Status`, `Ticket`, `TicketError`, `TicketSystem`, `Trajectory`; hosts free helpers `policy_violated`, `policy_violated_kind`, `now_millis`, `numeric_id`.
-  - `tickets/ticket.rs`: `Ticket`, `Status`, the `Replies` transcript-log helper, and the `tickets/<key>/...` path helpers.
-  - `tickets/reply.rs`: `Author`, `Reply`, `ReplyContent`, and their conversions to and from `providers::Message` / `ContentBlock`.
-  - `tickets/error.rs`: `TicketError`.
-  - `tickets/ticket_system.rs`: the `TicketSystem` struct, constructors, configuration, policy builders, ticket-creation API, agent binding, run lifecycle, results, and queries.
-  - `tickets/store.rs`: the `impl TicketSystem` block for store mutations (`insert`, `claim`, `set_finished`, `summarize`, transition recording, etc.).
-  - `tickets/trajectory.rs`: `Trajectory`, a ticket's replies captured as a training example, its `trajectories/<key>.json` write, and the `.html` rendering written beside it.
-- `loop/` holds the multi-agent loop, split by state:
-  - `loop/mod.rs`: module wiring and the `Step` enum naming each state of the per-ticket state machine.
-  - `loop/main.rs`: `run_main_loop`, which spawns one tokio task per registered agent and joins them on shutdown.
-  - `loop/agent.rs`: `run_agent` (outer claim loop plus the inner `Step` match), `TicketContext`, the ticket check, and the silence retry.
-  - `loop/compact.rs`: proactive and reactive transcript compaction.
-  - `loop/request.rs`: the provider round-trip with retry and backoff.
-  - `loop/tool_call.rs`: tool dispatch, output offloading, and the tool-failure budget.
-- `knowledge.rs` holds `Knowledge`: the cross-ticket store, an OKF v0.1 bundle in `<dir>/knowledge/` backed by a `pages/` directory of concept files and a derived `index.md`. Pages are curated through the `pages()` handle (`save` / `load` / `remove`) plus `clear`; failures are typed as `KnowledgeError`.
+- `knowledge.rs` holds `Knowledge`: the cross-ticket store, an OKF v0.1 bundle in `<dir>/knowledge/` backed by a `pages/` directory of concept files and a derived `index.md`. Pages are curated through the `pages()` handle (`save`, `load`, `remove`) plus `clear`; failures are typed as `KnowledgeError`.
 - `policy.rs` holds `Policies` and the limit checks the loop applies on each turn.
-- `stats.rs` holds `Stats` and the run-wide counters and timings.
+- `stats.rs` holds `Stats` and the run-wide statistics and timings.
 
-## The `providers/` module
+`tickets/` holds the ticket value types and the orchestrator. `Reply` is one entry in a ticket's replies; `ReplyContent` mirrors `providers::ContentBlock` and carries the same serde tags, so both serialize alike and the ticket surface stays free of provider types.
 
-**Holds every concrete provider plus the shared transport types.**
+- `tickets/mod.rs`: re-exports `Author`, `Reply`, `ReplyContent`, `Status`, `Ticket`, `TicketError`, `TicketSystem`, `Trajectory`; hosts the free helpers `policy_violated`, `policy_violated_kind`, `now_millis`, `numeric_id`.
+- `tickets/ticket.rs`: `Ticket`, `Status`, the `Replies` log helper, and the `tickets/<key>/...` path helpers.
+- `tickets/reply.rs`: `Author`, `Reply`, `ReplyContent`, and their conversions to and from `providers::Message` and `ContentBlock`.
+- `tickets/error.rs`: `TicketError`.
+- `tickets/ticket_system.rs`: the `TicketSystem` struct, constructors, configuration, policy builders, ticket-creation API, agent binding, run lifecycle, results, and queries.
+- `tickets/store.rs`: the `impl TicketSystem` block for store mutations (`insert`, `claim`, `set_finished`, `summarize`, transition recording).
+- `tickets/trajectory.rs`: `Trajectory`, a ticket's replies captured as a training example, its `trajectories/<key>.json` write, and the `.html` rendering written beside it.
+
+`loop/` holds the multi-agent loop, split by state:
+
+- `loop/mod.rs`: module wiring and the `Step` enum naming each state of the per-ticket state machine.
+- `loop/main.rs`: `run_main_loop`, which spawns one tokio task per registered agent and joins them on shutdown.
+- `loop/agent.rs`: `run_agent` (outer claim loop plus the inner `Step` match), `TicketContext`, the ticket check, and the silence retry.
+- `loop/compact.rs`: proactive and reactive compaction of a ticket's replies.
+- `loop/request.rs`: the provider round-trip with retry and backoff.
+- `loop/tool_call.rs`: tool dispatch, output offloading, and the tool-failure budget.
+
+## The `providers/` Module
+
+**Holds every concrete LLM provider plus the shared request and response types.**
 
 - `provider.rs` defines `Provider`, `ModelRequest`, `ProviderToolDefinition`, and `ToolChoice`.
 - `types.rs` defines `Message`, `ContentBlock`, `TokenUsage`, `AsUserMessage`, `ResponseStatus`, and `StreamEvent`.
@@ -65,21 +77,19 @@ Where code lives and the rules that govern placement.
 - `environment.rs` implements `from_env()` and `model_from_env()`.
 - `stream.rs` holds the SSE parser; `error.rs` holds `ProviderError`, `ProviderResult`, and `RequestErrorKind`.
 
-## The `tools/` module
+## The `tools/` Module
 
 **`tool.rs` holds the trait and registry; every other file is one built-in tool or a helper.**
 
 - `tool.rs` defines `ToolLike`, `Tool`, `ToolRegistry`, `ToolContext`, and `ToolCall`.
 - `read_file.rs`, `write_file.rs`, `edit_file.rs`, `glob.rs`, `grep.rs`, and `list_directory.rs` are filesystem tools.
 - `code.rs` backs `grep`'s `syntax: "code"` shape matching, delegating to the `codegrep` engine.
-- `bash.rs` is the shell tool (restricted via `new()`, unrestricted via `unrestricted()`).
-- `tickets/` holds `ManageTicketsTool` and `ReadTicketsTool`.
-- `manage_knowledge.rs` is the model-facing wrapper around `Knowledge` (the store lives in `agents::knowledge`).
-- `find_tools.rs` is the discovery surface for deferred tools.
-- `fetch_url.rs` is the web fetch tool.
+- `bash.rs` is the shell tool, restricted through `new()` and unrestricted through `unrestricted()`.
+- `tickets/` holds `ManageTicketsTool` and `ReadTicketsTool`; `manage_knowledge.rs` is the model-facing wrapper around `Knowledge`, whose store lives in `agents::knowledge`.
+- `find_tools.rs` is the discovery surface for deferred tools; `fetch_url.rs` is the web fetch tool.
 - Each built-in tool pairs with a `<tool>.tool.md` definition: `---` frontmatter (`name`, `read_only`), a prose body shown to the model, and a `## Schema` section whose ` ```json ` fence holds the input schema. `tool_file.rs` parses it; `util.rs` is a shared helper; `error.rs` holds `ToolError`.
 
-## The `prompts/` and `schemas/` modules
+## The `prompts/` and `schemas/` Modules
 
 **Composable prompt assembly and JSON-Schema validation.**
 

--- a/agentdocs/project.md
+++ b/agentdocs/project.md
@@ -1,8 +1,8 @@
 # Project
 
-agentwerk is a Rust crate for building LLM agents. An agent reads input, calls a provider, optionally invokes tools, and returns an output. The six sections below list the design principles the rest of the crate is measured against.
+agentwerk is a Rust crate for building LLM agents. An agent reads input, calls an LLM provider, optionally invokes tools, and returns an output. The six sections below list the design principles the rest of the crate is measured against.
 
-## Library, not framework
+## Library, Not Framework
 
 **The crate provides building blocks. The caller composes them.**
 
@@ -11,7 +11,7 @@ agentwerk is a Rust crate for building LLM agents. An agent reads input, calls a
 - No required structure for the consuming application.
 - Every feature is optional.
 
-## Minimal surface
+## Minimal Surface
 
 **Each abstraction must remove more complexity than it adds.**
 
@@ -20,25 +20,30 @@ agentwerk is a Rust crate for building LLM agents. An agent reads input, calls a
 - Providers own a `reqwest::Client` directly.
 - Indirection without a concrete benefit is not added.
 
-## Parallel by default
+## Parallel by Default
 
 **Many agents share one `TicketSystem` and pick up tickets concurrently.**
 
+```rust
+tickets.agent(Agent::new().name("scout_0").label("scan").from_env().build());
+tickets.ticket(Ticket::new("Audit src/db.").label("scan"));
+```
+
 - Each agent runs on its own tokio task; the shared queue claims a ticket exactly once.
-- Labels assign work to matching agents (Path B); names pin a ticket to one agent (Path A).
+- A label assigns work to every agent carrying it. An agent's own name is one of its labels, so naming a label pins the ticket to that one agent.
 - Agents are cloned and modified, then bound to a `TicketSystem`. No global registration, no implicit state.
 - A ticket carries a `Schema`; the loop validates the agent's result against it.
 
-## Provider-agnostic
+## Provider-Agnostic
 
-**The same agent code runs against any supported provider.**
+**The same agent code runs against any supported LLM provider.**
 
 - Anthropic, OpenAI, Mistral, and LiteLLM are supported.
 - Switching providers changes only the `.model(...)` call.
 - All providers share one retry policy.
 - `from_env()` and `model_from_env()` (in `providers::environment`) select a provider and model from environment variables.
 
-## Observe, do not prescribe
+## Observe, Do Not Prescribe
 
 **The loop emits events. The caller decides what to do with them.**
 
@@ -47,7 +52,7 @@ agentwerk is a Rust crate for building LLM agents. An agent reads input, calls a
 - The event handler receives `Event { kind, ... }` at every lifecycle boundary.
 - The handler may log, forward, store, or discard each event.
 
-## Correctness over convenience
+## Correctness Over Convenience
 
 **Zero warnings, typed errors, no silent fallbacks.**
 

--- a/agentdocs/style.md
+++ b/agentdocs/style.md
@@ -1,57 +1,62 @@
 # Style
 
-Naming and comment rules, plus README structure. Skim the section matching what is being written.
+Naming, comment, and prose rules, plus README structure. Skim the section matching what is being written.
 
-## Crate root
+## Crate Root
 
 **A type earns a `pub use` at `lib.rs` only when it names a concept in the one-sentence description of the crate, or when root-level signatures hand it to the caller.**
 
-- The current root: `Agent`, `AgentBuilder`, `TicketSystem`, `Ticket`, `Knowledge`, `Stats`, `Trajectory`, `Reply`, `Event`, `Status`, `EventKind`, `FinishReason`, `Schema`.
+`Agent`, `AgentBuilder`, `TicketSystem`, `Ticket`, `Knowledge`, `Stats`, `Trajectory`, `Reply`, `Event`, `Status`, `EventKind`, `FinishReason`, `Schema`
+
 - Discriminants callers match on in their own code earn a root slot: `Status` (on `Ticket.status`), `EventKind` (on `Event.kind`), `FinishReason` (from `finish_reason()`).
 - Errors and conversion traits do not earn a root slot. They live in their domain module.
 - Builder parameters and run outputs do earn one when callers name them in their own code: `Schema` (on `Ticket::schema`), `AgentBuilder` (from `Agent::new`), `Reply` (on `Ticket.replies`), `Trajectory` (built from a ticket an `on_ticket` handler receives).
 - Free functions at the root are forbidden: convert to an associated function or move to the domain module.
 - Name collisions at the root are forbidden; `ToolResult` next to `Result` is not acceptable.
 
-## Where non-root types live
+## Where Non-Root Types Live
 
 **Types live next to the abstraction, owner, or protocol they belong to.**
 
 - Concrete implementations live with their abstraction: `AnthropicProvider` under `providers::`, `BashTool` under `tools::`.
 - Companion types and handles live with their owner: `Ticket`, `Status`, `TicketError`, `Reply`, and `ReplyContent` under `agents::tickets`; `Stats` and `ToolStat` under `agents::stats`.
 - Domain errors live with their domain: `ProviderError`, `ToolError`.
-- Provider request and response types live with the protocol: `ModelRequest`, `Message`, `TokenUsage` under `providers::`.
+- Request and response types live with the protocol: `ModelRequest`, `Message`, `TokenUsage` under `providers::`.
 - Free functions live in their module, never at the crate root: `from_env()` in `providers::environment`, helpers in `tools::util`.
 
-## Name disambiguation
+## Name Disambiguation
 
 **Names are disambiguated through content, not through redundant prefixes.**
 
 - Specific compound names stand alone: `TicketSystem`, `ToolStat`, `PolicyKind`.
-- Vendor prefixes are used only to distinguish concrete providers or tools: `AnthropicProvider`, `OpenAiProvider`, `LiteLlmProvider`.
+- Vendor prefixes are used only to distinguish concrete LLM providers or tools: `AnthropicProvider`, `OpenAiProvider`, `LiteLlmProvider`.
 - Acronyms follow Rust API guidelines: `OpenAi`, not `OpenAI`.
 - Two structs may not share a bare name within one module; both stay qualified.
 
-## Failure variants
+## Failure Variants
 
 **Failure variants use passive-voice past-participle: `<Subject><Verb-ed>`.**
 
-- Accepted: `RequestFailed`, `TodoItemNotFound`, `ContextWindowExceeded`, `PolicyViolated`.
+```rust
+RequestFailed, TodoItemNotFound, ContextWindowExceeded, PolicyViolated   // accepted
+InvalidRequest, UnexpectedStatus, MissingKey, RequestError               // rejected
+```
+
 - Rejected: adjective-first forms such as `InvalidX`, `UnexpectedX`, or `MissingX`.
 - Rejected: noun-suffix forms such as `XError`; the `Error` suffix is reserved for the top-level `Error` and its domain sub-enums.
 - State-transition events use the same form: `AgentStarted`, `RequestRetried`, `ContextCompacted`.
 - Whether a failure is terminal is documented on the variant, not encoded in the name.
 
-## Variant shape
+## Variant Shape
 
 **Tuple for one payload. Struct for multiple fields or a meaningful field name.**
 
 - Tuple form: `Provider(ProviderError)`, `TodoItemNotFound(String)`, `IoFailed(io::Error)`.
 - Struct form: `AgentError::PolicyViolated { kind, limit }`.
 - Struct form is also used when a single field name carries meaning the type alone does not.
-- Two-arm result enums use one word per variant: `Success` / `Error`, with no `is_*` predicates.
+- Two-arm result enums use one word per variant: `Success` and `Error`, with no `is_*` predicates.
 
-## Payload fields
+## Payload Fields
 
 **One vocabulary is used across every error type.**
 
@@ -61,7 +66,7 @@ Naming and comment rules, plus README structure. Skim the section matching what 
 - A discriminant explaining why something happened is `reason`: `RunFinished`, `RequestFailed`, `RequestRetried`, `ToolCallFailed`, and the `Compaction*` variants all use it. `PolicyViolated` names its field `policy` instead, because `reason` next to `limit` reads as the limit's justification.
 - IMPORTANT: never name such a field `kind`. `Event` already carries `kind`, so `event.data["kind"]` and `event.kind` would be unrelated values one word apart. The type may still be named `PolicyKind` or `ToolFailureKind`; only the field is constrained.
 
-## RAII guard fields
+## RAII Guard Fields
 
 **Fields held only for their `Drop` behavior use a plain name and `#[allow(dead_code)]`.**
 
@@ -69,59 +74,62 @@ Naming and comment rules, plus README structure. Skim the section matching what 
 - `rustc`'s `dead_code` lint flags such fields because neither `Clone` nor drop glue count as reads; the attribute acknowledges this on the one field that needs it.
 - `#[expect(dead_code)]` is preferred on Rust 1.81+: it self-removes if the field later does get read.
 
-## Time-typed fields
+## Time-Typed Fields
 
 **Public API fields MUST use `std::time::Duration`. The type is the unit.**
 
 - No `_ms`, `_MS`, or `_seconds` suffix on public API names.
 - Internal helpers and on-the-wire JSON may use raw integers where the protocol requires it.
-- Example: `timeout_ms` is acceptable inside a tool input schema because the schema is the on-the-wire JSON shape.
+- Example: `timeout_ms` is acceptable inside a tool input schema, because the schema is the JSON shape sent to the model.
 
-## Path identifiers
+## Path Identifiers
 
 **A directory path uses `_dir`. A file path uses `_file`. The bare suffix `_path` is used only when the value can be either.**
 
-- Directories: `scan_dir`, `session_dir`, `base_dir`, `data_dir`. Matches `std::fs::read_dir`, `std::env::current_dir`, `std::fs::DirEntry`.
-- Files: `transcript_file`, `task_file`, `lock_file`. The value is always a concrete file on disk.
+- Directories: `results_dir`, `knowledge_dir`, `ticket_dir`, `working_dir`. Matches `std::fs::read_dir`, `std::env::current_dir`, `std::fs::DirEntry`.
+- Files: `page_file`, `tool_file`. The value is always a concrete file on disk.
 - `_path` is for genuinely ambiguous cases: input that could name either, or a value passed through as opaque.
 - IMPORTANT: `folder` is never used; it has no std analog.
 - Doc comments and environment labels may still say "working directory" in English prose.
 
-## Counter identifiers
+## Count Identifiers
 
-**Counters use a bare plural noun. No `_count` suffix on fields or on methods that return a count.**
+**A field or method that returns a count uses a bare plural noun. No `_count` suffix.**
 
-- `Stats` sets the vocabulary: `requests`, `tool_calls`, `turns`, `input_tokens`, `output_tokens`.
-- Event payloads follow suit: `usage` on `RequestFinished` carries token counts, not a `token_count`.
-- Accessor methods mirror the field form: `Stats::requests()` returns the count of recorded requests.
+`requests`, `tool_calls`, `turns`, `input_tokens`, `output_tokens`
+
+- `Stats` sets the vocabulary; event payloads follow suit: `usage` on `RequestFinished` carries token counts, not a `token_count`.
+- Accessor methods mirror the field form: `Stats::requests()` returns how many requests were recorded.
 - The `_count` suffix is reserved for the rare case where the plural would clash with a sibling collection field on the same type.
-- The ban is on scalars: a map keyed by subject is named for what its values are, `<subject>_counts()` for a bare count (`event_counts()`) and `<subject>_stats()` for a struct (`tool_stats()`). Bare `<subject>s()` stays reserved for a collection of the subject itself, so the count map is not `Stats::events()`.
+- The ban is on scalars: a map keyed by subject is named for what its values are, `<subject>_counts()` for a bare count (`event_counts()`) and `<subject>_stats()` for a struct (`tool_stats()`). Bare `<subject>s()` stays reserved for a collection of the subject itself, so the map is not `Stats::events()`.
 
-## Optional returns
+## Optional Returns
 
 **A value undefined over an empty population returns `Option`. A sum returns its zero.**
 
-- `Option`: `avg_ticket_duration()`, `tickets_success_rate()`, `ToolStat::error_rate()`, and `run_duration()`, which has no answer until a run starts.
+- `Option`: `avg_ticket_duration()`, `tickets_success_rate()`, `ToolStat::error_rate()`, and `run_duration()`, which has no answer until execution starts.
 - Not `Option`: `total_ticket_duration()`, `turns()`, `requests()`. Zero is the honest answer for a sum over nothing.
 - One sentence covers averages, rates, and not-yet-started values, so per-accessor exceptions are not added.
 - A sum is named `total_<noun>`: the bare noun reads as one subject's value, not the population's.
 
-## Persistence verbs
+## Persistence Verbs
 
-**Two traits cover every read/write in the crate. The trait dictates the verb; the implementer's type name binds the file location.**
+**Two traits cover every read and write in the crate. The trait dictates the verb; the implementer's type name binds the file location.**
 
-- `Persist` (in `persistence`) — `save(&self, dir)` / `load(dir, &Self::Key)`. Implemented by `Stats`, `Ticket`, `Page`. Service bootstrap (`TicketSystem::load`, `Knowledge::load`) uses the same `load` verb by convention.
-- `Append` (in `persistence`) — `append(dir, &Self::Record)`. Implemented by `Results` (`results.jsonl`) and `TicketEvents` (`tickets.jsonl`). Each implementer encodes its own filename, so the wrong file cannot be reached through the wrong type.
-- No `open` for bootstrap, no `write_X_to_dir`, no `to_json` / `from_json`, no `checkpoint`, `snapshot`, `persist`, or `counter` in names. The jargon these replaced is what the convention exists to keep out.
+- `Persist` (in `persistence`): `save(&self, dir)` and `load(dir, &Self::Key)`. Implemented by `Stats`, `Ticket`, `Page`. Service bootstrap (`TicketSystem::load`, `Knowledge::load`) uses the same `load` verb by convention.
+- `Append` (in `persistence`): `append(dir, &Self::Record)`. Implemented by `Results` (`results.jsonl`) and `TicketEvents` (`tickets.jsonl`). Each implementer encodes its own filename, so the wrong file cannot be reached through the wrong type.
+- No `open` for bootstrap, no `write_X_to_dir`, no `to_json` or `from_json`, and no `checkpoint`, `snapshot`, `persist`, or `counter` in names. The jargon these replaced is what the convention exists to keep out.
 - Function names do not embed the type names of their arguments: `Stats::derive(&tickets)`, not `derive_from_tickets`. The argument type carries the meaning.
 
 ## Builders
 
 **Builder methods are bare nouns. No `with_` prefix.**
 
-- Examples: `.name()`, `.model()`, `.tool()`, `.label()`, `.read_only()`.
-- The `with_` prefix is reserved for a bare name that would be ambiguous even with an inherent/trait split; no current builder needs it.
-- Two chaining shapes exist, picked by whether the type is shared. A value the caller owns before the run consumes itself: `AgentBuilder` takes `mut self` and returns `Self`, which is also what lets its type-state track the filled provider and model slots. A type handed out as `Arc` configures through `&self` and returns `&Self`: `TicketSystem` and `Knowledge`. A third shape, `self: Arc<Self> -> Arc<Self>`, is not used.
+`.name()`, `.model()`, `.tool()`, `.label()`, `.read_only()`
+
+- The `with_` prefix is reserved for a bare name that would be ambiguous even with an inherent and trait split; no current builder needs it.
+- Two chaining shapes exist, picked by whether the type is shared. A value the caller owns before execution consumes itself: `AgentBuilder` takes `mut self` and returns `Self`, which is also what lets its type-state track the filled provider and model slots.
+- A type handed out as `Arc` configures through `&self` and returns `&Self`: `TicketSystem` and `Knowledge`. A third shape, `self: Arc<Self> -> Arc<Self>`, is not used.
 
 ## Constructors
 
@@ -130,7 +138,7 @@ Naming and comment rules, plus README structure. Skim the section matching what 
 - `new()` is the primary constructor.
 - Named constructors: `load()`, `unrestricted()`, `success()`, `error()`, `empty()`, `from_id()`, `from_env()`.
 
-## Getters and setters
+## Getters and Setters
 
 **Mutable accessors use `set_` and `get_` prefixes to distinguish them from builders.**
 
@@ -141,14 +149,21 @@ Naming and comment rules, plus README structure. Skim the section matching what 
 
 **A hook's name says when it runs and how much it stops. Trigger and scope are separate axes, and both are spelled out.**
 
+```rust
+on_event(handler)                    // observe
+cancel_on_event(condition)           // react whenever the trigger matches
+cancel()                             // act once, now
+cancel_label_on_event(label, cond)   // react, scoped to one label
+```
+
 - `on_<trigger>(handler)` observes: the handler sees every `<trigger>` and returns nothing, as in `on_event`, `on_result`, and `on_failure`.
-- `<action>_on_<trigger>(..)` reacts whenever `<trigger>` matches: `cancel_on_event`, `cancel_on_result`, `cancel_label_on_failure`, `create_ticket_on_result`, `edit_replies_on_event`. The action may be more than one word, so `create_ticket_on_result` reads as `create_ticket` plus `on_result`.
-- A bare `<action>(..)` acts once, now: `cancel`, `cancel_label`, `edit_replies`. The `_on_` infix is the only thing separating a standing rule from an immediate call, so it is never dropped for brevity, including on a type that holds only standing ones.
-- Scope crosses all three forms and lives in the prefix: `cancel*` ends the run, `cancel_label*` ends one label's pool and leaves the others running.
+- `<action>_on_<trigger>(..)` reacts whenever `<trigger>` matches. The action may be more than one word, so `create_ticket_on_result` reads as `create_ticket` plus `on_result`.
+- A bare `<action>(..)` acts once, now: `cancel`, `cancel_label`, `edit_replies`. The `_on_` infix is the only thing separating a standing rule from an immediate call, so it is never dropped for brevity.
+- Scope crosses all three forms and lives in the prefix: `cancel*` ends execution, `cancel_label*` ends one label's pool and leaves the others running.
 - IMPORTANT: the trigger fixes the handler's parameters, the action fixes its return type. A caller who knows one hook in a column knows them all: `_on_event` hands over `&Event`, `_on_result` a `&Ticket` and its validated `&Value`, `_on_failure` the `&Event` and the `&Ticket` it happened in. Observing returns `()`, `cancel*` returns `bool`, `create_ticket*` returns `Option<Ticket>`.
 - Every trigger carries a reaction for every action, so the grid has no holes to explain. The three triggers cross `cancel`, `cancel_label`, and `create_ticket`; `on_ticket` sits outside it, observing a lifecycle transition rather than naming a trigger.
 - `<action>_on(value)` names no trigger, because the caller supplies the trigger whole instead of a condition over something agentwerk produces. `cancel_on` is the only one, and it is not renamed after a cancellation signal: `signal` already names the `AtomicBool` pair on `TicketSystem`.
-- The editor row is the one exception, and `edit_replies_on_event` is its only member. An editor runs once per request over the batch of events since the previous one, so an `_on_result` sibling would have no next request to act on and an `_on_failure` sibling would be a second rewriter of one transcript, which the singular-editor rule below forbids. A failure is already reachable by matching `EventKind::ToolCallFailed` inside the batch.
+- The editor row is the one exception, and `edit_replies_on_event` is its only member. An editor runs once per request over the batch of events since the previous one, so an `_on_result` sibling would have no next request to act on and an `_on_failure` sibling would be a second rewriter of one ticket's replies, which the singular-editor rule below forbids. A failure is already reachable by matching `EventKind::ToolCallFailed` inside the batch.
 
 ## Editors
 
@@ -159,7 +174,7 @@ Naming and comment rules, plus README structure. Skim the section matching what 
 - A hook that rewrites a value is named for that value, not for its trigger alone. Naming it `on_<trigger>` alone reads as an observer and hides what it changes.
 - IMPORTANT: an observer composes, an editor is singular. Every handler on the `on_event` chain runs, and agentwerk stacks `cancel_on_event`, `on_ticket` and the rest there; installing a second editor replaces the first, like `dir` or `max_turns`. Two rewriters of one value would each see the other's output, so stack edits inside a single editor.
 
-## Python bindings
+## Python Bindings
 
 **Every public Rust item has a Python counterpart of the same name. Six transforms are permitted; nothing else.**
 
@@ -171,39 +186,47 @@ Naming and comment rules, plus README structure. Skim the section matching what 
 - A `&mut` editor becomes a callable that returns the replacement, or `None` to keep the current value, since Python cannot take a Rust `&mut`.
 - IMPORTANT: no `with_` prefix in either language, and no seventh transform.
 
-## Free functions
+## Free Functions
 
-**A free function is used only for one of six reasons. Otherwise the function lives on a type.**
+**A free function is used only for one of five reasons. Otherwise the function lives on a type.**
 
 Permitted:
 
 - **Ambient state** has no receiver: timestamp helpers and similar utilities in `tools::util` or a sibling helper module.
 - **Foreign-type constructors** cannot use an inherent `impl`: `build_client()` returns a `reqwest::Client`.
 - **Module entry points** drive multiple types: `run_main_loop()` in `agents::r#loop`, `from_env()` in `providers::environment`.
-- **Higher-order utilities** take a closure and wrap it: `with_file_lock(path, || ...)`.
-- **Shared algorithm helpers** are called by two or more sibling types in the same module: helpers in `tools::util` shared across filesystem tools; provider-side helpers shared across concrete providers.
+- **Higher-order utilities** take a function and wrap it: `with_file_lock(path, || ...)`.
+- **Shared algorithm helpers** are called by two or more sibling types in the same module: helpers in `tools::util` shared across filesystem tools, and provider-side helpers shared across concrete providers.
 
 Forbidden:
 
 - A free function that delegates to a single method on one type. Inline it as a method instead.
 - A free constructor for a local type that already has an inherent `impl`. Constructors for `Foo` live on `Foo`.
 - A free helper called from exactly one private method. Make it a private method or a nested `fn`.
-- An associated function that takes no `self` and does not return `Self` or `Result<Self>`. Move it to the module as a free function. Exception: a per-variant static lookup where the `Type::` prefix partitions otherwise-colliding names, such as `AnthropicProvider::lookup_context_window_size` vs `OpenAiProvider::lookup_context_window_size`.
+- An associated function that takes no `self` and does not return `Self` or `Result<Self>`. Move it to the module as a free function. Exception: a per-variant static lookup where the `Type::` prefix partitions otherwise-colliding names, such as `AnthropicProvider::lookup_context_window_size` next to `OpenAiProvider::lookup_context_window_size`.
 
-Naming: `snake_case`. Tool structs keep the `{Name}Tool` suffix: `ReadFileTool`, `BashTool`, `ManageTicketsTool`.
+Naming is `snake_case`. Tool structs keep the `{Name}Tool` suffix: `ReadFileTool`, `BashTool`, `ManageTicketsTool`.
 
 The name the model calls is a separate namespace and takes no suffix: `read_file`, `bash`, `manage_tickets`. It lives in the tool's `.tool.md` frontmatter, never as a Rust literal at a call site. A `_tool` suffix there restates what the tools array already says.
 
-## Doc comments (`///`)
+## Doc Comments (`///`)
 
-**State the purpose in one sentence. No "This function…" or "Returns…".**
+**State the purpose in one sentence, with the same verb the item's README row uses.**
 
-- Noun phrase for types and fields; verb for functions.
-- Additional paragraphs are added only for a constraint, invariant, or non-obvious semantic.
+```rust
+/// Set the LLM provider.            // builder: imperative configuration verb
+/// Get the elapsed duration.        // accessor: Get
+/// Begin processing tickets.        // action: imperative effect
+/// A ticket finished successfully.  // event: past-tense state sentence
+```
+
+- Noun phrase for types and fields; verb for functions. No "This function…" or "Returns…".
+- The full set of verbs is under [README Table Shape](#readme-table-shape). A method and its README row say the same thing in the same words.
+- Additional paragraphs are added only for a constraint, invariant, or non-obvious semantic, and only when the caller can act on it.
 - Trivial getters, `Default::default`, `From` impls, and self-explanatory variants are left undocumented.
 - Within one type, coverage is all-or-none: every member has a real doc comment, or none does.
 
-## Module docs (`//!`)
+## Module Docs (`//!`)
 
 **Every file begins with a `//!` that states what the file contributes to the crate.**
 
@@ -212,7 +235,7 @@ The name the model calls is a separate namespace and takes no suffix: `read_file
 - Do not list the contents of the file.
 - The `//!` stays even when the filename is already descriptive.
 
-## Hiding internal types
+## Hiding Internal Types
 
 **A type a public trait or extension point hands to callers is documented; a genuinely internal type is `pub(crate)`.**
 
@@ -220,7 +243,7 @@ The name the model calls is a separate namespace and takes no suffix: `read_file
 - A type that is genuinely internal becomes `pub(crate)` instead. `tools::ToolFile` is the example: callers go through `Tool::from_tool_file(definition: &str)` and never name the struct.
 - `#[doc(hidden)]` is reserved for items a macro or trait forces `pub` that are useless even to implementors; there are currently none.
 
-## Line comments (`//`)
+## Line Comments (`//`)
 
 **Four reasons are allowed. Everything else is deleted.**
 
@@ -247,7 +270,7 @@ Not allowed:
 - A comment is justified only to pin an architectural invariant the test guards.
 - A module-level `//!` describing the test file's scope is acceptable.
 
-## Comment examples
+## Comment Examples
 
 **Good and bad variants of each comment type.**
 
@@ -255,7 +278,7 @@ Module `//!`:
 
 ```rust
 // GOOD: states what the file contributes
-//! Multi-agent loop driver. Each agent runs in its own tokio task, reading the shared ticket store.
+//! Runs many agents in parallel, each in its own tokio task, over one shared ticket store.
 
 // BAD: lists contents
 //! Agent loop.
@@ -279,7 +302,7 @@ Function `///`:
 
 ```rust
 // GOOD: verb, one line
-/// Build the environment metadata block for the first user message.
+/// Build the environment metadata block for the first message.
 
 // BAD: signature already says this
 /// This function returns a String containing the environment metadata.
@@ -304,7 +327,97 @@ counter += 1;
 // ----- Core types -----
 ```
 
-## README structure
+## Sentence Shape
+
+**One idea per sentence. A section lead is one sentence, and so is a table cell.**
+
+```markdown
+GOOD: A `Schema` constrains the result an agent produces for a ticket.
+BAD:  A `Schema` is a JSON Schema document that gets attached to a ticket and,
+      when the result comes back, is used to validate it; failures retry.
+```
+
+- Budgets: 10 to 25 words for a lead, 4 to 15 for a table cell. The cell figure is a hard cap.
+- Present tense, declarative, no hedging. No semicolons stapling two facts together.
+- A second short sentence is allowed only when it carries information the first cannot.
+- A description that needs more than two sentences moves to prose under the table.
+
+## Voice and Address
+
+**Second person for the reader. Imperative for the agent. No marketing language.**
+
+- "you" and "your" address the reader; "we" is never used.
+- In agent-facing text the agent is the actor and the tool exposes the action: `Fetch a URL and read its body.`
+- "Give the agent access to filesystem tools", not "empower the application".
+- Avoid adjectives that carry no information ("powerful", "seamless", "sensible").
+
+## Component Descriptions
+
+**Introduce a type as `` `Type` `` plus one clause saying what it is for.**
+
+```markdown
+An `Agent` is the core entity of agentwerk.
+A `Schema` constrains the result an agent produces for a ticket.
+`Knowledge` allows agents to share insights or learnings.
+```
+
+- A second sentence is added only for a constraint: "A violation triggers a retry until `max_schema_retries` is exhausted."
+- The type's `///` and its README lead use the same shape, so the two read alike.
+- Name the type's job, not its implementation: not "the shared work queue holding an `Arc<Mutex<..>>`", but "the core data structure of agentwerk allowing to coordinate complex interactions".
+
+## Abstraction Level
+
+**In caller-facing text, describe what the caller gets, not how it works inside.**
+
+- The reader may be new to agent concepts: write for them.
+- Internal type names, private field names, and enum variant names do not belong in the README. The reference lives in the API docs.
+- Internal mechanics do not appear in caller-facing rustdoc either: no `Weak<Self>` or `Arc<Self>` references, no "stamps", no "recorder protocol", no `record_*` or `mark_finished`, no lock ordering, no drain counts. They live in `agentdocs/architecture.md`.
+- Accepted: `// run the task once and return the result`, "Transient provider error triggered a retry".
+- Rejected: `// drive the loop`, `// one-shot`, "(carries typed `kind: RequestErrorKind`)", "`InBand` is model-fixable, `Infrastructure` is harness-level".
+- Jargon and internal terms are cut even when they are shorter.
+
+## Punctuation
+
+**No em dashes anywhere. A colon or a second sentence replaces one.**
+
+- Applies to the README, rustdoc, agentdocs, and agent-facing prompt files alike.
+- Numbers are spelled out with a space: "33 000 tokens", never "33K".
+- No emoji, and no decorative banners.
+- Prose is not hard-wrapped in Markdown files. Wrapping reflows a whole paragraph when one word changes.
+
+## Terminology
+
+**Word-level rules for caller-facing prose: rustdoc, README, and agentdocs (except where called out).**
+
+- "worker" is not used as a role noun. The type is `Agent`; the noun is "agent".
+- "user" is not a domain concept. It names one thing only, the `Message::User` role in the exchange with the model.
+- "routed" and "routing" are replaced with "assigned" and "assignment".
+- "replies" or "messages" replace "transcript". The field is `replies`, so name it.
+- "execution" is the word for a run in prose. `run` stays in identifiers: `run_duration()`, `EventKind::RunStarted`.
+- Bare "provider" in caller-facing prose is spelled "LLM provider". Identifier names (`Provider`, `AnthropicProvider`, the `providers::` module) stay unqualified.
+- "finisher" is banned outright, in agent-facing prompts (role files, `*.tool.md`, directives) as much as in caller-facing prose. It names nothing an agent can call: name the tool, `finish` (rustdoc names the type `FinishTool`).
+- "caps" is replaced with "limits" everywhere it is used as a noun. Imperative cells say "Limit X", not "Cap X".
+- "snapshot" does not appear in caller-facing prose. Say what the value is, not that it is a snapshot.
+- "counters" is replaced with "statistics" in caller-facing prose. `Stats` is statistics, not counters, on docs.rs.
+- "live" as an adjective for statistics is rejected ("live counters", "readable live"). Say *when* the value is available in plain English.
+- "wall-clock" is replaced with "elapsed duration", "max time", or "time cap".
+- "stamp", "trip", "walk off", and "mint" are internal metaphors for writing a timestamp, breaching a limit, releasing a ticket, and creating one. Use the plain verb.
+- "settle" and "settled" are replaced with "finish", "mark done", or "done".
+- "park" and other vehicle metaphors are replaced by what actually happens: "stays `InProgress`", "is not re-claimed".
+- "smoke test" is replaced with "high-signal set", "starting point", or "core checks".
+- "drift" is replaced with the specific verb, or with "safety margin" or "stays anchored".
+- "upsert" is replaced with "creates or replaces".
+- "wire-protocol" and "wire-shaped" are not used. Describe the types by what they carry.
+- The Knowledge store is described as durable memory the agent shares across tickets and other agents; the sharing is the headline, not a footnote.
+- "drives the provider/tool loop" is slang. An agent calls the LLM provider and runs the tools it requests.
+- "stream" and "streaming" are too technical for caller-facing prose. Say "print as it arrives", "forward", or "show live", or name the SSE layer when describing the implementation.
+- "the loop" and "the agent loop" are project-internal jargon. In caller-facing prose say "agentwerk", "the agent", or name the subject directly. The phrase is fine in `agentdocs/architecture.md` and `agentdocs/layout.md`, where the audience already knows what it refers to.
+- "ships" and "ships with" are empty filler; so are "sensible defaults", "tuning", and "various options". State one concrete fact, list the identifiers and point at docs.rs, or do both. Do not dump every default value into prose either; those numbers belong on docs.rs.
+- Rust async primitive nouns ("future", "closure", "predicate", "callback") are jargon in caller-facing prose. Say "another task that finishes", "a condition you supply", "your function". The Rust identifiers stay as identifiers; only the prose changes.
+- Abstract pronouns and fractions ("one half", "the other", "either side") leave the reader guessing. Name the subject directly: not "detect one half from the environment and override the other", but "read only the provider from the environment, or only the model".
+- "header" and "ticket header" are project-internal jargon for the on-disk file holding a `Ticket` without its `replies`. In caller-facing prose say "the ticket" or "the ticket without its messages"; the internal helper `ticket_header_path` and `architecture.md` may keep the term.
+
+## README Structure
 
 **Terse, example-driven, scannable.**
 
@@ -316,7 +429,7 @@ counter += 1;
 - Every section leads with one minimal example, then at most three sentences.
 - Facts live in one place; other sections cross-link rather than repeat.
 
-## README folds
+## README Folds
 
 **Above the fold is what a reader needs. The exhaustive reference goes inside a `<details>` block at the end of the section.**
 
@@ -326,16 +439,44 @@ counter += 1;
 - Snippet budgets: eight lines for a section lead, five for a subsection lead. Quick Start gets sixteen.
 - Agent Swarms is the one exception and runs long, because it is the only place a whole system is shown at once: a pool working in parallel, a second pool the first hands tickets to, and one knowledge store between them. Every line there earns its place by carrying one of those three, and anything that does not belongs in a section below.
 
-## README mechanics
+## README Mechanics
 
 **Formatting choices that are not about either language.**
 
-- Prose is not hard-wrapped. Wrapping reflows a whole paragraph when one word changes.
 - One `h1` per file, the title. Every section is `h2`, every subsection `h3`. No wrapper heading above a group of sections.
 - `h2` is Title Case, `h3` is Sentence case.
 - A method placeholder is spelled as what the caller passes, never a single letter: `max_turns(count)`, `cancel_on_event(condition)`, `results_for_label(label)`. In a bullet list the bare method name carries no parentheses at all, since the description says what it takes.
 - Centered blocks use `<div align="center">`. `align` is not allowed on `<p>` by the crates.io sanitizer, so `<p align="center">` renders left-aligned there.
-- No emoji.
+
+## README Tables
+
+**No table above a fold. Every enumeration inside a fold is a table.**
+
+- Above the fold there is prose and one example, so a table there is a sign the section is doing reference work it should have folded.
+- Inside a fold the content is the reference, and a two-column grid is what a reader scans. Bullets there only hide the second column.
+- A catalogue with categories takes a third column on the left holding the bold group label: the built-in tools and the event kinds.
+- Prose still belongs in a fold when it is a caveat rather than an entry, as does a snippet showing how one of the entries is called.
+
+## README Table Shape
+
+**Each table picks one cell shape and holds it. Mixing shapes inside one table is a defect.**
+
+- Builder rows lead with an imperative configuration verb: `Set the LLM provider.`
+- Action rows lead with the imperative effect: `Begin processing tickets.`
+- Accessor rows lead with `Get`: `Get every finished ticket's result.`
+- Tool rows lead with the imperative action the agent takes: `Fetch a URL and read its body.`
+- Event rows are past-tense state sentences: `A ticket finished successfully.`
+- Every row is a description, not a constraint fragment. A cell that does not lead with a verb is a defect.
+- A tool does not act; the agent does. The table intro carries that framing once so individual rows stay terse.
+- The prose verb "Return" stays for instructions to the caller, as in "Return `ToolResult::error(message)` for a failure the model should work around".
+
+## README Examples
+
+**Show the smallest snippet that demonstrates the feature.**
+
+- Example models are `claude-haiku-4-5-20251001` or `claude-sonnet-4-20250514`.
+- Update triggers: a new builder method, a new tool, a new event kind, a new environment variable, or a changed default.
+- A code change edits only the doc sentences it made wrong. Surrounding prose is not rewritten unprompted.
 
 ## Rust and Python READMEs
 
@@ -345,73 +486,3 @@ counter += 1;
 - A snippet is a translation of its twin: same variable names, same string literals, same order of operations.
 - A difference that is real belongs in `crates/agentwerk-py/DIFFS.md`, and the README shows it in the same place in both files.
 - Only the Installation cross-links and the Development section differ in substance.
-
-## README voice
-
-**Direct and neutral. No marketing language.**
-
-- "Give the agent access to filesystem tools", not "empower the application".
-- Examples stay minimal; show the smallest snippet that demonstrates the feature.
-- Example models are `claude-haiku-4-5-20251001` or `claude-sonnet-4-20250514`.
-- Update triggers: a new builder method, a new tool, a new event kind, a new environment variable, or a changed default.
-
-## Terminology
-
-**Word-level rules for caller-facing prose: rustdoc, README, and agentdocs (except where called out).**
-
-- "worker" is not used as a role noun. The type is `Agent`; the noun is "agent".
-- "routed" / "routing" is replaced with "assigned" / "assignment".
-- Bare "provider" in caller-facing prose is spelled "LLM provider". Identifier names (`Provider`, `AnthropicProvider`, the `providers::` module) stay unqualified.
-- "finisher" is banned outright, in agent-facing prompts (role files, `*.tool.md`, directives) as much as in caller-facing prose. It names nothing an agent can call: name the tool, `finish` (rustdoc names the type `FinishTool`).
-- Internal mechanics do not appear in caller-facing rustdoc: no `Weak<Self>` / `Arc<Self>` references, no "stamps", no "recorder protocol", no `record_*` / `mark_finished`. They live in `agentdocs/architecture.md`.
-- "caps" is replaced with "limits" everywhere it is used as a noun. Imperative cells say "Limit X" not "Cap X".
-- "snapshot" does not appear in caller-facing prose. Say what the value is, not that it is a snapshot.
-- "counters" is replaced with "statistics" in caller-facing prose. `Stats` is statistics, not counters, on docs.rs.
-- "live" as an adjective for stats is rejected ("live counters", "readable live"). Say *when* the value is available in plain English.
-- The Knowledge store is described as durable memory the agent shares across tickets and other agents; the sharing is the headline, not a footnote.
-- "drives the provider/tool loop" is slang. An agent calls the LLM provider and runs the tools it requests.
-- "stream" / "streaming" is too technical for caller-facing prose. Say "print as it arrives", "forward", "show live", or name the SSE layer when describing the implementation.
-- "the loop" / "the agent loop" is project-internal jargon. In caller-facing prose say "agentwerk", "the agent", or name the subject directly. The phrase is fine in `agentdocs/architecture.md` and `agentdocs/layout.md`, where the audience already knows what "the loop" refers to.
-- "ships" / "ships with" is empty filler; so are "sensible defaults", "tuning", "various options". State one concrete fact, list the identifiers and point at docs.rs, or do both. Do not dump every default value into prose either; those numbers belong on docs.rs.
-- Rust async primitive nouns ("future", "closure", "predicate", "callback") are jargon in caller-facing prose. Say "another task that finishes", "a condition you supply", "your function". The Rust identifiers stay as identifiers (parameter names, type names); only the prose changes.
-- Abstract pronouns and fractions ("one half", "the other", "either side") leave the reader guessing. Name the subject directly: not "detect one half from the environment and override the other", but "read only the provider from the environment, or only the model".
-- "header" / "ticket header" is project-internal jargon for the on-disk file holding a `Ticket` without its `replies`. In caller-facing prose say "the ticket" or "the ticket without its messages"; the internal helpers `ticket_header_path` and architecture.md may keep the term since the codebase audience knows what it means.
-- "transcript" is replaced with "messages" or "replies". The field is `replies`, so name it.
-
-## README tables
-
-**No table above a fold. Every enumeration inside a fold is a table.**
-
-- Above the fold there is prose and one example, so a table there is a sign the section is doing reference work it should have folded.
-- Inside a fold the content is the reference, and a two-column grid is what a reader scans. Bullets there only hide the second column.
-- A catalogue with categories takes a third column on the left holding the bold group label: the built-in tools and the event kinds.
-- Prose still belongs in a fold when it is a caveat rather than an entry, as does a snippet showing how one of the entries is called.
-
-## README table shape
-
-**Each table picks one cell shape and holds it. Mixing shapes inside one table is a defect.**
-
-- Builder rows lead with an imperative verb describing the configuration effect: `Set the LLM provider.`, `Register a tool.`, `Restrict the agent to matching labels.`
-- Action rows lead with an imperative verb describing the effect: `Create a task.`, `Run until interrupted.`
-- Accessor rows lead with `Get ...`: `Get every finished ticket's result.` The prose verb `Return` stays for instructions to the caller, as in "Return `ToolResult::error(message)` for a failure the model should work around".
-- Tool rows lead with an imperative verb describing the action the tool exposes: `Read a file with line numbers.`, `Fetch a URL and read its body.` The tool itself does not act; the agent does. The table intro carries that framing once so individual rows stay terse.
-- Event rows are past-tense state sentences: `A ticket finished successfully.`
-
-## README cell length
-
-**One sentence per cell. No semicolons stapling two facts together.**
-
-- Hard cap: roughly fifteen words per cell.
-- A second short sentence is allowed only when it carries information the first cannot.
-- A description that needs more than two sentences moves to prose under the table.
-- Em dashes are not used; colons or two sentences replace them.
-
-## README descriptions
-
-**In README table cells, bullet descriptions, and inline `//` comments, describe what the caller gets, not how it works inside.**
-
-- The reader may be new to agent concepts: write for them.
-- The README is an abstraction: internal type names, private field names, and enum variant names do not belong there. The reference lives in the API docs.
-- Accepted: `// run the task once and return the result`, "Transient provider error triggered a retry".
-- Rejected: `// drive the loop`, `// one-shot`, "(carries typed `kind: RequestErrorKind`)", "`InBand` is model-fixable, `Infrastructure` is harness-level".
-- Jargon and internal terms are cut even when they are shorter.

--- a/agentdocs/testing.md
+++ b/agentdocs/testing.md
@@ -6,7 +6,7 @@ How tests are organized and written. Commands used to run them live in [workflow
 
 **Two layers: integration and inline.**
 
-- `tests/integration/` uses a real provider; bundled by `tests/integration.rs`.
+- `tests/integration/` uses a real LLM provider; bundled by `tests/integration.rs`.
 - Inline `#[cfg(test)] mod tests` lives next to the code it covers and runs without a network.
 - Shared integration helpers live in `tests/integration/common.rs`.
 
@@ -17,46 +17,51 @@ How tests are organized and written. Commands used to run them live in [workflow
 - A test exists because a single contract would otherwise go undemonstrated.
 - A failure points to one cause: no grab-bag assertions across unrelated concerns.
 - A sibling that already covers the same behavior with different inputs is merged or removed.
-- Behaviour is tested at the layer where it lives: unit, integration, or inline.
+- Behavior is tested at the layer where it lives: unit, integration, or inline.
 
 ## Naming
 
 **The name states the behavior, not the method called.**
 
-- Accepted: `rejects_submit_when_cart_is_empty`, `deposit_increases_balance`.
-- Rejected: `test_submit`, `test_submit_works`, `test_balance`.
+```rust
+add_reply_appends_one_line_to_replies_jsonl        // accepted
+an_explicit_ticket_schema_overrides_the_label_default
+test_add_reply                                     // rejected
+test_schema_works
+```
+
 - The body verifies what the name claims, with no surprise assertions.
 - The name is the first line of the documentation the test provides.
 
-## API focus
+## API Focus
 
 **Tests exercise the public surface the way callers hold it.**
 
 - Call the public entry point; do not poke at private fields, patched internals, or field assignments.
 - Mock at trust boundaries (network, clock, disk), never at the subject under test.
 - Assert observable outcomes, not call logs or the order internal methods ran in.
-- The arrange/act/assert shape mirrors how a real caller would use the API.
+- The arrange, act, and assert shape mirrors how a real caller would use the API.
 
-## State transitions
+## State Transitions
 
 **Actions and the resulting state MUST be visible through the public API.**
 
-- Build starting state by calling real actions, not by field assignment that bypasses invariants.
-- Read resulting state back through a public query, not by peeking at private fields.
-- Assert both starting and final state so the transition is shown, not implied.
+- Build the starting state by calling real actions, not by field assignment that bypasses invariants.
+- Read the resulting state back through a public query, not by peeking at private fields.
+- Assert both the starting and the final state so the transition is shown, not implied.
 - Cover illegal transitions and verify state is unchanged after a rejection.
-- One transition per test so a failure locates the exact broken action.
+- One transition per test, so a failure locates the exact broken action.
 
 ## Clarity
 
 **Setup is hidden. Intent is highlighted.**
 
 - Push scaffolding into factories, builders, and fixtures so the body reads as a short story.
-- Name literals that carry meaning: `EXPIRED_COUPON`, not `42`; `ADMIN_USER`, not `"foo"`.
+- Name literals that carry meaning: `EXPIRED_COUPON`, not `42`.
 - Keep the act step a single visible line; do not bury it in setup.
 - Comments are justified only to pin an architectural invariant the test guards.
 
-## Coverage shape
+## Coverage Shape
 
 **Every public operation has a test that demonstrates intended usage.**
 

--- a/agentdocs/this.md
+++ b/agentdocs/this.md
@@ -2,23 +2,39 @@
 
 How every file under `agentdocs/` is written. This file is itself an example of the format.
 
-## File shape
+## File Shape
 
 **One topic per file. Start with a title and a one-sentence description.**
 
+```markdown
+# Style
+
+Naming and comment rules, plus README structure. Skim the section matching what is being written.
+```
+
 - `# Title`: one word or short phrase, no trailing punctuation.
-- One sentence under the title that states what the file covers.
+- One sentence under the title states what the file covers.
 - Sections use plain headings: `## Title Cased Heading`. No numbers: adding a section must not force renumbering.
-- Each section is self-contained; a reader can skip to it directly.
+- Each section is self-contained, so a reader can skip straight to it.
 
-## Section shape
+## Section Shape
 
-**Bold rule first. Bullets second. A closing sentence is optional.**
+**Bold rule first. One example second. Bullets last.**
 
-- The first line after the heading is a bold one-liner stating the rule.
-- The rule is an instruction, not a description.
-- Bullets follow, optionally preceded by a one-line framing sentence.
-- A closing sentence is added only when it carries information the bullets do not.
+```markdown
+## Builders
+
+**Builder methods are bare nouns. No `with_` prefix.**
+
+`.name()`, `.model()`, `.tool()`, `.label()`, `.read_only()`
+
+- The `with_` prefix is reserved for a bare name that would be ambiguous.
+```
+
+- The first line after the heading is a bold one-liner stating the rule as an instruction.
+- An example follows whenever the rule is about code or about the shape of text. Use the smallest form that shows the rule: a fence, a line of identifiers, or a good and bad pair.
+- A section whose own text already demonstrates the rule needs no separate example.
+- Bullets carry what the rule and the example do not. A closing sentence is added only when it carries information the bullets cannot.
 
 ## Bullets
 
@@ -33,10 +49,15 @@ How every file under `agentdocs/` is written. This file is itself an example of 
 
 **Use bullets, not tables.**
 
+```markdown
+- `Persist`: `save(&self, dir)` and `load(dir, &Self::Key)`.
+- `Append`: `append(dir, &Self::Record)`.
+```
+
 - Tables produce wide rows that are hard to compare.
 - For `name: description` pairs, write `` `Name`: description. ``
 - Group related bullets under a one-line header ending in a colon.
-- Code fences are acceptable for commands and small code examples.
+- Tables belong in the README, where a `<details>` fold gives them a place to sit. These files have no folds.
 
 ## Punctuation
 
@@ -50,6 +71,11 @@ How every file under `agentdocs/` is written. This file is itself an example of 
 
 **Direct and neutral. No marketing language. No unnecessary jargon.**
 
+```markdown
+GOOD: `Stats` records every event and exposes read accessors.
+BAD:  `Stats` seamlessly wires a powerful metrics plane into the kernel.
+```
+
 - State the rule; justify only when the rule is not obvious on its own.
 - Prefer present tense and second person over passive voice.
 - Avoid adjectives that do not carry information ("powerful", "clean", "seamless").
@@ -59,12 +85,12 @@ How every file under `agentdocs/` is written. This file is itself an example of 
 
 **Use MUST for non-negotiable rules. Use IMPORTANT for easy-to-miss gotchas.**
 
-- MUST: correctness-critical rules where a violation breaks compilation, the request and response shape exchanged with providers, or an architectural invariant.
+- MUST: correctness-critical rules where a violation breaks compilation, the shape exchanged with LLM providers, or an architectural invariant.
 - IMPORTANT: prefixes a bullet that a reader skimming would miss and regret later.
 - Most rules need neither: the bold one-liner is already the rule.
 - SHOULD, MAY, and CAN are not used: RFC-2119 without the full spec is noise.
 
-## Code grounding
+## Code Grounding
 
 **Rules name identifiers that exist in the crate. No invented vocabulary.**
 
@@ -73,11 +99,11 @@ How every file under `agentdocs/` is written. This file is itself an example of 
 - A rule that cannot point at code is opinion, not architecture: drop it or move it to the consuming application.
 - When a name changes in code, the docs change in the same commit.
 
-## Cross-linking
+## Cross-Linking
 
 **Each fact lives in one file. Other files link to it.**
 
-- Commands belong in `workflow.md`; other files link to it rather than restating commands.
+- Commands belong in `workflow.md`; other files link there rather than restating them.
 - File and module placement belongs in `layout.md`; `architecture.md` describes invariants and assumes placement is known.
 - Naming and comment rules belong in `style.md`; `testing.md` covers test-specific naming and links out for the rest.
 - A duplicated fact is a future inconsistency: when two files would say the same thing, one of them links instead.

--- a/agentdocs/workflow.md
+++ b/agentdocs/workflow.md
@@ -6,37 +6,43 @@ Commands used to build, test, release, and run example agents.
 
 **Every build MUST run with `-D warnings`.**
 
-- `make` compiles the crate.
-- `make fmt` formats the code.
-- `make clean` removes build artefacts.
+```bash
+make        # compile the crate
+make fmt    # format the code
+make clean  # remove build artifacts
+```
+
 - Any warning fails the build.
 
 ## Test
 
 **Test layout and writing rules live in [testing.md](testing.md).**
 
-- `make test` runs three passes: `--lib` (every crate's inline `#[cfg(test)] mod tests`), `--doc` (the examples in `///` comments), and `-p use-cases --bins` (the tests inside the use-case binaries). `--lib` alone reaches neither of the last two.
+- `make test` runs three passes: `--lib` (every crate's inline `#[cfg(test)] mod tests`), `--doc` (the examples in `///` comments), and `-p use-cases --bins` (the tests inside the use-case binaries).
+- `--lib` alone reaches neither of the last two.
 - `make test_integration` runs the live-provider tests bundled by `tests/integration.rs`.
 
-## Python bindings
+## Python Bindings
 
 **`make python` builds the extension; the two test targets split on whether an LLM provider is needed.**
 
-- `make python` runs `maturin develop` in `crates/agentwerk-py/`, building the extension into the active virtualenv. Create one first with `python3 -m venv .venv` at the repo root and activate it: maturin fails without a virtualenv, and the test targets resolve `python3` off the PATH, so an unactivated one imports the system interpreter instead.
+- `make python` runs `maturin develop` in `crates/agentwerk-py/`, building the extension into the active virtualenv.
+- Create the virtualenv first with `python3 -m venv .venv` at the repo root and activate it. maturin fails without one, and the test targets resolve `python3` off the PATH, so an unactivated virtualenv imports the system interpreter instead.
 - `make python_test` runs the offline pytest suite. It needs no network and no `.env`.
 - `make python_test_integration` sources `.env` and runs the tests marked `live`, which call a real LLM provider.
 - Both test targets depend on `make python`, so an edit to the binding crate is picked up automatically.
 
-## Integration env
+## Integration Environment
 
-**Integration tests read provider config from a `.env` file at the repo root.**
+**Integration tests read LLM provider configuration from a `.env` file at the repo root.**
+
+```bash
+export OPENAI_API_KEY=sk-local
+export OPENAI_BASE_URL=http://localhost:8095
+```
 
 - `make test_integration` sources `.env` automatically when present.
-- The file holds shell `export` statements, one per variable:
-  ```
-  export OPENAI_API_KEY=sk-local
-  export OPENAI_BASE_URL=http://localhost:8095
-  ```
+- The file holds shell `export` statements, one per variable.
 - `OPENAI_BASE_URL` points at a local OpenAI-compatible proxy on port 8095.
 - `.env` is gitignored: each contributor maintains their own.
 
@@ -53,14 +59,20 @@ Commands used to build, test, release, and run example agents.
 
 **`make hooks` installs Claude Code hooks into `.claude/settings.local.json`.**
 
-- Source files live in `hooks/` (tracked). `make hooks` copies them into `.claude/hooks/` (ignored) and merges the config.
+- Source files live in `hooks/` (tracked). `make hooks` copies them into `.claude/hooks/` (ignored) and merges the configuration.
 - `check-conventions.sh` injects `agentdocs/style.md` and `agentdocs/architecture.md` as context after each Rust file edit.
-## Use cases
+
+## Use Cases
 
 **Example agents live in a separate crate and run through `make use_case`.**
 
+```bash
+make use_case                # list available names
+make use_case name=<name>    # run one
+```
+
 - Source is in `crates/use-cases/src/`.
-- Run an example with `make use_case name=<name>`.
 - `terminal-repl` is a per-turn interactive chat that prints output as it arrives.
 - `divide-and-conquer` partitions an arithmetic problem across agents sharing one ticket queue.
-- `deep-research` is a two-phase research pipeline with web search (requires `BRAVE_API_KEY`).
+- `deep-research` is a two-phase research pipeline with web search, and requires `BRAVE_API_KEY`.
+- `malware-scanner` identifies indicators of compromise in a software package.

--- a/crates/agentwerk-py/README.md
+++ b/crates/agentwerk-py/README.md
@@ -564,7 +564,7 @@ See [`EventKind`](https://docs.rs/agentwerk/latest/agentwerk/event/enum.EventKin
 | | `on_result(handler)` | Read every finished ticket together with its result. |
 | | `on_failure(handler)` | Read every failure together with the ticket it happened in. |
 | | `on_ticket(handler)` | Read a ticket as it starts, finishes, or fails. |
-| **Stop the run** | `cancel_on(awaitable)` | Stop execution when the given awaitable completes. |
+| **Stop the run** | `cancel_on(awaitable)` | Stop execution when another task you supply finishes. |
 | | `cancel_on_event(condition)` | Stop execution when an event matches. |
 | | `cancel_on_result(condition)` | Stop execution when a finished result matches. |
 | | `cancel_on_failure(condition)` | Stop execution when a failure matches. |

--- a/crates/agentwerk-py/python/agentwerk/__init__.py
+++ b/crates/agentwerk-py/python/agentwerk/__init__.py
@@ -1,6 +1,6 @@
-"""agentwerk: Python bindings for the agentwerk Rust agent loop.
+"""agentwerk: a minimal Python library for running many agents in parallel.
 
-The compiled extension (`._agentwerk`) holds the real types; this package
+The compiled extension (`._agentwerk`) holds the real types, and this package
 re-exports them so `from agentwerk import Agent, ReadFileTool` works.
 """
 
@@ -59,14 +59,13 @@ def tool(
     name=None,
     description=None,
 ):
-    """Mark a Python callable as an agent tool.
+    """Turn a Python function into a tool an agent may call.
 
-    Usage: ``@tool`` or ``@tool(read_only=True, schema={...})``. The name
-    defaults to the function name and the description to its docstring. The
-    tool input object is passed to the callable as keyword arguments. A
-    ``defer``red tool stays hidden until the agent finds it with
-    ``FindToolsTool``. ``paths`` names the input fields holding a file path, so
-    the files the tool opens reach ``Stats.file_stats()``.
+    Write ``@tool`` or ``@tool(read_only=True, schema={...})``. The name
+    defaults to the function's, and the description to its docstring. The input
+    arrives as keyword arguments. ``defer`` holds the tool back until the agent
+    looks it up with ``FindToolsTool``. ``paths`` names the input fields holding
+    a file path, so the files a call opens are included in statistics.
     """
 
     def decorate(fn):

--- a/crates/agentwerk-py/python/agentwerk/__init__.pyi
+++ b/crates/agentwerk-py/python/agentwerk/__init__.pyi
@@ -3,10 +3,10 @@
 from typing import Any, Awaitable, Callable, Optional, overload
 
 class Provider:
-    """An LLM provider handle."""
+    """An LLM provider, passed to ``Agent.provider(...)``."""
 
 class Model:
-    """A model name with optional context-window and reasoning-effort tuning."""
+    """A model name, with an optional context window size and reasoning level."""
 
     def __init__(self, name: str) -> None: ...
     def context_window(self, size: int) -> "Model": ...
@@ -15,13 +15,13 @@ class Model:
     def get_reasoning_effort(self) -> str: ...
 
 def provider_from_env() -> Provider:
-    """Detect and construct a provider from environment variables."""
+    """Read the LLM provider from environment variables."""
 
 def model_from_env() -> str:
-    """Read the model name from the environment."""
+    """Read the model name from environment variables."""
 
 def context_window_from_env() -> Optional[int]:
-    """Read ``MODEL_CONTEXT_WINDOW``, or ``None`` when it is unset."""
+    """Read the context window size from ``MODEL_CONTEXT_WINDOW``, or ``None``."""
 
 def AnthropicProvider(
     api_key: str, base_url: Optional[str] = ..., timeout: Optional[float] = ...
@@ -37,7 +37,7 @@ def LiteLlmProvider(
 ) -> Provider: ...
 
 class Tool:
-    """A built-in tool handle passed to Agent.tool(...)."""
+    """A tool an agent may call, passed to ``Agent.tool(...)``."""
 
 class ToolResult:
     """What a tool reports back when a bare return value is not enough."""
@@ -53,7 +53,7 @@ def ReadFileTool() -> Tool: ...
 def WriteFileTool() -> Tool: ...
 def EditFileTool() -> Tool: ...
 def GrepTool() -> Tool:
-    """Search file contents by regex, or a code shape via ``syntax="code"``."""
+    """Search file contents by regular expression, or by code shape with ``syntax="code"``."""
     ...
 def GlobTool() -> Tool: ...
 def ListDirectoryTool() -> Tool: ...
@@ -89,7 +89,7 @@ class Schema:
     def validate(self, value: Any) -> Any: ...
 
 class ReplyContent:
-    """One payload block inside a reply."""
+    """One block inside a reply: text, a tool call, a tool result, or reasoning."""
 
     kind: str
     data: dict
@@ -239,7 +239,8 @@ class ModelStat:
     def __repr__(self) -> str: ...
 
 class Stats:
-    """Statistics for a run, or one label or agent within it. Durations are seconds."""
+    """The metrics about tickets, tokens, and time, for the whole execution or for
+    one label or agent within it. Every duration is in seconds."""
 
     def stats_for_label(self, label: str) -> "Stats": ...
     def stats_for_agent(self, agent_name: str) -> "Stats": ...
@@ -268,7 +269,8 @@ class Stats:
     def __repr__(self) -> str: ...
 
 class Agent:
-    """Configured with the fluent methods, armed by ``build()``, then driven."""
+    """The core entity of agentwerk. It has access to tools for solving tasks in
+    the form of tickets."""
 
     def __init__(self) -> None: ...
     @staticmethod

--- a/crates/agentwerk-py/src/agent.rs
+++ b/crates/agentwerk-py/src/agent.rs
@@ -1,14 +1,10 @@
-//! The agent as Python sees it. One class in two phases: `Agent()` collects
-//! configuration, `build()` assembles the real agent, and the methods that drive
-//! a run work from there on.
+//! The agent as Python sees it. One class in two phases: `Agent()` collects the
+//! configuration, `build()` creates the agent, and the rest drives it.
 //!
-//! Rust splits the phases across two types, because `AgentBuilder<P, M>` changes
-//! type as the provider and model slots fill and `build(self)` consumes it.
-//! Python can hold neither, so the two collapse into the built type's name and
-//! the config is assembled in one shot at `build()`. That collapse is why
-//! `build()` runs once: the Python object owns the private ticket system, so
-//! rebuilding would orphan the queue that clones already handed out still point
-//! at.
+//! Rust splits those phases across two types, which Python cannot hold, so they
+//! collapse into one class here. That is why `build()` runs once: the Python
+//! object owns the agent's own ticket system, and rebuilding would leave the
+//! queue that its copies still point at with nothing reading it.
 
 use std::collections::BTreeMap;
 use std::sync::Arc;
@@ -25,22 +21,22 @@ use crate::ticket::PyTicket;
 use crate::ticket_system::PyTicketSystem;
 use crate::tools::{extract_tool, BoxedTool};
 
-/// Which provider the built agent should use. Resolved at `build()`.
+/// Which LLM provider the agent will use, decided at `build()`.
 enum ProviderSpec {
     Unset,
     Env,
     Explicit(Arc<dyn Provider>),
 }
 
-/// Which model the built agent should use. Resolved at `build()`.
+/// Which model the agent will use, decided at `build()`.
 enum ModelSpec {
     Unset,
     Env,
     Explicit(Model),
 }
 
-/// An agent: configured with the fluent methods, armed by `build()`, then
-/// driven with `task(...)` and `finish()`.
+/// An `Agent` is the core entity of agentwerk. It has access to tools for
+/// solving tasks in the form of tickets.
 #[pyclass(name = "Agent")]
 pub struct PyAgent {
     name: Option<String>,
@@ -54,10 +50,10 @@ pub struct PyAgent {
     tools: Vec<Arc<dyn ToolLike>>,
     knowledge: Option<Arc<Knowledge>>,
     directive_editor: Option<Py<PyAny>>,
-    /// True when the agent came from `Agent.empty()`, which leaves the finish
-    /// tool unregistered.
+    /// True when the agent came from `Agent.empty()`, which registers no finish
+    /// tool.
     empty: bool,
-    /// Filled by `build()`. Every method that reaches the queue needs it.
+    /// Set by `build()`. Every method that reaches the queue needs it.
     agent: Option<Agent>,
 }
 
@@ -80,15 +76,15 @@ impl PyAgent {
         }
     }
 
-    /// The built agent, for callers that drive a run.
+    /// The built agent, for the methods that drive it.
     pub(crate) fn built(&self) -> PyResult<&Agent> {
         self.agent
             .as_ref()
             .ok_or_else(|| runtime_error("agent not built: call build() first"))
     }
 
-    /// Guards every configuration method. Rust gets this from `build(self)`
-    /// consuming the builder; Python has to check.
+    /// Guards every configuration method. Rust prevents this at compile time;
+    /// Python has to check.
     fn ensure_unbuilt(&self) -> PyResult<()> {
         match self.agent {
             Some(_) => Err(runtime_error(
@@ -98,7 +94,7 @@ impl PyAgent {
         }
     }
 
-    /// Turn the collected configuration into a real `Agent`.
+    /// Turn the collected configuration into an `Agent`.
     fn assemble(&self) -> PyResult<Agent> {
         let base = if self.empty {
             Agent::empty()
@@ -180,14 +176,15 @@ impl PyAgent {
         PyAgent::create(false)
     }
 
-    /// An agent with no finish tool pre-registered, for callers that compose the
-    /// whole tool set themselves.
+    /// Create an agent with no tools pre-registered.
+    ///
+    /// Register a finish tool yourself, or the agent cannot finish a ticket.
     #[staticmethod]
     fn empty() -> Self {
         PyAgent::create(true)
     }
 
-    /// Detect both provider and model from environment variables.
+    /// Read environment variables for configuration.
     fn from_env(mut slf: PyRefMut<'_, Self>) -> PyResult<PyRefMut<'_, Self>> {
         slf.ensure_unbuilt()?;
         slf.provider = ProviderSpec::Env;
@@ -195,14 +192,14 @@ impl PyAgent {
         Ok(slf)
     }
 
-    /// Detect the provider from environment variables.
+    /// Read only the LLM provider from environment variables.
     fn provider_from_env(mut slf: PyRefMut<'_, Self>) -> PyResult<PyRefMut<'_, Self>> {
         slf.ensure_unbuilt()?;
         slf.provider = ProviderSpec::Env;
         Ok(slf)
     }
 
-    /// Use an explicit provider handle.
+    /// Define the LLM provider.
     fn provider<'py>(
         mut slf: PyRefMut<'py, Self>,
         provider: PyRef<'_, PyProvider>,
@@ -212,8 +209,8 @@ impl PyAgent {
         Ok(slf)
     }
 
-    /// Set the model, either by name (e.g. `"gpt-4o"`) or with a `Model`
-    /// carrying context-window and reasoning-effort overrides.
+    /// Set the model, by name or as a `Model` carrying a context window size
+    /// and a reasoning level.
     fn model<'py>(
         mut slf: PyRefMut<'py, Self>,
         model: &Bound<'_, PyAny>,
@@ -228,7 +225,7 @@ impl PyAgent {
         Ok(slf)
     }
 
-    /// Detect the model name from environment variables.
+    /// Read only the model from environment variables.
     fn model_from_env(mut slf: PyRefMut<'_, Self>) -> PyResult<PyRefMut<'_, Self>> {
         slf.ensure_unbuilt()?;
         slf.model = ModelSpec::Env;
@@ -259,15 +256,17 @@ impl PyAgent {
         Ok(slf)
     }
 
-    /// Pause on assistant replies that carry no tool calls, for REPL hosts.
+    /// Let the agent wait for new instructions to keep a ticket in-progress.
     fn interactive(mut slf: PyRefMut<'_, Self>) -> PyResult<PyRefMut<'_, Self>> {
         slf.ensure_unbuilt()?;
         slf.interactive = true;
         Ok(slf)
     }
 
-    /// Bind `{key}` to `value` in the role and in string tasks. Binding
-    /// `context` shadows the built-in block the role expands.
+    /// Inject data into prompts with template strings.
+    ///
+    /// `{key}` is replaced in the role and in any text task. Binding `context`
+    /// replaces the built-in block the role expands.
     fn template(
         mut slf: PyRefMut<'_, Self>,
         key: String,
@@ -278,7 +277,7 @@ impl PyAgent {
         Ok(slf)
     }
 
-    /// Bind every `{key}` in the mapping at once.
+    /// Inject more than one entry into prompts.
     fn templates(
         mut slf: PyRefMut<'_, Self>,
         variables: BTreeMap<String, String>,
@@ -288,15 +287,15 @@ impl PyAgent {
         Ok(slf)
     }
 
-    /// Directory tools resolve filesystem paths against.
+    /// Set the directory the agent has access to.
     fn dir(mut slf: PyRefMut<'_, Self>, dir: String) -> PyResult<PyRefMut<'_, Self>> {
         slf.ensure_unbuilt()?;
         slf.dir = Some(dir);
         Ok(slf)
     }
 
-    /// Share a knowledge store for durable, cross-ticket memory. Bind the same
-    /// store to several agents to share their memory.
+    /// Share a knowledge store, the durable memory the agent carries across
+    /// tickets and shares with other agents.
     fn knowledge<'py>(
         mut slf: PyRefMut<'py, Self>,
         store: PyRef<'_, PyKnowledge>,
@@ -306,8 +305,8 @@ impl PyAgent {
         Ok(slf)
     }
 
-    /// Register a tool the agent may call: a built-in handle (e.g.
-    /// `ReadFileTool()`) or a `@tool`-decorated function.
+    /// Register a tool the agent may call, either a built-in such as
+    /// `ReadFileTool()` or a `@tool`-decorated function.
     fn tool<'py>(
         mut slf: PyRefMut<'py, Self>,
         tool: &Bound<'_, PyAny>,
@@ -318,7 +317,7 @@ impl PyAgent {
         Ok(slf)
     }
 
-    /// Register several tools at once, each of the shapes `tool(...)` accepts.
+    /// Register several tools the agent may call.
     fn tools<'py>(
         mut slf: PyRefMut<'py, Self>,
         tools: &Bound<'_, PyAny>,
@@ -331,10 +330,11 @@ impl PyAgent {
         Ok(slf)
     }
 
-    /// Rewrite the corrective directive injected when a turn ends without an
-    /// accepted result. The editor receives the bare reason and the default
-    /// directive, and returns the replacement, or `None` to keep the default.
-    /// Called inline per failure, so keep it cheap.
+    /// Override the prompt that corrects an agent asked to try again.
+    ///
+    /// Your function receives the reason and the built-in text, and returns the
+    /// replacement, or `None` to keep it. It runs once per retry, so keep it
+    /// cheap.
     fn edit_directive_on_retry(
         mut slf: PyRefMut<'_, Self>,
         editor: Py<PyAny>,
@@ -344,9 +344,11 @@ impl PyAgent {
         Ok(slf)
     }
 
-    /// Arm the agent from the configuration collected so far. Runs once: after
-    /// it, the configuration methods and a second `build()` are rejected. Errors
-    /// if provider or model is unset, or if environment detection fails.
+    /// Create the agent.
+    ///
+    /// It runs once: afterwards the configuration methods and a second `build()`
+    /// are rejected. Raises when the LLM provider or the model is unset, or when
+    /// neither can be read from the environment.
     fn build(mut slf: PyRefMut<'_, Self>) -> PyResult<PyRefMut<'_, Self>> {
         slf.ensure_unbuilt()?;
         let agent = slf.assemble()?;
@@ -354,19 +356,21 @@ impl PyAgent {
         Ok(slf)
     }
 
-    /// Enqueue a task (any JSON-serializable value) and return its ticket key.
+    /// Submit a task and return its ticket key.
+    ///
+    /// Call it as often as you like: one agent can drive many tickets.
     fn task(&self, task: &Bound<'_, PyAny>) -> PyResult<String> {
         let value = py_to_value(task)?;
         Ok(self.built()?.task(value))
     }
 
-    /// Enqueue a fully-built ticket on the bound system and return its key.
+    /// Submit a `Ticket` with custom labels or schema, and return its key.
     fn ticket(&self, ticket: PyRef<'_, PyTicket>) -> PyResult<String> {
         Ok(self.built()?.ticket(ticket.to_ticket()))
     }
 
-    /// Bind the agent to a shared ticket system, draining any work it had
-    /// queued privately into that system.
+    /// Attach a built agent to a ticket system, moving any tickets it queued on
+    /// its own across first.
     fn ticket_system<'py>(
         mut slf: PyRefMut<'py, Self>,
         system: PyRef<'_, PyTicketSystem>,
@@ -376,16 +380,18 @@ impl PyAgent {
         Ok(slf)
     }
 
-    /// Start the loop on a background task and return the bound system.
+    /// Begin processing tickets, and hand back the ticket system.
     fn start(&self) -> PyResult<PyTicketSystem> {
         Ok(PyTicketSystem {
             inner: self.built()?.start(),
         })
     }
 
-    /// Run every queued ticket to completion. Awaitable; returns the bound
-    /// `TicketSystem` so results are read off it. Raises at call time, not on
-    /// await, when the agent is not built.
+    /// Process every queued ticket, then hand back the ticket system so results
+    /// can be read from it. Awaitable.
+    ///
+    /// An agent that was never built raises when this is called, not when it is
+    /// awaited.
     fn finish<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         let agent = self.built()?.clone();
         pyo3_async_runtimes::tokio::future_into_py(py, async move {

--- a/crates/agentwerk-py/src/convert.rs
+++ b/crates/agentwerk-py/src/convert.rs
@@ -1,24 +1,22 @@
-//! One JSON conversion path between `serde_json::Value` and Python objects,
-//! plus the error mappings the bindings reuse. Tool inputs, task bodies, and
-//! results all cross the boundary here so there is a single place to keep the
-//! encoding honest.
+//! The one place JSON crosses between Rust and Python, and the errors that
+//! crossing can raise. Tool inputs, task bodies, and results all pass here.
 
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
 use serde_json::Value;
 
-/// Render a `serde_json::Value` as a native Python object (`dict`/`list`/`str`/...).
+/// Hand a `serde_json::Value` to Python as a `dict`, `list`, or scalar.
 pub fn value_to_py<'py>(py: Python<'py>, value: &Value) -> PyResult<Bound<'py, PyAny>> {
     pythonize::pythonize(py, value).map_err(|e| PyValueError::new_err(e.to_string()))
 }
 
-/// Read a native Python object back into a `serde_json::Value`.
+/// Read a Python object back into a `serde_json::Value`.
 pub fn py_to_value(obj: &Bound<'_, PyAny>) -> PyResult<Value> {
     pythonize::depythonize(obj).map_err(|e| PyValueError::new_err(e.to_string()))
 }
 
-/// Map a crate-side error (provider, tool, IO) to a Python exception. The crate
-/// never hands us a `From` blanket, so the mapping stays explicit here too.
+/// Turn a crate error into a Python exception. The crate maps every conversion
+/// explicitly, and so does this.
 pub fn runtime_error(message: impl std::fmt::Display) -> PyErr {
     PyRuntimeError::new_err(message.to_string())
 }

--- a/crates/agentwerk-py/src/event.rs
+++ b/crates/agentwerk-py/src/event.rs
@@ -1,6 +1,6 @@
-//! Events as Python sees them. An `Event` is flattened to a small object with
-//! `kind`, `agent_name`, `ticket_key`, and a `data` dict carrying the variant's
-//! payload, so a Python handler can inspect any event without a class per kind.
+//! Events as Python sees them: one object with `kind`, `agent_name`,
+//! `ticket_key`, and a `data` dict, so a handler reads any event without a class
+//! per kind.
 
 use agentwerk::event::{Event, EventKind};
 use pyo3::prelude::*;
@@ -8,7 +8,7 @@ use serde_json::{json, Value};
 
 use crate::convert::value_to_py;
 
-/// One observation from a run.
+/// An `Event` reports one thing that happened as agents work.
 #[pyclass(name = "Event")]
 pub struct PyEvent {
     #[pyo3(get)]
@@ -22,7 +22,7 @@ pub struct PyEvent {
 
 #[pymethods]
 impl PyEvent {
-    /// The variant payload (model, tokens, tool name, message, ...) as a dict.
+    /// What the event carries: model, tokens, tool name, message.
     #[getter]
     fn data<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         value_to_py(py, &self.data)
@@ -46,9 +46,8 @@ pub fn to_py_event(event: &Event) -> PyEvent {
     }
 }
 
-/// The variant's payload as JSON. Enum-typed fields (error kinds, policy kinds,
-/// reasons) render through their `Display` impl, so every string Python sees is
-/// snake_case and named in one place on the crate side.
+/// What the event carries, as JSON. A typed field renders through its `Display`,
+/// so every string Python sees is snake_case and spelled in one place.
 fn payload(kind: &EventKind) -> Value {
     use EventKind::*;
     match kind {

--- a/crates/agentwerk-py/src/knowledge.rs
+++ b/crates/agentwerk-py/src/knowledge.rs
@@ -1,7 +1,8 @@
-//! The cross-ticket knowledge store as Python sees it. Build one store, cap its
-//! rendered index, and bind it to one or more agents so they share durable
-//! facts across every ticket and across runs. `pages()` is the seam for curating
-//! those facts from Python instead of leaving them to the agent.
+//! The knowledge store as Python sees it. Open one, limit its index, and hand it
+//! to one or more agents so they share what they learn.
+//!
+//! `pages()` is how you write those pages yourself, rather than leaving them to
+//! the agent.
 
 use std::sync::Arc;
 
@@ -11,7 +12,8 @@ use pyo3::prelude::*;
 
 use crate::convert::runtime_error;
 
-/// A shared knowledge store rooted at a directory.
+/// `Knowledge` allows agents to share insights or learnings, kept on disk under
+/// one directory.
 #[pyclass(name = "Knowledge")]
 pub struct PyKnowledge {
     pub inner: Arc<Knowledge>,
@@ -19,30 +21,31 @@ pub struct PyKnowledge {
 
 #[pymethods]
 impl PyKnowledge {
-    /// Open (or seed from) an Open Knowledge Format bundle at `dir/knowledge`.
+    /// Open a knowledge store at `dir/knowledge`, or seed one from the pages
+    /// already there.
     #[staticmethod]
     fn load(dir: &str) -> PyResult<Self> {
         let inner = Knowledge::load(dir).map_err(runtime_error)?;
         Ok(PyKnowledge { inner })
     }
 
-    /// Cap the rendered index injected into the system prompt, in characters.
+    /// Limit the index size, in characters.
     fn index_char_limit<'py>(slf: PyRef<'py, Self>, n: usize) -> PyRef<'py, Self> {
         slf.inner.index_char_limit(n);
         slf
     }
 
-    /// Rendered-index char budget in force, 12 000 until it is overridden.
+    /// Get the index size limit in force, 12 000 until it is changed.
     fn get_index_char_limit(&self) -> usize {
         self.inner.get_index_char_limit()
     }
 
-    /// The current rendered index (the bullet list), or an empty string.
+    /// Get the index, which is injected into the agent prompt.
     fn index(&self) -> String {
         self.inner.index()
     }
 
-    /// The page collection, for curating the store directly.
+    /// Get the page collection for reading and writing pages.
     fn pages(&self) -> PyPages {
         PyPages {
             store: Arc::clone(&self.inner),
@@ -55,9 +58,8 @@ impl PyKnowledge {
     }
 }
 
-/// The page collection of one store. Rust borrows the store for the duration of
-/// the call; Python holds a shared handle instead, so the object outlives the
-/// expression that produced it.
+/// The page collection of one store. Python holds a shared handle, so it
+/// outlives the expression that produced it.
 #[pyclass(name = "Pages")]
 pub struct PyPages {
     store: Arc<Knowledge>,
@@ -71,31 +73,31 @@ impl PyPages {
 
 #[pymethods]
 impl PyPages {
-    /// Create or replace a page and its index entry.
+    /// Create or replace a page, and its entry in the index.
     fn save(&self, page: PyRef<'_, PyPage>) -> PyResult<()> {
         self.pages().save(page.to_page()).map_err(runtime_error)
     }
 
-    /// The page stored under `slug`. Raises when there is none.
+    /// Read one page by its slug. Raises when there is none.
     fn load(&self, slug: &str) -> PyResult<PyPage> {
         let page = self.pages().load(slug).map_err(runtime_error)?;
         Ok(PyPage { inner: page })
     }
 
-    /// Every page in the store, in index order.
+    /// Get every page in the store, in index order.
     fn list(&self) -> PyResult<Vec<PyPage>> {
         let pages = self.pages().list().map_err(runtime_error)?;
         Ok(pages.into_iter().map(|inner| PyPage { inner }).collect())
     }
 
-    /// Drop a page and its index entry.
+    /// Remove one page and its entry in the index.
     fn remove(&self, slug: &str) -> PyResult<()> {
         self.pages().remove(slug).map_err(runtime_error)
     }
 }
 
-/// One knowledge page: a concept document with a slug, a one-line description,
-/// a markdown body, and tags.
+/// A `Page` is one thing an agent learned: a slug, a one-line description, a
+/// markdown body, and tags.
 #[pyclass(name = "Page")]
 pub struct PyPage {
     inner: Page,
@@ -109,7 +111,7 @@ impl PyPage {
 
 #[pymethods]
 impl PyPage {
-    /// `kind` names the concept type.
+    /// What kind of page this is.
     #[new]
     #[pyo3(signature = (slug, description, content, kind="Knowledge", tags=None))]
     fn new(

--- a/crates/agentwerk-py/src/lib.rs
+++ b/crates/agentwerk-py/src/lib.rs
@@ -1,6 +1,5 @@
-//! Python bindings for agentwerk: a thin PyO3 layer wrapping the Rust crate,
-//! which stays the single source of truth. This module exposes its builder,
-//! tools, providers, and ticket system to Python.
+//! The Python bindings wrap the Rust crate, which stays the one source of
+//! truth, and expose its agents, tools, LLM providers, and ticket system.
 
 use pyo3::prelude::*;
 

--- a/crates/agentwerk-py/src/providers.rs
+++ b/crates/agentwerk-py/src/providers.rs
@@ -1,6 +1,6 @@
-//! Provider and model handles for Python. Environment detection covers the
-//! common case; explicit per-vendor constructors and a `Model` tuning object
-//! cover local endpoints and non-default context windows or reasoning effort.
+//! The LLM providers and models as Python sees them. Reading the environment
+//! covers the common case; the per-vendor constructors and `Model` cover a local
+//! endpoint, a different context window, or a different reasoning level.
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -14,13 +14,13 @@ use pyo3::prelude::*;
 
 use crate::convert::runtime_error;
 
-/// An LLM provider the agent builder can be pointed at with `.provider(...)`.
+/// An LLM provider, passed to `.provider(...)`.
 #[pyclass(name = "Provider")]
 pub struct PyProvider {
     pub inner: Arc<dyn Provider>,
 }
 
-/// A model name plus optional context-window and reasoning-effort overrides,
+/// A model name, with an optional context window size and reasoning level,
 /// passed to `.model(...)`.
 #[pyclass(name = "Model")]
 pub struct PyModel {
@@ -36,13 +36,13 @@ impl PyModel {
         }
     }
 
-    /// Override the model's context window, in tokens.
+    /// Set the context window size for a model, in tokens.
     fn context_window(mut slf: PyRefMut<'_, Self>, size: u64) -> PyRefMut<'_, Self> {
         slf.inner = slf.inner.clone().context_window(size);
         slf
     }
 
-    /// Set reasoning effort: `"off"`, `"low"`, `"medium"`, or `"high"`.
+    /// Set the reasoning level: `"off"`, `"low"`, `"medium"`, or `"high"`.
     fn reasoning_effort<'py>(
         mut slf: PyRefMut<'py, Self>,
         effort: &str,
@@ -62,19 +62,19 @@ impl PyModel {
         Ok(slf)
     }
 
-    /// The context window in tokens: the registry default, or the override.
+    /// Get the configured window size, in tokens.
     fn get_context_window(&self) -> Option<u64> {
         self.inner.get_context_window()
     }
 
-    /// `"off"`, `"low"`, `"medium"`, or `"high"`.
+    /// Get the configured effort.
     fn get_reasoning_effort(&self) -> String {
         self.inner.get_reasoning_effort().to_string()
     }
 }
 
-/// Detect and construct a provider from environment variables
-/// (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `MISTRAL_API_KEY`, `LITELLM_API_KEY`).
+/// Read the LLM provider from `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`,
+/// `MISTRAL_API_KEY`, or `LITELLM_API_KEY`.
 #[pyfunction]
 #[pyo3(name = "provider_from_env")]
 fn provider_from_env() -> PyResult<PyProvider> {
@@ -82,16 +82,16 @@ fn provider_from_env() -> PyResult<PyProvider> {
     Ok(PyProvider { inner })
 }
 
-/// Read the model name from `MODEL`, `<PROVIDER>_MODEL`, or the detected
-/// provider's default.
+/// Read the model name from `MODEL`, from `<PROVIDER>_MODEL`, or from the
+/// detected provider's own default.
 #[pyfunction]
 #[pyo3(name = "model_from_env")]
 fn model_from_env() -> PyResult<String> {
     detect_model().map_err(runtime_error)
 }
 
-/// Read `MODEL_CONTEXT_WINDOW`, or `None` when it is unset or not a positive
-/// integer.
+/// Read the context window size from `MODEL_CONTEXT_WINDOW`, or `None` when it
+/// is unset or not a positive integer.
 #[pyfunction]
 #[pyo3(name = "context_window_from_env")]
 fn context_window_from_env() -> Option<u64> {

--- a/crates/agentwerk-py/src/reply.rs
+++ b/crates/agentwerk-py/src/reply.rs
@@ -9,8 +9,7 @@ use serde_json::Value;
 
 use crate::convert::{py_to_value, runtime_error, value_to_py};
 
-/// One entry in a ticket's replies. Extractable, since a reply editor
-/// hands these back.
+/// One entry in a ticket's replies, which an editor hands back.
 #[pyclass(name = "Reply", from_py_object)]
 #[derive(Clone)]
 pub struct PyReply {
@@ -19,7 +18,7 @@ pub struct PyReply {
 
 #[pymethods]
 impl PyReply {
-    /// A reply carrying one text block, as the agent loop writes them.
+    /// A reply carrying one block of text.
     #[staticmethod]
     fn user_text(text: &str) -> Self {
         PyReply {
@@ -47,7 +46,8 @@ impl PyReply {
             .collect()
     }
 
-    /// Millis since epoch. Zero on a reply built here, until it is stored.
+    /// Milliseconds since the epoch, zero on a reply built here until it is
+    /// stored.
     #[getter]
     fn created_at(&self) -> u64 {
         self.inner.created_at
@@ -62,8 +62,8 @@ impl PyReply {
     }
 }
 
-/// One payload block inside a reply: text, a tool call, a tool result, or
-/// the model's reasoning.
+/// One block inside a reply: text, a tool call, a tool result, or the model's
+/// reasoning.
 #[pyclass(name = "ReplyContent", skip_from_py_object)]
 #[derive(Clone)]
 pub struct PyReplyContent {
@@ -134,7 +134,7 @@ impl PyReplyContent {
         .into()
     }
 
-    /// The block's fields as a dict, without the `kind` tag.
+    /// The block's fields as a dict, without `kind`.
     #[getter]
     fn data<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         let mut value = serde_json::to_value(&self.inner).map_err(runtime_error)?;
@@ -149,7 +149,7 @@ impl PyReplyContent {
     }
 }
 
-/// Render replies as Python objects for an editor to inspect.
+/// Hand the replies to Python for an editor to read.
 pub(crate) fn replies_to_py(replies: &[Reply]) -> Vec<PyReply> {
     replies
         .iter()
@@ -158,9 +158,10 @@ pub(crate) fn replies_to_py(replies: &[Reply]) -> Vec<PyReply> {
         .collect()
 }
 
-/// Read an editor's returned list back into replies. Takes the `Reply`
-/// objects the editor was handed, so a dict built by hand is rejected by
-/// name rather than failing on a missing field.
+/// Read an editor's returned list back into replies.
+///
+/// It takes the `Reply` objects the editor was handed, so a dict built by hand
+/// is rejected by name rather than failing on a missing field.
 pub(crate) fn py_to_replies(obj: &Bound<'_, PyAny>) -> PyResult<Vec<Reply>> {
     let replies: Vec<PyReply> = obj.extract().map_err(|_| {
         runtime_error(

--- a/crates/agentwerk-py/src/schema.rs
+++ b/crates/agentwerk-py/src/schema.rs
@@ -1,14 +1,13 @@
-//! JSON-Schema handles for Python. A `Schema` validates a ticket's result; it
-//! is built from a Python dict (or JSON string) and attached to a ticket or a
-//! label default.
+//! The schema as Python sees it: built from a dict or a JSON string, then
+//! attached to a ticket or registered for a label.
 
 use agentwerk::Schema;
 use pyo3::prelude::*;
 
 use crate::convert::{py_to_value, runtime_error, value_to_py};
 
-/// A parsed result schema. Cheap to clone, so a ticket or a label default can
-/// hold the same compiled schema without a second parse.
+/// A `Schema` constrains the result an agent produces for a ticket. Copying it
+/// is cheap, so a ticket and a label can share one.
 #[pyclass(name = "Schema")]
 pub struct PySchema {
     pub inner: Schema,
@@ -16,16 +15,15 @@ pub struct PySchema {
 
 #[pymethods]
 impl PySchema {
-    /// Parse a schema from a Python dict (or any JSON-like value).
+    /// Create a schema from a dict, or from any JSON-like value.
     #[new]
     fn new(document: &Bound<'_, PyAny>) -> PyResult<Self> {
         let inner = Schema::parse(py_to_value(document)?).map_err(runtime_error)?;
         Ok(PySchema { inner })
     }
 
-    /// Validate `value` and return the value to keep: a value the agent
-    /// double-encoded as a JSON string comes back decoded. Raises on a
-    /// violation.
+    /// Validate content and give back the value to keep. A value the agent
+    /// wrote as a JSON string comes back decoded. Raises on a violation.
     fn validate<'py>(
         &self,
         py: Python<'py>,

--- a/crates/agentwerk-py/src/stats.rs
+++ b/crates/agentwerk-py/src/stats.rs
@@ -1,7 +1,8 @@
-//! Run statistics as Python sees them. The Rust accessors are computed, not
-//! stored, so serialising the struct would hand Python the field layout instead
-//! of the numbers callers ask for. This class exposes the accessors themselves,
-//! under their Rust names, with every duration in seconds.
+//! The statistics as Python sees them: the same accessors under the same names,
+//! with every duration in seconds.
+//!
+//! The numbers are computed rather than stored, so handing over the struct
+//! itself would expose the layout instead of the figures.
 
 use std::collections::BTreeMap;
 use std::sync::Arc;
@@ -13,14 +14,15 @@ use pyo3::prelude::*;
 use crate::convert::{runtime_error, value_to_py};
 
 /// Where the numbers come from. The run-wide statistics live inside the ticket
-/// system, so holding the system is what keeps them alive; a nested slice is
-/// its own shared value.
+/// system, so holding the system is what keeps them alive. A slice scoped to one
+/// label or agent is its own shared value.
 enum Source {
     Run(Arc<TicketSystem>),
     Slice(Arc<Stats>),
 }
 
-/// Statistics for a run, or for one label or agent within it.
+/// `Stats` holds the metrics about tickets, tokens, and time, for the whole
+/// execution or for one label or agent within it.
 #[pyclass(name = "Stats")]
 pub struct PyStats {
     source: Source,
@@ -43,31 +45,32 @@ impl PyStats {
 
 #[pymethods]
 impl PyStats {
-    /// Statistics scoped to one ticket label. `run_duration()` is always `None`
-    /// on a slice, since run timing stays global.
+    /// Get statistics scoped to one label. `run_duration()` is always `None`
+    /// here, since timing stays global.
     fn stats_for_label(&self, label: &str) -> PyStats {
         PyStats {
             source: Source::Slice(self.get().stats_for_label(label)),
         }
     }
 
-    /// Statistics scoped to one agent, by the name it was registered under.
-    /// `tickets_created()` counts the tickets that agent filed. The rest count
-    /// the tickets it claimed. Tickets the host filed report as `user`.
+    /// Get statistics scoped to one agent, by the name it was added under.
+    ///
+    /// `tickets_created()` counts the tickets that agent filed; the rest count
+    /// the tickets it claimed.
     fn stats_for_agent(&self, agent_name: &str) -> PyStats {
         PyStats {
             source: Source::Slice(self.get().stats_for_agent(agent_name)),
         }
     }
 
-    /// The token usage recorded for one ticket, oldest first.
+    /// Get a ticket's token usage, oldest first.
     fn usage_history<'py>(&self, py: Python<'py>, ticket_key: &str) -> PyResult<Bound<'py, PyAny>> {
         let history = self.get().usage_history(ticket_key);
         let value = serde_json::to_value(&history).map_err(runtime_error)?;
         value_to_py(py, &value)
     }
 
-    /// Per-tool call and failure tallies, keyed by tool name.
+    /// Get per-tool call and failure counts, keyed by tool name.
     fn tool_stats(&self) -> BTreeMap<String, PyToolStat> {
         self.get()
             .tool_stats()
@@ -76,7 +79,7 @@ impl PyStats {
             .collect()
     }
 
-    /// Per-path open and failure counts for the files tools opened.
+    /// Get per-path open and failure counts for the files tools opened.
     fn file_stats(&self) -> BTreeMap<String, PyFileStat> {
         self.get()
             .file_stats()
@@ -85,14 +88,14 @@ impl PyStats {
             .collect()
     }
 
-    /// Knowledge-store usage across the run.
+    /// Get knowledge usage: write, read, remove, list, and miss counts.
     fn knowledge_stats(&self) -> PyKnowledgeStat {
         PyKnowledgeStat {
             inner: self.get().knowledge_stats(),
         }
     }
 
-    /// Per-model request and token totals, keyed by model name.
+    /// Get per-model requests and token usage, keyed by model name.
     fn model_stats(&self) -> BTreeMap<String, PyModelStat> {
         self.get()
             .model_stats()
@@ -117,7 +120,7 @@ impl PyStats {
         self.get().errors()
     }
 
-    /// Per-event counts, keyed by event name.
+    /// Get per-event counts, keyed by event name.
     fn event_counts(&self) -> BTreeMap<String, u64> {
         self.get().event_counts()
     }
@@ -142,17 +145,18 @@ impl PyStats {
         self.get().tickets_failed()
     }
 
-    /// How long the run has been going, in seconds. `None` before it starts.
+    /// Get the elapsed duration in seconds, or `None` before execution starts.
     fn run_duration(&self) -> Option<f64> {
         self.get().run_duration().map(|d| d.as_secs_f64())
     }
 
-    /// `finished / (finished + failed)`, or `None` when nothing resolved.
+    /// Get `finished / (finished + failed)`, or `None` before any ticket is
+    /// resolved.
     fn tickets_success_rate(&self) -> Option<f64> {
         self.get().tickets_success_rate()
     }
 
-    /// Total seconds tickets spent between creation and a terminal status.
+    /// Get the total time from creation to resolution, in seconds.
     fn total_ticket_duration(&self) -> f64 {
         self.get().total_ticket_duration().as_secs_f64()
     }
@@ -161,7 +165,7 @@ impl PyStats {
         self.get().avg_ticket_duration().map(|d| d.as_secs_f64())
     }
 
-    /// Total seconds tickets spent between being claimed and a terminal status.
+    /// Get the total time agents held tickets, in seconds.
     fn total_work_duration(&self) -> f64 {
         self.get().total_work_duration().as_secs_f64()
     }
@@ -170,7 +174,7 @@ impl PyStats {
         self.get().avg_work_duration().map(|d| d.as_secs_f64())
     }
 
-    /// The same numbers as one dict, matching the on-disk `stats.json`.
+    /// Get every figure as one dict, the same shape as `stats.json`.
     fn to_dict<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         let value = serde_json::to_value(self.get()).map_err(runtime_error)?;
         value_to_py(py, &value)
@@ -186,7 +190,7 @@ impl PyStats {
     }
 }
 
-/// Call and failure tallies for one tool.
+/// A `ToolStat` counts one tool's calls and failures.
 #[pyclass(name = "ToolStat")]
 pub struct PyToolStat {
     inner: ToolStat,
@@ -194,7 +198,7 @@ pub struct PyToolStat {
 
 #[pymethods]
 impl PyToolStat {
-    /// Every attempt, including calls naming a tool that is not registered.
+    /// Every call, including calls naming a tool that is not registered.
     #[getter]
     fn calls(&self) -> u64 {
         self.inner.calls
@@ -215,12 +219,12 @@ impl PyToolStat {
         self.inner.schema_failed
     }
 
-    /// The three failure counts added together.
+    /// Get the total failures across the three kinds.
     fn errors(&self) -> u64 {
         self.inner.errors()
     }
 
-    /// Failures over calls, or `None` when the tool was never called.
+    /// Get `errors / calls`, or `None` when the tool was never called.
     fn error_rate(&self) -> Option<f64> {
         self.inner.error_rate()
     }
@@ -234,7 +238,8 @@ impl PyToolStat {
     }
 }
 
-/// Open and failure counts for one path.
+/// A `FileStat` counts how often a tool opened one path, and how often it could
+/// not.
 #[pyclass(name = "FileStat")]
 pub struct PyFileStat {
     inner: FileStat,
@@ -260,7 +265,7 @@ impl PyFileStat {
     }
 }
 
-/// Knowledge-store operation counts.
+/// A `KnowledgeStat` counts what agents did to the knowledge pages.
 #[pyclass(name = "KnowledgeStat")]
 pub struct PyKnowledgeStat {
     inner: KnowledgeStat,
@@ -288,7 +293,7 @@ impl PyKnowledgeStat {
         self.inner.lists
     }
 
-    /// Reads that found no page.
+    /// Reads and removes naming a page the store does not have.
     #[getter]
     fn misses(&self) -> u64 {
         self.inner.misses
@@ -302,7 +307,7 @@ impl PyKnowledgeStat {
     }
 }
 
-/// Request and token totals for one model.
+/// A `ModelStat` counts one model's requests and token usage.
 #[pyclass(name = "ModelStat")]
 pub struct PyModelStat {
     inner: ModelStat,

--- a/crates/agentwerk-py/src/ticket.rs
+++ b/crates/agentwerk-py/src/ticket.rs
@@ -1,9 +1,9 @@
-//! The ticket as Python sees it. One class in both directions: the constructor
-//! takes the caller-settable fields, and the same class comes back out of
-//! queries and callbacks with its recorded state and messages as attributes.
-//! Rust spells those fields as chained builders (`Ticket::new(...).label(...)
-//! .schema(...).parent(...)`); a Python class cannot carry a `labels` method
-//! and a `labels` attribute, so they arrive as keyword arguments instead.
+//! The ticket as Python sees it. One class in both directions: you set the
+//! fields you own, and the same class comes back with its status and messages.
+//!
+//! Rust sets those fields with chained methods. A Python class cannot carry a
+//! `labels` method and a `labels` attribute, so they are keyword arguments
+//! here.
 
 use agentwerk::Ticket;
 use pyo3::prelude::*;
@@ -11,8 +11,7 @@ use pyo3::prelude::*;
 use crate::convert::{py_to_value, value_to_py};
 use crate::schema::PySchema;
 
-/// A ticket to enqueue on a `TicketSystem`, and the ticket the system hands
-/// back.
+/// A `Ticket` is a task plus what assigns and validates it.
 #[pyclass(name = "Ticket")]
 pub struct PyTicket {
     pub inner: Ticket,
@@ -20,9 +19,10 @@ pub struct PyTicket {
 
 #[pymethods]
 impl PyTicket {
-    /// Create a ticket carrying `task` (any JSON-serializable value). `labels`
-    /// assign it to agents, `schema` is validated against the result, and
-    /// `parent` records a handover audit trail.
+    /// Create a ticket carrying `task`.
+    ///
+    /// `labels` assign it to agents, `schema` is what the result must satisfy,
+    /// and `parent` names the ticket it came from.
     #[new]
     #[pyo3(signature = (task, *, labels=None, schema=None, parent=None))]
     fn new(
@@ -44,37 +44,37 @@ impl PyTicket {
         Ok(PyTicket { inner })
     }
 
-    /// True when the ticket carries `label`.
+    /// Check whether the ticket carries a label.
     fn has_label(&self, label: &str) -> bool {
         self.inner.has_label(label)
     }
 
-    /// True while the ticket is created but not yet claimed.
+    /// Check whether the ticket is still waiting to be claimed.
     fn is_todo(&self) -> bool {
         self.inner.is_todo()
     }
 
-    /// True once the ticket produced an accepted result.
+    /// Check whether the ticket finished.
     fn is_finished(&self) -> bool {
         self.inner.is_finished()
     }
 
-    /// True once the ticket gave up without a result.
+    /// Check whether the ticket failed.
     fn is_failed(&self) -> bool {
         self.inner.is_failed()
     }
 
-    /// True while an agent is working the ticket.
+    /// Check whether an agent is working on the ticket.
     fn is_in_progress(&self) -> bool {
         self.inner.is_in_progress()
     }
 
-    /// True while the ticket still has work left: todo or in progress.
+    /// Check whether the ticket is still open, either todo or in progress.
     fn is_pending(&self) -> bool {
         self.inner.is_pending()
     }
 
-    /// True once the ticket reached a terminal status: finished or failed.
+    /// Check whether the ticket is resolved, either finished or failed.
     fn is_resolved(&self) -> bool {
         self.inner.is_resolved()
     }
@@ -108,7 +108,7 @@ impl PyTicket {
         self.inner.labels.clone()
     }
 
-    /// The schema the result is validated against, when the ticket carries one.
+    /// Schema the result must satisfy, when there is one.
     #[getter]
     fn schema(&self) -> Option<PySchema> {
         self.inner.schema.as_ref().map(|schema| PySchema {
@@ -147,8 +147,8 @@ impl PyTicket {
         self.inner.failed_at
     }
 
-    /// The messages exchanged with the model. Converted on access, so a
-    /// callback that never asks never pays for them.
+    /// The messages exchanged with the model, built on access so a handler that
+    /// never asks never pays for them.
     #[getter]
     fn replies(&self) -> Vec<crate::reply::PyReply> {
         crate::reply::replies_to_py(&self.inner.replies)
@@ -164,17 +164,18 @@ impl PyTicket {
 }
 
 impl PyTicket {
-    /// Wrap a ticket the system owns, messages included.
+    /// Hand over a ticket the system owns, messages included.
     pub fn from_ticket(ticket: &Ticket) -> Self {
         PyTicket {
             inner: ticket.clone(),
         }
     }
 
-    /// Build the ticket to enqueue. Copies the caller-settable fields only:
-    /// `insert` stamps key, status, reporter, and result but leaves the
-    /// messages and lifecycle timestamps, so a ticket that came back out of
-    /// the system would otherwise carry its messages into the new one.
+    /// Build the ticket to submit, copying only the fields you own.
+    ///
+    /// Submitting sets key, status, reporter, and result, but leaves the
+    /// messages and timestamps, so a ticket that came back out of the system
+    /// would otherwise carry its messages into the new one.
     pub fn to_ticket(&self) -> Ticket {
         let mut ticket = Ticket::new(self.inner.task.clone()).labels(self.inner.labels.clone());
         if let Some(schema) = &self.inner.schema {

--- a/crates/agentwerk-py/src/ticket_system.rs
+++ b/crates/agentwerk-py/src/ticket_system.rs
@@ -1,7 +1,5 @@
-//! The ticket system as Python sees it: register agents, enqueue work, set
-//! policies, install callbacks, drive the run, and read results. The Rust
-//! surface is `&self -> &Self` on a shared `Arc`, so these methods take
-//! `PyRef<Self>` and return it for chaining.
+//! The ticket system as Python sees it: add agents, submit work, set limits,
+//! install handlers, drive execution, and read results.
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -20,7 +18,8 @@ use crate::schema::PySchema;
 use crate::stats::PyStats;
 use crate::ticket::PyTicket;
 
-/// A shared queue one or more agents work. Wraps `Arc<TicketSystem>`.
+/// The core data structure of agentwerk, coordinating complex work across
+/// agents.
 #[pyclass(name = "TicketSystem")]
 pub struct PyTicketSystem {
     pub inner: Arc<TicketSystem>,
@@ -35,144 +34,152 @@ impl PyTicketSystem {
         }
     }
 
-    /// Reopen a session directory written by a prior run.
+    /// Continue a session from a directory written earlier.
     #[staticmethod]
     fn load(dir: &str) -> PyResult<Self> {
         let inner = TicketSystem::load(dir).map_err(runtime_error)?;
         Ok(PyTicketSystem { inner })
     }
 
-    /// Register an agent. Drains any work it had queued privately into this
-    /// system and adds it to the dispatch set.
+    /// Add an agent to this ticket system, moving any tickets it queued on its
+    /// own across first.
     fn agent<'py>(slf: PyRef<'py, Self>, agent: PyRef<'_, PyAgent>) -> PyResult<PyRef<'py, Self>> {
         slf.inner.agent(agent.built()?.clone());
         Ok(slf)
     }
 
-    /// Enqueue a task (any JSON-serializable value) and return its ticket key.
+    /// Submit a task and return its ticket key.
     fn task(slf: PyRef<'_, Self>, task: &Bound<'_, PyAny>) -> PyResult<String> {
         Ok(slf.inner.task(py_to_value(task)?))
     }
 
-    /// Enqueue a fully-built ticket and return its key.
+    /// Submit a `Ticket` with custom labels or schema, and return its key.
     fn ticket(slf: PyRef<'_, Self>, ticket: PyRef<'_, PyTicket>) -> String {
         slf.inner.ticket(ticket.to_ticket())
     }
 
-    /// Append a reply to a paused ticket, driving its next turn.
+    /// Add a reply to a ticket, which drives its next turn.
     fn reply<'py>(slf: PyRef<'py, Self>, key: &str, content: &str) -> PyRef<'py, Self> {
         slf.inner.reply(key, content);
         slf
     }
 
-    /// Attach a result and finish a ticket from outside the run. Raises when
-    /// the key is unknown or the result misses the ticket's schema.
+    /// Finish a ticket with a result, from outside the execution.
+    ///
+    /// Raises when the key is unknown, or when the result misses the ticket's
+    /// schema.
     fn set_finished(&self, key: &str, result: &Bound<'_, PyAny>) -> PyResult<()> {
         self.inner
             .set_finished(key, py_to_value(result)?)
             .map_err(runtime_error)
     }
 
-    /// Fail a ticket from outside the run. Raises when the key is unknown.
+    /// Fail a ticket, from outside the execution. Raises when the key is unknown.
     fn set_failed(&self, key: &str) -> PyResult<()> {
         self.inner.set_failed(key).map_err(runtime_error)
     }
 
+    /// Limit the total number of turns.
     fn max_turns(slf: PyRef<'_, Self>, n: u32) -> PyRef<'_, Self> {
         slf.inner.max_turns(n);
         slf
     }
 
+    /// Limit the total input tokens.
     fn max_input_tokens(slf: PyRef<'_, Self>, n: u64) -> PyRef<'_, Self> {
         slf.inner.max_input_tokens(n);
         slf
     }
 
+    /// Limit the total output tokens.
     fn max_output_tokens(slf: PyRef<'_, Self>, n: u64) -> PyRef<'_, Self> {
         slf.inner.max_output_tokens(n);
         slf
     }
 
+    /// Limit the output tokens of a single request.
     fn max_request_tokens(slf: PyRef<'_, Self>, n: u32) -> PyRef<'_, Self> {
         slf.inner.max_request_tokens(n);
         slf
     }
 
+    /// Limit how often a result may fail its schema before the ticket fails.
     fn max_schema_retries(slf: PyRef<'_, Self>, n: u32) -> PyRef<'_, Self> {
         slf.inner.max_schema_retries(n);
         slf
     }
 
+    /// Limit how often a failing request is retried.
     fn max_request_retries(slf: PyRef<'_, Self>, n: u32) -> PyRef<'_, Self> {
         slf.inner.max_request_retries(n);
         slf
     }
 
-    /// Total elapsed-time cap, in seconds.
+    /// Limit the total elapsed duration, in seconds.
     fn max_time(slf: PyRef<'_, Self>, seconds: f64) -> PyRef<'_, Self> {
         slf.inner.max_time(Duration::from_secs_f64(seconds));
         slf
     }
 
-    /// Delay between request retries, in seconds.
+    /// Wait this long between retries, in seconds.
     fn request_retry_delay(slf: PyRef<'_, Self>, seconds: f64) -> PyRef<'_, Self> {
         slf.inner
             .request_retry_delay(Duration::from_secs_f64(seconds));
         slf
     }
 
-    /// Turn cap in force, or `None` when the run is unlimited.
+    /// Get the turn limit, or `None` when there is none.
     fn get_max_turns(&self) -> Option<u32> {
         self.inner.get_max_turns()
     }
 
-    /// Total input-token cap in force, or `None`.
+    /// Get the input-token limit, or `None` when there is none.
     fn get_max_input_tokens(&self) -> Option<u64> {
         self.inner.get_max_input_tokens()
     }
 
-    /// Total output-token cap in force, or `None`.
+    /// Get the output-token limit, or `None` when there is none.
     fn get_max_output_tokens(&self) -> Option<u64> {
         self.inner.get_max_output_tokens()
     }
 
-    /// Per-request output-token cap in force, or `None`.
+    /// Get the per-request output-token limit, or `None` when there is none.
     fn get_max_request_tokens(&self) -> Option<u32> {
         self.inner.get_max_request_tokens()
     }
 
-    /// Schema-retry cap in force, 10 until it is overridden.
+    /// Get the schema-retry limit, 10 until it is changed.
     fn get_max_schema_retries(&self) -> Option<u32> {
         self.inner.get_max_schema_retries()
     }
 
-    /// Request-retry cap in force, 10 until it is overridden.
+    /// Get the request-retry limit, 10 until it is changed.
     fn get_max_request_retries(&self) -> u32 {
         self.inner.get_max_request_retries()
     }
 
-    /// Total elapsed-time cap in force, in seconds, or `None`.
+    /// Get the elapsed-duration limit in seconds, or `None` when there is none.
     fn get_max_time(&self) -> Option<f64> {
         self.inner.get_max_time().map(|d| d.as_secs_f64())
     }
 
-    /// Delay between request retries in force, in seconds.
+    /// Get the delay between retries, in seconds.
     fn get_request_retry_delay(&self) -> f64 {
         self.inner.get_request_retry_delay().as_secs_f64()
     }
 
-    /// Directory the session's logs and state are written to.
+    /// Define where a session is stored.
     fn dir<'py>(slf: PyRef<'py, Self>, dir: &str) -> PyRef<'py, Self> {
         slf.inner.dir(dir);
         slf
     }
 
-    /// Directory the system writes to, `./.agentwerk` until `dir` overrides it.
+    /// Get the session directory, `./.agentwerk` until `dir` changes it.
     fn get_dir(&self) -> String {
         self.inner.get_dir().display().to_string()
     }
 
-    /// Register a default result schema for every ticket carrying `label`.
+    /// Register a schema every ticket of that label validates against.
     fn schema_for_label<'py>(
         slf: PyRef<'py, Self>,
         label: &str,
@@ -182,7 +189,8 @@ impl PyTicketSystem {
         slf
     }
 
-    /// Install an event handler. Replaces the default stderr logger.
+    /// Read every event as it is emitted. It replaces the handler that prints to
+    /// stderr.
     fn on_event<'py>(slf: PyRef<'py, Self>, callback: Py<PyAny>) -> PyRef<'py, Self> {
         slf.inner.on_event(move |event: &Event| {
             Python::attach(|py| {
@@ -195,8 +203,8 @@ impl PyTicketSystem {
         slf
     }
 
-    /// Call `callback(ticket, result)` for every finished ticket, with the
-    /// result already validated against the ticket's schema.
+    /// Read every finished ticket together with its result, already validated
+    /// against the ticket's schema.
     fn on_result<'py>(slf: PyRef<'py, Self>, callback: Py<PyAny>) -> PyRef<'py, Self> {
         slf.inner.on_result(move |ticket: &Ticket, result: &Value| {
             Python::attach(|py| {
@@ -208,9 +216,9 @@ impl PyTicketSystem {
         slf
     }
 
-    /// Call `callback(event, ticket)` for every failure: a failed ticket, a
-    /// failed tool call, a failed request, a file that would not open, or
-    /// compaction that could not finish. Read `event.kind` to tell them apart.
+    /// Read every failure together with the ticket it happened in: a failed
+    /// ticket, tool call, or request, a file that would not open, or compaction
+    /// that could not finish. Read `event.kind` to tell them apart.
     fn on_failure<'py>(slf: PyRef<'py, Self>, callback: Py<PyAny>) -> PyRef<'py, Self> {
         slf.inner.on_failure(move |event: &Event, ticket: &Ticket| {
             Python::attach(|py| {
@@ -222,7 +230,7 @@ impl PyTicketSystem {
         slf
     }
 
-    /// Cancel the run when `predicate(event)` first returns truthy.
+    /// Stop execution when an event matches.
     fn cancel_on_event<'py>(slf: PyRef<'py, Self>, predicate: Py<PyAny>) -> PyRef<'py, Self> {
         slf.inner.cancel_on_event(move |event: &Event| {
             Python::attach(|py| {
@@ -236,8 +244,7 @@ impl PyTicketSystem {
         slf
     }
 
-    /// Cancel the run when `predicate(ticket, result)` first returns truthy
-    /// for a finished ticket.
+    /// Stop execution when a finished result matches.
     fn cancel_on_result<'py>(slf: PyRef<'py, Self>, predicate: Py<PyAny>) -> PyRef<'py, Self> {
         slf.inner
             .cancel_on_result(move |ticket: &Ticket, result: &Value| {
@@ -250,8 +257,7 @@ impl PyTicketSystem {
         slf
     }
 
-    /// Cancel the run when `predicate(event, ticket)` first returns truthy
-    /// for a failure.
+    /// Stop execution when a failure matches.
     fn cancel_on_failure<'py>(slf: PyRef<'py, Self>, predicate: Py<PyAny>) -> PyRef<'py, Self> {
         slf.inner
             .cancel_on_failure(move |event: &Event, ticket: &Ticket| {
@@ -264,8 +270,8 @@ impl PyTicketSystem {
         slf
     }
 
-    /// Cancel the run when `awaitable` resolves. Its result is discarded;
-    /// only completion matters.
+    /// Stop execution when another task you supply finishes. Its result is
+    /// discarded; only finishing matters.
     fn cancel_on<'py>(slf: PyRef<'py, Self>, awaitable: Py<PyAny>) -> PyResult<PyRef<'py, Self>> {
         let future = Python::attach(|py| {
             pyo3_async_runtimes::tokio::into_future(awaitable.bind(py).clone())
@@ -278,8 +284,8 @@ impl PyTicketSystem {
         Ok(slf)
     }
 
-    /// After every event, call `make(event)`; a returned `Ticket` is
-    /// enqueued, `None` enqueues nothing.
+    /// Enqueue a follow-up ticket from any event. Returning `None` adds
+    /// nothing.
     fn create_ticket_on_event<'py>(slf: PyRef<'py, Self>, make: Py<PyAny>) -> PyRef<'py, Self> {
         slf.inner.create_ticket_on_event(move |event: &Event| {
             Python::attach(|py| {
@@ -290,8 +296,8 @@ impl PyTicketSystem {
         slf
     }
 
-    /// After each finished ticket, call `make(ticket, result)`; a returned
-    /// `Ticket` is enqueued, `None` enqueues nothing.
+    /// Enqueue a follow-up ticket from a finished ticket. Returning `None` adds
+    /// nothing.
     fn create_ticket_on_result<'py>(slf: PyRef<'py, Self>, make: Py<PyAny>) -> PyRef<'py, Self> {
         slf.inner
             .create_ticket_on_result(move |ticket: &Ticket, result: &Value| {
@@ -303,9 +309,10 @@ impl PyTicketSystem {
         slf
     }
 
-    /// After each failure, call `make(event, ticket)`; a returned `Ticket` is
-    /// enqueued, `None` enqueues nothing. The retry path: count the attempts
-    /// yourself, or a ticket that always fails re-queues itself forever.
+    /// Enqueue a retry for a ticket that failed. Returning `None` adds nothing.
+    ///
+    /// Count the attempts yourself, or a ticket that fails every time re-queues
+    /// itself forever.
     fn create_ticket_on_failure<'py>(slf: PyRef<'py, Self>, make: Py<PyAny>) -> PyRef<'py, Self> {
         slf.inner
             .create_ticket_on_failure(move |event: &Event, ticket: &Ticket| {
@@ -317,21 +324,22 @@ impl PyTicketSystem {
         slf
     }
 
-    /// Cancel every ticket carrying `label`.
+    /// Stop one label's agents while the rest keep working.
     fn cancel_label<'py>(slf: PyRef<'py, Self>, label: &str) -> PyRef<'py, Self> {
         slf.inner.cancel_label(label);
         slf
     }
 
-    /// True when `label` names a pool called off via `cancel_label`. Ask before
-    /// minting follow-up work: a ticket carrying a cancelled label is never
-    /// claimed.
+    /// Check whether one label's agents have been stopped.
+    ///
+    /// Ask before creating follow-up work: a ticket carrying a stopped label is
+    /// never claimed.
     fn label_cancelled(&self, label: &str) -> bool {
         self.inner.label_cancelled(label)
     }
 
-    /// Call off `label`'s agents when `predicate(event)` first returns
-    /// truthy. Only that pool stops; other labels keep going.
+    /// Stop one label's agents when an event matches, while the rest keep
+    /// working.
     fn cancel_label_on_event<'py>(
         slf: PyRef<'py, Self>,
         label: &str,
@@ -350,9 +358,8 @@ impl PyTicketSystem {
         slf
     }
 
-    /// Call off `label`'s agents when a finished ticket makes
-    /// `predicate(ticket, result)` truthy. Only that pool stops; other labels
-    /// keep going.
+    /// Stop one label's agents when a finished result matches, while the rest
+    /// keep working.
     fn cancel_label_on_result<'py>(
         slf: PyRef<'py, Self>,
         label: &str,
@@ -369,8 +376,8 @@ impl PyTicketSystem {
         slf
     }
 
-    /// Call off `label`'s agents when a failure makes `predicate(event,
-    /// ticket)` truthy. Only that pool stops; other labels keep going.
+    /// Stop one label's agents when a failure matches, while the rest keep
+    /// working.
     fn cancel_label_on_failure<'py>(
         slf: PyRef<'py, Self>,
         label: &str,
@@ -387,13 +394,13 @@ impl PyTicketSystem {
         slf
     }
 
-    /// Name of the model the bound agent named `agent_name` runs, or `None`.
-    /// `Trajectory.from_ticket` wants it.
+    /// Get the model that agent runs, or `None` when no agent of that name is
+    /// added. `Trajectory.from_ticket` needs it.
     fn model_for_agent(&self, agent_name: &str) -> Option<String> {
         self.inner.model_for_agent(agent_name)
     }
 
-    /// The ticket with `key`, or `None`.
+    /// Get one ticket by key.
     fn get_ticket(&self, py: Python<'_>, key: &str) -> PyResult<Option<Py<PyTicket>>> {
         match self.inner.get_ticket(key) {
             Some(ticket) => Ok(Some(Py::new(py, PyTicket::from_ticket(&ticket))?)),
@@ -401,7 +408,7 @@ impl PyTicketSystem {
         }
     }
 
-    /// Every ticket, in creation order.
+    /// Get every ticket in creation order.
     fn tickets(&self, py: Python<'_>) -> PyResult<Vec<Py<PyTicket>>> {
         self.inner
             .tickets()
@@ -410,7 +417,7 @@ impl PyTicketSystem {
             .collect()
     }
 
-    /// Every ticket carrying `label`, in creation order, whatever its status.
+    /// Get every ticket carrying a specific label, whatever its status.
     fn tickets_for_label(&self, py: Python<'_>, label: &str) -> PyResult<Vec<Py<PyTicket>>> {
         self.inner
             .tickets_for_label(label)
@@ -419,7 +426,7 @@ impl PyTicketSystem {
             .collect()
     }
 
-    /// Every ticket for which `predicate(ticket)` is truthy.
+    /// Get every ticket matching a condition.
     fn find_tickets(&self, py: Python<'_>, predicate: Py<PyAny>) -> PyResult<Vec<Py<PyTicket>>> {
         self.inner
             .find_tickets(|ticket| ticket_predicate(&predicate, ticket))
@@ -428,7 +435,7 @@ impl PyTicketSystem {
             .collect()
     }
 
-    /// The first ticket for which `predicate(ticket)` is truthy, or `None`.
+    /// Get the earliest ticket matching a condition.
     fn find_ticket(&self, py: Python<'_>, predicate: Py<PyAny>) -> PyResult<Option<Py<PyTicket>>> {
         match self
             .inner
@@ -439,8 +446,8 @@ impl PyTicketSystem {
         }
     }
 
-    /// Await the first ticket for which `predicate(ticket)` is truthy. Resolves
-    /// to the ticket, or `None` if the run ends first.
+    /// Wait for one matching ticket instead of draining the queue. Gives back
+    /// `None` when execution ends first.
     fn wait_for_ticket<'py>(
         &self,
         py: Python<'py>,
@@ -458,9 +465,10 @@ impl PyTicketSystem {
         })
     }
 
-    /// Call `callback(event, ticket)` when a ticket starts, finishes, or
-    /// fails. The ticket arrives with its messages, so a handler can hand it
-    /// straight to `Trajectory.from_ticket`.
+    /// Read a ticket as it starts, finishes, or fails.
+    ///
+    /// It arrives with its messages, so a handler can pass it straight to
+    /// `Trajectory.from_ticket`.
     fn on_ticket<'py>(slf: PyRef<'py, Self>, callback: Py<PyAny>) -> PyRef<'py, Self> {
         slf.inner.on_ticket(move |event: &Event, ticket: &Ticket| {
             Python::attach(|py| {
@@ -474,14 +482,15 @@ impl PyTicketSystem {
         slf
     }
 
-    /// Rewrite or drop a ticket's replies before its next request.
-    /// `editor(events, replies)` receives the events since the ticket's
-    /// previous request and the current `Reply` list, and returns the new
-    /// list (or `None` to leave it unchanged). The editor must keep
-    /// tool_use/tool_result pairs matched. The edit persists across
-    /// resumption. An editor that raises prints its traceback and leaves the
-    /// replies untouched: this runs on an agent's worker thread, with no
-    /// Python frame to raise into.
+    /// Rewrite a ticket's replies before its next request.
+    ///
+    /// Your function receives the events since the ticket's previous request and
+    /// the current replies, and returns the new list, or `None` to change
+    /// nothing. Keep each `tool_use` paired with its `tool_result`. The edit is
+    /// permanent and survives the session being continued.
+    ///
+    /// Raising prints the traceback and leaves the replies alone: this runs on
+    /// an agent's own thread, with no Python frame to raise into.
     fn edit_replies_on_event<'py>(slf: PyRef<'py, Self>, editor: Py<PyAny>) -> PyRef<'py, Self> {
         slf.inner
             .edit_replies_on_event(move |events: &[Event], replies: &mut Vec<Reply>| {
@@ -505,11 +514,11 @@ impl PyTicketSystem {
         slf
     }
 
-    /// Rewrite or drop a ticket's replies now, without triggering a
-    /// request. `editor(replies)` receives the current `Reply` list and
-    /// returns the new one (or `None` to leave it unchanged). Persists the
-    /// edit in place; a missing ticket is a no-op. An editor that raises,
-    /// or returns something other than a list of `Reply`, raises here: this
+    /// Rewrite one ticket's replies now, without sending a request.
+    ///
+    /// Your function receives the current replies and returns the new ones, or
+    /// `None` to change nothing. A ticket that does not exist changes nothing.
+    /// Raising, or returning anything but a list of `Reply`, raises here: this
     /// call has a Python frame to unwind into, so it does not guess.
     fn edit_replies<'py>(
         slf: PyRef<'py, Self>,
@@ -544,7 +553,7 @@ impl PyTicketSystem {
         slf
     }
 
-    /// Run every queued ticket to completion. Awaitable.
+    /// Process every queued ticket, then return. Awaitable.
     fn finish<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         let inner = Arc::clone(&self.inner);
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
@@ -561,19 +570,19 @@ impl PyTicketSystem {
         self.inner.is_cancelled()
     }
 
-    /// How the run ended (`"drained"`, `"cancelled"`, `"policy_violated(..)"`),
-    /// or `None` if it has not finished.
+    /// Check the reason for the finishing: `"drained"`, `"cancelled"`, or
+    /// `"policy_violated(..)"`. `None` until execution ends.
     fn finish_reason(&self) -> Option<String> {
         self.inner.finish_reason().map(|reason| reason.to_string())
     }
 
-    /// Run statistics: requests, tokens, ticket counts, and the per-tool,
-    /// per-file, per-label, and per-model breakdowns.
+    /// Get the execution statistics: requests, tokens, ticket counts, and the
+    /// per-tool, per-file, per-label, and per-model figures.
     fn stats(&self) -> PyStats {
         PyStats::for_run(Arc::clone(&self.inner))
     }
 
-    /// The most recent finished ticket's result, or `None`.
+    /// Get the most recent ticket result.
     fn last_result<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyAny>>> {
         match self.inner.last_result() {
             Some(value) => Ok(Some(value_to_py(py, &value)?)),
@@ -581,7 +590,7 @@ impl PyTicketSystem {
         }
     }
 
-    /// Every finished ticket's result, in creation order.
+    /// Get every ticket's result in creation order.
     fn results<'py>(&self, py: Python<'py>) -> PyResult<Vec<Bound<'py, PyAny>>> {
         self.inner
             .results()
@@ -590,7 +599,7 @@ impl PyTicketSystem {
             .collect()
     }
 
-    /// Finished results scoped to one label.
+    /// Get every ticket's result carrying a specific label.
     fn results_for_label<'py>(
         &self,
         py: Python<'py>,
@@ -604,8 +613,8 @@ impl PyTicketSystem {
     }
 }
 
-/// Call a Python callable with the `(ticket, result)` pair every `_on_result`
-/// hook hands over.
+/// Call a Python function with the ticket and result every `_on_result` hook
+/// hands over.
 fn call_with_result<'py>(
     py: Python<'py>,
     callable: &Py<PyAny>,
@@ -617,8 +626,8 @@ fn call_with_result<'py>(
     callable.bind(py).call1((view, value))
 }
 
-/// Call a Python callable with the `(event, ticket)` pair every `_on_failure`
-/// hook hands over.
+/// Call a Python function with the event and ticket every `_on_failure` hook
+/// hands over.
 fn call_with_ticket<'py>(
     py: Python<'py>,
     callable: &Py<PyAny>,
@@ -629,8 +638,8 @@ fn call_with_ticket<'py>(
     callable.bind(py).call1((to_py_event(event), view))
 }
 
-/// Read a ticket back out of what a `create_ticket_*` callable returned.
-/// `None`, or anything that is not a `Ticket`, enqueues nothing.
+/// Read a ticket back out of what a `create_ticket_*` function returned. `None`,
+/// or anything that is not a `Ticket`, adds nothing.
 fn built_ticket(produced: &Bound<'_, PyAny>) -> Option<Ticket> {
     if produced.is_none() {
         return None;
@@ -638,9 +647,8 @@ fn built_ticket(produced: &Bound<'_, PyAny>) -> Option<Ticket> {
     Some(produced.extract::<PyRef<PyTicket>>().ok()?.to_ticket())
 }
 
-/// Call a Python predicate with a ticket, reading back its truthiness. A
-/// conversion or Python error reads as `false` so a bad predicate never panics
-/// a worker thread.
+/// Ask a Python condition about a ticket. A conversion or Python error reads as
+/// false, so a broken condition never brings down an agent's thread.
 fn ticket_predicate(predicate: &Py<PyAny>, ticket: &Ticket) -> bool {
     Python::attach(|py| {
         Py::new(py, PyTicket::from_ticket(ticket))

--- a/crates/agentwerk-py/src/tools.rs
+++ b/crates/agentwerk-py/src/tools.rs
@@ -1,6 +1,5 @@
-//! Built-in tools exposed to Python, plus the extraction seam that turns a
-//! Python-visible tool object back into an `Arc<dyn ToolLike>` the agent
-//! builder can register.
+//! The built-in tools as Python sees them, and how a Python tool object becomes
+//! one the agent builder can register.
 
 use std::future::Future;
 use std::pin::Pin;
@@ -59,16 +58,17 @@ impl ToolLike for BoxedTool {
     }
 }
 
-/// A tool handle Python holds and passes to `Agent.tool(...)`. Every built-in
-/// factory returns one; the extraction seam reads its inner trait object.
+/// A tool handle Python passes to `Agent.tool(...)`. Every built-in returns
+/// one.
 #[pyclass(name = "Tool")]
 pub struct PyTool {
     pub inner: Arc<dyn ToolLike>,
 }
 
-/// Wraps a `@tool`-decorated Python callable as a first-class `ToolLike`. The
-/// five sync methods read cached metadata; `call` runs the callable on a
-/// blocking thread under the GIL so it never stalls the async executor.
+/// Turns a `@tool`-decorated Python function into a tool agentwerk can call.
+///
+/// The name, description, and schema are read once and kept. The function
+/// itself runs on its own thread, so it never holds up the rest of the work.
 struct PyToolAdapter {
     func: Py<PyAny>,
     name: String,
@@ -132,9 +132,8 @@ impl ToolLike for PyToolAdapter {
     }
 }
 
-/// Call the Python tool and turn its return value into a `ToolResult`. The tool
-/// input object is passed as keyword arguments; a coroutine result is driven to
-/// completion so async tool bodies work too.
+/// Call the Python tool and turn what it returns into a `ToolResult`. The input
+/// arrives as keyword arguments, and an async function is awaited.
 fn invoke_python(py: Python<'_>, func: &Py<PyAny>, input: &Value) -> PyResult<ToolResult> {
     let arg = value_to_py(py, input)?;
     let bound = func.bind(py);
@@ -165,9 +164,8 @@ fn invoke_python(py: Python<'_>, func: &Py<PyAny>, input: &Value) -> PyResult<To
     Ok(ToolResult::success(value.to_string()))
 }
 
-/// What a tool reports back. Returning a plain string or dict is the same as
-/// `ToolResult.success(...)`; the other two say the call failed without ending
-/// the run.
+/// What a tool reports back when a bare return value is not enough. Returning a
+/// plain string or dict is the same as `ToolResult.success(...)`.
 #[pyclass(name = "ToolResult")]
 pub struct PyToolResult {
     inner: ToolResult,
@@ -175,7 +173,7 @@ pub struct PyToolResult {
 
 #[pymethods]
 impl PyToolResult {
-    /// The tool did its work; `content` goes back to the model.
+    /// The tool did its work, and `content` goes back to the model.
     #[staticmethod]
     fn success(content: String) -> Self {
         PyToolResult {
@@ -183,7 +181,7 @@ impl PyToolResult {
         }
     }
 
-    /// The tool failed; `content` explains why so the model can adjust.
+    /// The tool failed, and `content` says why so the model can work around it.
     #[staticmethod]
     fn error(content: String) -> Self {
         PyToolResult {
@@ -191,8 +189,7 @@ impl PyToolResult {
         }
     }
 
-    /// The input did not match the tool's schema. Counted against
-    /// `max_schema_retries`.
+    /// The input was malformed. It counts against `max_schema_retries`.
     #[staticmethod]
     fn schema_error(content: String) -> Self {
         PyToolResult {
@@ -201,8 +198,8 @@ impl PyToolResult {
     }
 }
 
-/// Pull an `Arc<dyn ToolLike>` out of whatever Python passed to `.tool(...)`:
-/// a built-in `Tool` handle, or a `@tool`-decorated callable.
+/// Read a usable tool out of whatever Python passed to `.tool(...)`: a built-in
+/// handle, or a `@tool`-decorated function.
 pub fn extract_tool(obj: &Bound<'_, PyAny>) -> PyResult<Arc<dyn ToolLike>> {
     if let Ok(handle) = obj.extract::<PyRef<PyTool>>() {
         return Ok(Arc::clone(&handle.inner));
@@ -233,7 +230,7 @@ fn handle(inner: Arc<dyn ToolLike>) -> PyTool {
     PyTool { inner }
 }
 
-// --- built-in factories ---
+// Built-in factories
 // Each reads as a constructor at the Python call site (e.g. `ReadFileTool()`).
 
 #[pyfunction]
@@ -254,7 +251,8 @@ fn edit_file_tool() -> PyTool {
     handle(Arc::new(EditFileTool))
 }
 
-/// Search file contents by regex, or a code shape via `syntax="code"`.
+/// Search file contents by regular expression, or by code shape with
+/// `syntax="code"`.
 #[pyfunction]
 #[pyo3(name = "GrepTool")]
 fn grep_tool() -> PyTool {
@@ -279,16 +277,17 @@ fn fetch_url_tool() -> PyTool {
     handle(Arc::new(FetchUrlTool))
 }
 
-/// Discover the tools an agent deferred until they are needed.
+/// Look up the tools held back until they are needed.
 #[pyfunction]
 #[pyo3(name = "FindToolsTool")]
 fn find_tools_tool() -> PyTool {
     handle(Arc::new(FindToolsTool))
 }
 
-/// Bind the knowledge tool to `store` without making it the agent's own
-/// knowledge. `Agent.knowledge(store)` is the usual route: it does this
-/// and also renders the store's index into the system prompt.
+/// Point the knowledge tool at `store` without making it the agent's own.
+///
+/// `Agent.knowledge(store)` is the usual route, and also shows the store's index
+/// in the prompt.
 #[pyfunction]
 #[pyo3(name = "ManageKnowledgeTool")]
 fn manage_knowledge_tool(store: PyRef<'_, PyKnowledge>) -> PyTool {
@@ -301,8 +300,8 @@ fn read_tickets_tool() -> PyTool {
     handle(Arc::new(ReadTicketsTool))
 }
 
-/// Finish a ticket with a result, optionally handing work to a child ticket.
-/// Registered on every agent built with `Agent()`.
+/// Write the result for the current ticket and mark it finished, handing work
+/// on to a child ticket when needed. Registered on every agent.
 #[pyfunction]
 #[pyo3(name = "FinishTool")]
 fn finish_tool() -> PyTool {
@@ -315,7 +314,7 @@ fn manage_tickets_tool() -> PyTool {
     handle(Arc::new(ManageTicketsTool))
 }
 
-/// Shell tool restricted to commands matching `pattern` (e.g. `"git *"`).
+/// Run a shell command matching an allowed pattern, such as `"git *"`.
 #[pyfunction]
 #[pyo3(name = "BashTool", signature = (name, pattern, description=None, read_only=false))]
 fn bash_tool(name: &str, pattern: &str, description: Option<&str>, read_only: bool) -> PyTool {
@@ -327,7 +326,7 @@ fn bash_tool(name: &str, pattern: &str, description: Option<&str>, read_only: bo
     handle(Arc::new(tool))
 }
 
-/// Shell tool with no command restriction. Only for trusted inputs.
+/// Run any shell command. Only for input you trust.
 #[pyfunction]
 #[pyo3(name = "UnrestrictedBashTool")]
 fn unrestricted_bash_tool() -> PyTool {

--- a/crates/agentwerk-py/src/trajectory.rs
+++ b/crates/agentwerk-py/src/trajectory.rs
@@ -7,7 +7,7 @@ use pyo3::prelude::*;
 use crate::convert::runtime_error;
 use crate::ticket::PyTicket;
 
-/// A finished agent run reduced to its messages.
+/// A `Trajectory` is one finished ticket kept as a training example.
 #[pyclass(name = "Trajectory")]
 pub struct PyTrajectory {
     inner: Trajectory,
@@ -16,8 +16,7 @@ pub struct PyTrajectory {
 #[pymethods]
 impl PyTrajectory {
     /// Capture `ticket`'s messages as an example produced by `agent` using
-    /// `model`. Read the model name from
-    /// `TicketSystem.model_for_agent(event.agent_name)`.
+    /// `model`, whose name `TicketSystem.model_for_agent` gives you.
     #[staticmethod]
     fn from_ticket(agent: &str, model: Option<&str>, ticket: PyRef<'_, PyTicket>) -> Self {
         PyTrajectory {
@@ -25,13 +24,14 @@ impl PyTrajectory {
         }
     }
 
-    /// Write the example under `dir` as `trajectories/<key>.json`, plus an
-    /// `.html` sibling rendering the messages for reading.
+    /// Save the example under `dir` as `trajectories/<key>.json`, with an
+    /// `.html` beside it for reading.
     fn save(&self, dir: &str) -> PyResult<()> {
         self.inner.save(dir).map_err(runtime_error)
     }
 
-    /// Example id `<agent>-<ticket>`; also the file name.
+    /// The example's identifier, `<agent>-<ticket>`, which is also its file
+    /// name.
     #[getter]
     fn key(&self) -> &str {
         &self.inner.key

--- a/crates/agentwerk/src/agents/agent.rs
+++ b/crates/agentwerk/src/agents/agent.rs
@@ -1,9 +1,5 @@
-//! Agent: identity + prompt parts + provider/model + a bound ticket system.
-//! `AgentBuilder::build()` produces the final agent, which
-//! `tickets.agent(agent)` binds to the system. agentwerk upgrades the
-//! bound reference once at the start of `run_agent` and accesses
-//! `tickets`, `policies`, `stats`, and `stop_signal` through the
-//! resulting `Arc<TicketSystem>`.
+//! The core entity of agentwerk: who an agent is, what it may call, and which
+//! queue it works from.
 
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -27,15 +23,14 @@ fn default_agent_name() -> String {
     format!("agent-{n}")
 }
 
-/// Caller hook that rewrites a corrective directive in place, reading the
-/// bare failure reason as context; see
-/// [`AgentBuilder::edit_directive_on_retry`].
+/// Your function for rewriting the prompt that corrects an agent asked to try
+/// again. See [`AgentBuilder::edit_directive_on_retry`].
 pub(crate) type DirectiveEditor = dyn Fn(&str, &mut String) + Send + Sync;
 
-// --- builder ---
+// Builder
 
-/// Builder for [`Agent`]. Configures the LLM provider, model, role,
-/// tools, labels, and the working directory.
+/// An `AgentBuilder` collects who the agent is, what it may call, and where it
+/// works, then hands back the finished [`Agent`].
 #[derive(Clone)]
 pub struct AgentBuilder<P, M> {
     name: String,
@@ -72,11 +67,10 @@ impl AgentBuilder<(), ()> {
         }
     }
 
-    /// Construct an `Agent` with no tools pre-registered, for callers
-    /// that want to compose the whole registry themselves. The caller is
-    /// responsible for registering `FinishTool` via [`Self::tool`]:
-    /// without it the agent cannot finish its ticket and the loop
-    /// re-runs it.
+    /// Create an agent with no tools pre-registered.
+    ///
+    /// Register `FinishTool` yourself through [`Self::tool`]. Without it the
+    /// agent cannot finish a ticket, and the same ticket is tried again.
     pub fn empty() -> Self {
         let knowledge = Knowledge::load(".agentwerk").expect("open knowledge store");
         let mut tools = ToolRegistry::default();
@@ -96,9 +90,10 @@ impl AgentBuilder<(), ()> {
         }
     }
 
-    /// Detect both the provider and the model from environment variables.
-    /// Equivalent to `provider_from_env().model_from_env()`. Panics if no
-    /// provider env var is set.
+    /// Read environment variables for configuration.
+    ///
+    /// The same as `provider_from_env().model_from_env()`. Panics when no LLM
+    /// provider variable is set.
     pub fn from_env(self) -> AgentBuilder<Arc<dyn Provider>, Model> {
         self.provider_from_env().model_from_env()
     }
@@ -121,7 +116,7 @@ impl<M> AgentBuilder<(), M> {
         }
     }
 
-    /// Detect the provider from environment variables. Panics if no provider env var is set.
+    /// Read only the LLM provider from environment variables. Panics when none is set.
     pub fn provider_from_env(self) -> AgentBuilder<Arc<dyn Provider>, M> {
         let p = crate::providers::provider_from_env().expect(
             "LLM provider required: set ANTHROPIC_API_KEY, OPENAI_API_KEY, MISTRAL_API_KEY, or LITELLM_API_KEY",
@@ -147,7 +142,7 @@ impl<P> AgentBuilder<P, ()> {
         }
     }
 
-    /// Read the model name from environment variables. Panics if no model can be detected.
+    /// Read only the model from environment variables. Panics when none is set.
     pub fn model_from_env(self) -> AgentBuilder<P, Model> {
         let model = crate::providers::model_from_env().expect("model name required");
         self.model(model)
@@ -160,24 +155,24 @@ impl<P, M> AgentBuilder<P, M> {
         self
     }
 
-    /// The agent's system prompt. A `{context}` placeholder anywhere in
-    /// it expands to the run's facts — ticket key, date, working
-    /// directory, platform, and a bullet per configured budget. Nothing
-    /// is added when the placeholder is absent, so the role owns both
-    /// whether the facts appear and where.
+    /// Define who the agent is and how it should work.
+    ///
+    /// A `{context}` placeholder anywhere in the text expands to the facts of
+    /// the moment: ticket key, date, working directory, platform, and one line
+    /// per configured limit. Leave the placeholder out and nothing is added, so
+    /// the role decides both whether those facts appear and where.
     pub fn role(mut self, r: impl Into<String>) -> Self {
         self.role = r.into();
         self
     }
 
-    /// Add a single label to the agent's scope. Use [`Self::labels`] to
-    /// add several at once.
+    /// Restrict the agent to tickets carrying a matching label.
     pub fn label(mut self, l: impl Into<String>) -> Self {
         self.labels.push(l.into());
         self
     }
 
-    /// Add many labels at once.
+    /// Restrict the agent to tickets carrying any of these labels.
     pub fn labels<I, S>(mut self, iter: I) -> Self
     where
         I: IntoIterator<Item = S>,
@@ -187,24 +182,27 @@ impl<P, M> AgentBuilder<P, M> {
         self
     }
 
-    /// Pause on assistant replies that carry no tool calls, for REPL
-    /// hosts that drive subsequent turns via `TicketSystem::reply`.
+    /// Let the agent wait for new instructions to keep a ticket in-progress.
+    ///
+    /// The agent stops after a reply that calls no tool, and
+    /// `TicketSystem::reply` drives the next turn.
     pub fn interactive(mut self) -> Self {
         self.interactive = true;
         self
     }
 
-    /// Bind `{key}` to `value`. The placeholder is substituted in the
-    /// agent's `role` and in any string-typed `Ticket::task` enqueued
-    /// through this agent. Unresolved placeholders are left verbatim.
-    /// Binding `context` shadows the built-in block described on
+    /// Inject data into prompts with template strings.
+    ///
+    /// `{key}` is replaced in the agent's role and in any text task submitted
+    /// through this agent. A placeholder with no value is left as it is.
+    /// Binding `context` replaces the built-in block described on
     /// [`Self::role`].
     pub fn template(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
         self.templates.push((key.into(), value.into()));
         self
     }
 
-    /// Bind many `{key} → value` pairs at once.
+    /// Inject more than one entry into prompts.
     pub fn templates<I, K, V>(mut self, vars: I) -> Self
     where
         I: IntoIterator<Item = (K, V)>,
@@ -216,13 +214,13 @@ impl<P, M> AgentBuilder<P, M> {
         self
     }
 
-    /// Register a single tool the agent may call.
+    /// Register a tool the agent may call.
     pub fn tool(mut self, tool: impl ToolLike + 'static) -> Self {
         self.tools.register(tool);
         self
     }
 
-    /// Register many tools at once.
+    /// Register several tools the agent may call.
     pub fn tools<I, T>(mut self, tools: I) -> Self
     where
         I: IntoIterator<Item = T>,
@@ -234,18 +232,18 @@ impl<P, M> AgentBuilder<P, M> {
         self
     }
 
-    /// Directory tools resolve filesystem paths against. Defaults to the
-    /// process's current directory at construction time.
+    /// Set the directory the agent has access to, the current one by default.
     pub fn dir(mut self, p: impl Into<PathBuf>) -> Self {
         self.dir = p.into();
         self
     }
 
-    /// Knowledge store the agent uses for its long-term memory. Replaces
-    /// the default store opened at construction, both as the store rendered
-    /// into the system prompt and as the one `ManageKnowledgeTool` writes to.
-    /// Share one store across multiple agents the same way
-    /// `ticket_system(&shared)` shares a queue.
+    /// Share a knowledge store, the durable memory the agent carries across
+    /// tickets and shares with other agents.
+    ///
+    /// It replaces the store opened by default, both for what the prompt shows
+    /// and for what `ManageKnowledgeTool` writes to. Hand the same store to
+    /// several agents the way `ticket_system(&shared)` shares a queue.
     pub fn knowledge(mut self, store: &Arc<Knowledge>) -> Self {
         self.tools
             .register(ManageKnowledgeTool::new(Arc::clone(store)));
@@ -253,12 +251,13 @@ impl<P, M> AgentBuilder<P, M> {
         self
     }
 
-    /// Rewrite the corrective directive agentwerk injects when it asks the
-    /// agent again after a turn ended without an accepted result: the model
-    /// called no tool, or a finish tool's output failed the ticket schema.
-    /// The editor reads the bare reason and rewrites the directive in place,
-    /// which arrives holding the built-in text, so an editor that writes
-    /// nothing keeps the default. Called inline per retry, so keep it cheap.
+    /// Override the prompt that corrects an agent asked to try again.
+    ///
+    /// agentwerk asks again when a turn ends without an accepted result: the
+    /// model called no tool, or its result missed the ticket's schema. Your
+    /// function reads the reason and rewrites the prompt, which arrives holding
+    /// the built-in text, so writing nothing keeps the default. It runs once per
+    /// retry, so keep it cheap.
     pub fn edit_directive_on_retry(
         mut self,
         editor: impl Fn(&str, &mut String) + Send + Sync + 'static,
@@ -350,10 +349,11 @@ impl<P, M> AgentBuilder<P, M> {
 }
 
 impl AgentBuilder<Arc<dyn Provider>, Model> {
-    /// Produce the final `Agent`. The agent is born bound to a private
-    /// `TicketSystem` so `.task(...).finish().await` works without an
-    /// external system; `TicketSystem::agent(...)` later drains the private
-    /// queue into a shared system.
+    /// Create the agent.
+    ///
+    /// It starts with a ticket system of its own, so `.task(...).finish().await`
+    /// works without one being set up. `TicketSystem::agent(...)` later moves
+    /// those tickets into the shared system.
     pub fn build(self) -> Agent {
         let mut agent = Agent {
             name: self.name,
@@ -376,12 +376,10 @@ impl AgentBuilder<Arc<dyn Provider>, Model> {
     }
 }
 
-// --- agent ---
+// Agent
 
-/// Handle from an `Agent` to its `TicketSystem`. `Private` is what a
-/// freshly-built agent carries until `bind_agent` adopts it; `Shared` is
-/// what every other agent (rebound ones, clones, agents inside
-/// `TicketSystem::agents`) carries.
+/// How an `Agent` reaches its `TicketSystem`. A freshly built agent carries
+/// `Private` until it is added to a system; everything else carries `Shared`.
 pub(crate) enum TicketSystemRef {
     Shared(Weak<TicketSystem>),
     Private(Arc<TicketSystem>),
@@ -396,9 +394,11 @@ impl TicketSystemRef {
     }
 }
 
-/// Bound to a [`TicketSystem`]. Claims tickets assigned by name or
-/// label, calls the LLM provider and runs the tools it requests, then
-/// writes the result back through `FinishTool`.
+/// An `Agent` is the core entity of agentwerk. It has access to tools for
+/// solving tasks in the form of tickets.
+///
+/// It claims the tickets its name or labels match, calls the LLM provider, runs
+/// the tools the model asks for, and writes the result back.
 ///
 /// ```no_run
 /// use agentwerk::Agent;
@@ -432,8 +432,8 @@ pub struct Agent {
 }
 
 impl Clone for Agent {
-    /// Convert `Private` to `Shared(Weak)` on clone so rebinding the
-    /// original cannot leave a stale clone enqueuing into an orphaned queue.
+    /// A clone points at the shared system, so rebinding the original cannot
+    /// leave the clone filing tickets into a queue nothing reads.
     fn clone(&self) -> Self {
         let ticket_system = match &self.ticket_system {
             TicketSystemRef::Shared(w) => TicketSystemRef::Shared(w.clone()),
@@ -457,12 +457,12 @@ impl Clone for Agent {
 }
 
 impl Agent {
-    /// Entry point for the fluent builder.
+    /// Start building an agent.
     pub fn new() -> AgentBuilder<(), ()> {
         AgentBuilder::new()
     }
 
-    /// Entry point for a builder with no tools pre-registered.
+    /// Start building an agent with no tools pre-registered.
     pub fn empty() -> AgentBuilder<(), ()> {
         AgentBuilder::empty()
     }
@@ -561,26 +561,23 @@ impl Agent {
         out
     }
 
-    /// Bind this agent to a shared `TicketSystem`. Drains any tickets
-    /// the agent had already enqueued in its prior store into `sys`,
-    /// binds `sys` to the agent so it reads the shared queue, and
-    /// registers a clone of `self` into `sys`'s agents list so the
-    /// loop will dispatch this agent at `run` / `finish` time.
+    /// Attach a built agent to a ticket system.
+    ///
+    /// Any tickets the agent already queued move across, and the agent starts
+    /// reading the shared queue.
     pub fn ticket_system(mut self, sys: &Arc<TicketSystem>) -> Self {
         sys.bind_agent(&mut self);
         self
     }
 
-    /// Enqueue a ticket carrying `task` as its body on the bound system.
-    /// Returns the new ticket's key, mirroring [`TicketSystem::task`].
-    /// Chain lifecycle calls on [`Agent::finish`], which returns the
-    /// bound system.
+    /// Submit a task and return its ticket key.
+    ///
+    /// Call it as often as you like: one agent can drive many tickets.
     pub fn task<T: Serialize>(&self, task: T) -> String {
         self.dispatch(Ticket::new(task))
     }
 
-    /// Enqueue a fully-built `Ticket` on the bound system. Returns the
-    /// new ticket's key, mirroring [`TicketSystem::ticket`].
+    /// Submit a `Ticket` with custom labels or schema, and return its key.
     pub fn ticket(&self, ticket: Ticket) -> String {
         self.dispatch(ticket)
     }
@@ -596,8 +593,8 @@ impl Agent {
         sys.insert(ticket, self.name.clone())
     }
 
-    /// Start the agent loop on a background tokio task. Returns the bound
-    /// system so callers can `cancel()` or read results on the same value.
+    /// Begin processing tickets, and hand back the ticket system so results and
+    /// cancellation stay one call away.
     pub fn start(&self) -> Arc<TicketSystem> {
         let sys = self
             .ticket_system
@@ -607,9 +604,8 @@ impl Agent {
         sys
     }
 
-    /// Start a background run and wait for every queued ticket to finish.
-    /// Returns the bound system so the caller can read results via
-    /// [`TicketSystem::last_result`] etc.
+    /// Process every queued ticket, then hand back the ticket system so results
+    /// can be read from it.
     pub async fn finish(&self) -> Arc<TicketSystem> {
         let sys = self
             .ticket_system
@@ -688,7 +684,7 @@ mod tests {
         assert!(b.get_name().starts_with("agent-"));
     }
 
-    /// `system_prompt` with empty runtime state and a fixed ticket key.
+    /// The system prompt with no live state and a fixed ticket key.
     fn system_prompt<P, M>(agent: &AgentBuilder<P, M>, knowledge: Option<&str>) -> String {
         agent.system_prompt(knowledge, &Policies::default(), &Stats::new(), "T-1")
     }
@@ -931,9 +927,9 @@ mod tests {
     #[test]
     fn system_prompt_renders_knowledge_section_when_body_present() {
         let agent = Agent::new().role("R");
-        let prompt = system_prompt(&agent, Some("- **config** — Port 8080"));
+        let prompt = system_prompt(&agent, Some("- **config**: Port 8080"));
         assert!(prompt.contains("R"));
-        assert!(prompt.contains("## Knowledge\n\n- **config** — Port 8080"));
+        assert!(prompt.contains("## Knowledge\n\n- **config**: Port 8080"));
     }
 
     #[test]

--- a/crates/agentwerk/src/agents/compaction.rs
+++ b/crates/agentwerk/src/agents/compaction.rs
@@ -1,4 +1,4 @@
-//! Context-window compaction: collapse an over-long transcript into
+//! Context-window compaction: collapse a ticket's older messages into
 //! a single summary message before the next request would overflow.
 
 use std::sync::Arc;
@@ -103,10 +103,10 @@ pub(crate) fn should_compact_proactively(
 }
 
 /// Run one compaction round-trip for the ticket at `ticket_key`: read
-/// the current transcript, summarise it via [`compact`], and apply the
+/// the current messages, summarise them through [`compact`], and apply the
 /// result through [`TicketSystem::summarize`]. Returns `Ok(true)` when a
 /// summary was applied, `Ok(false)` when the ticket is missing or the
-/// transcript collapses to a no-op.
+/// messages collapse to nothing worth replacing.
 pub(crate) async fn run(
     provider: &Arc<dyn Provider>,
     model: &str,
@@ -125,11 +125,11 @@ pub(crate) async fn run(
 
 /// Compact `messages` into a single summary by sending them to the
 /// provider with no tools and the compaction directive as the system
-/// prompt. When `window` is set and the transcript would overflow it,
+/// prompt. When `window` is set and the messages would overflow it,
 /// split the largest splittable message in half (recursively until
 /// every chunk fits) and summarise each chunk separately; the resulting
 /// partial summaries are joined with a blank line. Returns `Ok(None)`
-/// when the transcript collapses to a no-op (a single message that
+/// when the messages collapse to nothing worth replacing (a single message that
 /// already fits, or nothing to summarise); the caller treats that as a
 /// no-op.
 pub(crate) async fn compact(
@@ -397,7 +397,7 @@ mod tests {
     fn should_compact_proactively_uses_last_delta_to_fire_one_turn_early() {
         // Threshold = 200_000 - 33_000 = 167_000. The current estimate
         // sits at 160_000 (under threshold), but the last per-turn delta
-        // was 10_000 — the next request after this one would land at
+        // was 10_000: the next request after this one would land at
         // ~170_000 and overflow. Trigger must fire now, not next turn.
         let history = [
             TokenUsage {
@@ -422,7 +422,7 @@ mod tests {
     #[test]
     fn should_compact_proactively_ignores_shrinking_series() {
         // Threshold = 167_000. Latest entry is 160_000 (under), and the
-        // delta is negative — saturating_sub clamps it to 0, so the
+        // delta is negative, so saturating_sub clamps it to 0 and the
         // trigger behaves like a single-sample history and stays quiet.
         let history = [
             TokenUsage {
@@ -444,7 +444,7 @@ mod tests {
         ));
     }
 
-    // ---- compact ----
+    // Compact
 
     use crate::providers::types::{ModelResponse, ResponseStatus};
     use std::future::Future;
@@ -579,7 +579,7 @@ mod tests {
         assert!(matches!(err, ProviderError::ResponseMalformed { .. }));
     }
 
-    // ---- chunking ----
+    // Chunking
 
     #[test]
     fn binary_split_at_newline_preserves_total_text() {
@@ -652,7 +652,7 @@ mod tests {
         }
     }
 
-    // ---- compact (continued) ----
+    // Compact (continued)
 
     #[tokio::test]
     async fn compact_builds_a_tool_less_request() {

--- a/crates/agentwerk/src/agents/knowledge.rs
+++ b/crates/agentwerk/src/agents/knowledge.rs
@@ -1,8 +1,5 @@
-//! File-backed knowledge store that persists across tickets and runs.
-//! Pages are markdown files addressed by slug, held in a `knowledge/`
-//! bundle under the store directory; a compact index is injected into the
-//! system prompt. The model-facing `ManageKnowledgeTool` is a thin wrapper
-//! in `tools::knowledge` that holds an `Arc<Knowledge>` from this module.
+//! Durable memory an agent shares across tickets and with other agents, stored
+//! as markdown pages on disk.
 
 use std::fmt;
 use std::fs;
@@ -21,8 +18,8 @@ const DEFAULT_INDEX_CHAR_LIMIT: usize = 12000;
 const DEFAULT_PAGE_TYPE: &str = "Knowledge";
 const LEGACY_MEMORY_FILE: &str = "memory.jsonl";
 const MIGRATED_SUFFIX: &str = ".migrated";
-/// OKF changelog file. We never write one, but reserve the name so a seed
-/// bundle's `log.md` is not walked in as a concept page.
+/// The OKF changelog filename. agentwerk never writes one, but the name is
+/// reserved so a seeded bundle's `log.md` is not read in as a page.
 const LOG_FILE: &str = "log.md";
 
 /// One entry in the in-memory index.
@@ -35,15 +32,15 @@ struct IndexEntry {
     path: String,
 }
 
-/// Errors raised by knowledge-store reads and mutations. `Display`
-/// renders the message `ManageKnowledgeTool` shows the model verbatim.
+/// What can go wrong reading or writing knowledge pages. `Display` renders the
+/// message the agent sees.
 #[derive(Debug)]
 pub enum KnowledgeError {
     /// A slug, description, or content value was rejected.
     PageRejected { message: String },
     /// No page exists at `slug`.
     PageMissing { slug: String },
-    /// The write would push the rendered index past its char limit.
+    /// The write would push the index past its character limit.
     IndexLimitExceeded {
         used: usize,
         limit: usize,
@@ -86,13 +83,13 @@ fn io_failed(message: impl Into<String>) -> impl FnOnce(io::Error) -> KnowledgeE
     |source| KnowledgeError::IoFailed { message, source }
 }
 
-/// Durable memory the agent curates and shares across tickets and other
-/// agents, stored on disk as an Open Knowledge Format (OKF) v0.1 bundle and
-/// curated through `ManageKnowledgeTool`. The bundle lives in
-/// `<dir>/knowledge/`: each page is a markdown concept file under
-/// `<dir>/knowledge/pages/<slug>.md` with `type`/`description`/`timestamp`
-/// frontmatter, and `<dir>/knowledge/index.md` is a derived index of one-line
-/// descriptions injected into the system prompt.
+/// `Knowledge` allows agents to share insights or learnings, kept on disk so
+/// they outlive the ticket that produced them.
+///
+/// Pages are created in the Open Knowledge Format (OKF) v0.1 under
+/// `<dir>/knowledge/pages/<slug>.md`, each carrying `type`, `description`, and
+/// `timestamp` frontmatter. `<dir>/knowledge/index.md` lists them in one line
+/// each, and that list is what the agent's prompt shows.
 ///
 /// Two agents bound to one store share it:
 ///
@@ -130,12 +127,12 @@ pub struct Knowledge {
 }
 
 impl Knowledge {
-    /// Open or create a knowledge store under `store_dir`, holding an OKF v0.1
-    /// bundle in `<store_dir>/knowledge/`. Creates the bundle's `pages/` if
-    /// missing. The index is rebuilt by walking the concept files under the
-    /// bundle, so placing an existing OKF bundle there seeds the store from it.
-    /// A `memory.jsonl` left by an older version next to the bundle is migrated
-    /// once into `knowledge/pages/legacy-notes.md`.
+    /// Open a knowledge store under `store_dir`, or create one there.
+    ///
+    /// The index is rebuilt from the pages themselves, so dropping an existing
+    /// OKF bundle at `<store_dir>/knowledge/` seeds the store from it. A
+    /// `memory.jsonl` left by an older version is moved once into
+    /// `knowledge/pages/legacy-notes.md`.
     pub fn load(store_dir: impl Into<PathBuf>) -> io::Result<Arc<Self>> {
         let store_dir = store_dir.into();
         let knowledge_dir = store_dir.join(BUNDLE_DIR);
@@ -160,39 +157,37 @@ impl Knowledge {
         }))
     }
 
-    /// Override the rendered-index char budget. Default is 12 000. Page
-    /// bodies are never capped; only the bullet list injected into the
-    /// system prompt is bounded. Call it on the loaded store before
-    /// binding the store to any agent:
-    /// `let store = Knowledge::load(dir)?; store.index_char_limit(12_000);`.
+    /// Limit the index size, 12 000 characters by default.
+    ///
+    /// Only the list shown in the prompt is limited; page bodies are not. Set it
+    /// on the loaded store before handing the store to any agent.
     pub fn index_char_limit(&self, n: usize) -> &Self {
         self.index_char_limit.store(n, Ordering::Relaxed);
         self
     }
 
-    /// Rendered-index char budget in force, 12 000 until
-    /// [`Self::index_char_limit`] overrides it.
+    /// Get the index size limit in force, 12 000 until
+    /// [`Self::index_char_limit`] changes it.
     pub fn get_index_char_limit(&self) -> usize {
         self.index_char_limit.load(Ordering::Relaxed)
     }
 
-    /// Rendered index content for the system prompt. Returns the body
-    /// of `index.md` (the bullet list), or an empty string when no
-    /// pages exist.
+    /// Get the index, which is injected into the agent prompt. Empty while the
+    /// store holds no pages.
     pub fn index(&self) -> String {
         let index = self.index.lock().unwrap();
         render_index(&index)
     }
 
-    /// Sub-handle for the page collection. Save, load, list, and remove
-    /// pages through `knowledge.pages()` so the verb pair stays bare
-    /// `save` / `load` and the bootstrap `Knowledge::load(dir)` does
-    /// not collide with per-slug loads.
+    /// Get the page collection for reading and writing pages.
+    ///
+    /// Going through `pages()` keeps `save` and `load` bare, so opening the
+    /// store and loading one page do not share a name.
     pub fn pages(&self) -> Pages<'_> {
         Pages { inner: self }
     }
 
-    /// Remove every page file and the index.
+    /// Remove every page from the store.
     pub fn clear(&self) -> Result<(), KnowledgeError> {
         let _w = self.write_lock.lock().unwrap();
 
@@ -216,9 +211,8 @@ impl Knowledge {
         Ok(())
     }
 
-    /// Index usage: rendered chars, the char budget, and the page count.
-    /// Read by `ManageKnowledgeTool` to show the model how much of the
-    /// budget a mutation consumed.
+    /// How large the index is, how large it may get, and how many pages it
+    /// holds. `ManageKnowledgeTool` shows the agent what a write consumed.
     pub(crate) fn index_usage(&self) -> (usize, usize, usize) {
         let index = self.index.lock().unwrap();
         (
@@ -229,13 +223,12 @@ impl Knowledge {
     }
 }
 
-/// One knowledge page: an OKF v0.1 concept document stored under
-/// `<dir>/knowledge/pages/<slug>.md`. The frontmatter carries `type` (from `kind`),
-/// `description`, and `timestamp`; the markdown body follows.
+/// A `Page` is one thing an agent learned, stored as markdown under
+/// `<dir>/knowledge/pages/<slug>.md` with its frontmatter above the body.
 #[derive(Debug, Clone)]
 pub struct Page {
     pub slug: String,
-    /// OKF `type`: a short concept kind. Defaults to `Knowledge`.
+    /// What kind of page this is, `Knowledge` by default.
     pub kind: String,
     pub description: String,
     pub content: String,
@@ -263,16 +256,14 @@ impl Persist for Page {
     }
 }
 
-/// Sub-handle returned by [`Knowledge::pages`]. Hosts the verb-bare
-/// `save` / `load` / `list` / `remove` over the page collection while
-/// keeping the index updated and the char budget enforced.
+/// The page collection, returned by [`Knowledge::pages`]. Every write through
+/// it updates the index and respects the size limit.
 pub struct Pages<'a> {
     inner: &'a Knowledge,
 }
 
 impl Pages<'_> {
-    /// Create or replace `page` and its index entry, refreshing the
-    /// index file.
+    /// Create or replace a page, and its entry in the index.
     pub fn save(&self, page: Page) -> Result<(), KnowledgeError> {
         let slug = normalize_slug(&page.slug)?;
         let description = page.description.trim();
@@ -337,9 +328,10 @@ impl Pages<'_> {
         Ok(())
     }
 
-    /// Read the page at `slug`. Returns the full [`Page`] struct. Resolves
-    /// the file through the index so a seeded page outside `pages/` is still
-    /// readable; falls back to `pages/<slug>.md`.
+    /// Read one page by its slug.
+    ///
+    /// The index says where the file is, so a seeded page kept outside `pages/`
+    /// is still readable.
     pub fn load(&self, slug: &str) -> Result<Page, KnowledgeError> {
         let slug = normalize_slug(slug)?;
         let relative = self
@@ -369,8 +361,7 @@ impl Pages<'_> {
         })
     }
 
-    /// Read every page in the store, in index order. Collects the slugs
-    /// before reading so the index lock is not held across the file reads.
+    /// Get every page in the store, in index order.
     pub fn list(&self) -> Result<Vec<Page>, KnowledgeError> {
         let slugs: Vec<String> = self
             .inner
@@ -383,7 +374,7 @@ impl Pages<'_> {
         slugs.iter().map(|slug| self.load(slug)).collect()
     }
 
-    /// Delete the page file at `slug` and its index entry.
+    /// Remove one page and its entry in the index.
     pub fn remove(&self, slug: &str) -> Result<(), KnowledgeError> {
         let slug = normalize_slug(slug)?;
         let _w = self.inner.write_lock.lock().unwrap();
@@ -416,13 +407,13 @@ fn page_path(knowledge_dir: &Path, slug: &str) -> PathBuf {
     knowledge_dir.join(PAGES_DIR).join(format!("{slug}.md"))
 }
 
-// ---- slug validation ----
+// Slug validation
 
-/// Normalize an arbitrary string into a valid slug: lowercase
-/// `[a-z0-9-]`, no leading/trailing hyphens, max 60 chars.
-/// Slashes, dots, underscores, spaces, and other non-alphanumeric
-/// characters are replaced with hyphens; consecutive hyphens are
-/// collapsed; file extensions are stripped.
+/// Turn any string into a slug: lowercase `[a-z0-9-]`, no hyphen at either
+/// end, at most 60 characters.
+///
+/// Every other character becomes a hyphen, runs of hyphens collapse, and a file
+/// extension is dropped.
 pub(crate) fn normalize_slug(raw: &str) -> Result<String, KnowledgeError> {
     let slug: String = raw
         .to_ascii_lowercase()
@@ -481,7 +472,7 @@ pub(crate) fn normalize_slug(raw: &str) -> Result<String, KnowledgeError> {
     Ok(collapsed)
 }
 
-// ---- frontmatter ----
+// Frontmatter
 
 fn render_page(kind: &str, description: &str, content: &str, tags: &[String]) -> String {
     let now = format_iso8601_now();
@@ -500,9 +491,9 @@ fn render_page(kind: &str, description: &str, content: &str, tags: &[String]) ->
     format!("---\ntype: {kind}\ndescription: {description}\ntimestamp: {now}{tags_str}\n---\n{content}\n")
 }
 
-/// Parse a page file into `(kind, description, tags, content)`. A missing
-/// `type` defaults to `Knowledge`; the legacy `summary` key is still read as
-/// `description` so older stores load.
+/// Read a page file into `(kind, description, tags, content)`. A missing `type`
+/// reads as `Knowledge`, and the older `summary` key still reads as
+/// `description`.
 fn parse_page(raw: &str) -> (String, String, Vec<String>, String) {
     let trimmed = raw.trim_start();
     if !trimmed.starts_with("---") {
@@ -558,10 +549,10 @@ fn strip_frontmatter(raw: &str) -> String {
     parse_page(raw).3
 }
 
-// ---- index rendering / parsing ----
+// Index rendering / parsing
 
-/// Compact index injected into the system prompt. The model reads a page by
-/// its slug, so the slug stays visible here.
+/// The index the prompt shows. The agent reads a page by its slug, so each slug
+/// stays visible.
 fn render_index(entries: &[IndexEntry]) -> String {
     entries
         .iter()
@@ -570,9 +561,8 @@ fn render_index(entries: &[IndexEntry]) -> String {
         .join("\n")
 }
 
-/// The on-disk `index.md`: an OKF progressive-disclosure view. Frontmatter-free,
-/// with a clickable link to each concept file. Written as a derived artifact and
-/// never parsed back; the page frontmatter is the source of truth.
+/// The `index.md` written to disk, one clickable link per page. It is derived
+/// and never read back: the pages themselves are the source of truth.
 fn render_index_file(entries: &[IndexEntry]) -> String {
     if entries.is_empty() {
         return String::new();
@@ -585,10 +575,8 @@ fn render_index_file(entries: &[IndexEntry]) -> String {
     format!("{body}\n")
 }
 
-/// Rebuild the in-memory index by walking the bundle for concept files, then
-/// regenerate the derived `index.md`. The page frontmatter is the source of
-/// truth (OKF: `index.md` is a derived view), so an external OKF bundle left
-/// in the bundle directory seeds the store from it.
+/// Rebuild the index from the pages on disk, then write `index.md` again. This
+/// is what lets a bundle authored elsewhere seed the store.
 fn rebuild_index_from_pages(knowledge_dir: &Path) -> io::Result<Vec<IndexEntry>> {
     let mut entries = Vec::new();
     collect_pages(knowledge_dir, knowledge_dir, &mut entries)?;
@@ -601,9 +589,9 @@ fn rebuild_index_from_pages(knowledge_dir: &Path) -> io::Result<Vec<IndexEntry>>
     Ok(entries)
 }
 
-/// Walk `dir` recursively, turning every non-reserved markdown file into an
-/// index entry. The description comes from page frontmatter, falling back to
-/// the body H1 for a frontmatter-less page.
+/// Turn every markdown file under `dir` into an index entry, taking the
+/// description from the frontmatter or, without one, from the body's first
+/// heading.
 fn collect_pages(root: &Path, dir: &Path, entries: &mut Vec<IndexEntry>) -> io::Result<()> {
     if !dir.exists() {
         return Ok(());
@@ -657,8 +645,8 @@ fn is_reserved(file_name: &str) -> bool {
     file_name == INDEX_FILE || file_name == LOG_FILE || file_name.ends_with(MIGRATED_SUFFIX)
 }
 
-/// Slug for a concept file: its bundle-relative path minus `.md`, with a
-/// leading `pages/` stripped so a native page keeps `slug == file stem`.
+/// The slug for a page file: its path without `.md`, and without a leading
+/// `pages/`, so a page written by an agent keeps the file's own name.
 fn bundle_slug(root: &Path, path: &Path) -> Result<String, KnowledgeError> {
     let relative = path.strip_prefix(root).unwrap_or(path).with_extension("");
     let mut text = relative.to_string_lossy().replace('\\', "/");
@@ -678,7 +666,7 @@ fn extract_h1_summary(body: &str) -> String {
     "(no summary)".to_string()
 }
 
-// ---- migration from memory.jsonl ----
+// Migration from memory.jsonl
 
 #[derive(serde::Deserialize)]
 struct LegacyMemoryRecord {
@@ -739,11 +727,10 @@ fn migrate_memory_jsonl(store_dir: &Path, knowledge_dir: &Path) -> io::Result<Ve
     Ok(entries)
 }
 
-// ---- timestamp ----
+// Timestamp
 
-/// ISO 8601 UTC timestamp without external dependencies. Uses the same
-/// civil-from-days algorithm as `prompts::format_current_date`, extended
-/// with hours, minutes, and seconds.
+/// An ISO 8601 UTC timestamp, computed the same way as
+/// `prompts::format_current_date` and extended with the time of day.
 fn format_iso8601_now() -> String {
     let epoch_secs = SystemTime::now()
         .duration_since(UNIX_EPOCH)

--- a/crates/agentwerk/src/agents/loop/agent.rs
+++ b/crates/agentwerk/src/agents/loop/agent.rs
@@ -1,5 +1,5 @@
-//! Per-agent driver: an outer loop claims tickets, an inner state machine
-//! drives each claimed ticket through requests, tool calls, and compaction.
+//! Drives one agent: it claims a ticket, then works it through requests, tool
+//! calls, and summarizing until the ticket is resolved.
 
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -110,7 +110,7 @@ fn should_stop(agent: &Agent, ticket_system: &TicketSystem) -> bool {
 }
 
 /// Claim a `Todo` ticket for this agent, or resume one of its `InProgress`
-/// tickets; seed the transcript on first contact.
+/// tickets; write the first message when there is none.
 fn claim<'a>(agent: &'a Agent, ticket_system: &'a Arc<TicketSystem>) -> Option<TicketContext<'a>> {
     let claimable = |t: &Ticket| {
         t.status == Status::Todo

--- a/crates/agentwerk/src/agents/loop/compact.rs
+++ b/crates/agentwerk/src/agents/loop/compact.rs
@@ -1,4 +1,5 @@
-//! Transcript compaction: proactive before the window fills, reactive after the provider reports overflow.
+//! Summarizing a ticket's older messages: ahead of the context window filling
+//! up, and after the LLM provider reports it has.
 
 use std::sync::Arc;
 

--- a/crates/agentwerk/src/agents/loop/main.rs
+++ b/crates/agentwerk/src/agents/loop/main.rs
@@ -1,4 +1,4 @@
-//! Main supervisor loop: spawns one tokio task per registered agent and joins them on shutdown.
+//! Starts one tokio task per registered agent and waits for them on shutdown.
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;

--- a/crates/agentwerk/src/agents/loop/mod.rs
+++ b/crates/agentwerk/src/agents/loop/mod.rs
@@ -1,6 +1,6 @@
 //! Multi-agent loop driver. One tokio task per registered agent,
 //! reading the shared `TicketSystem` through the upgraded
-//! `Weak<TicketSystem>` stamped at `bind_agent`.
+//! `Weak<TicketSystem>` set when the agent was added.
 
 use std::time::Duration;
 

--- a/crates/agentwerk/src/agents/loop/request.rs
+++ b/crates/agentwerk/src/agents/loop/request.rs
@@ -1,5 +1,5 @@
-//! Provider round-trip: sends the transcript, retries transient errors, and
-//! routes overflow to reactive compaction.
+//! One round-trip to the LLM provider: sends the messages, retries a transient
+//! error, and summarizes the older messages when the context window overflows.
 
 use std::sync::Arc;
 

--- a/crates/agentwerk/src/agents/loop/test_util.rs
+++ b/crates/agentwerk/src/agents/loop/test_util.rs
@@ -13,7 +13,7 @@ use crate::providers::{ContentBlock, Message, Provider, ProviderError, ProviderR
 use crate::schemas::Schema;
 use crate::tools::ManageTicketsTool;
 
-// ---- mock provider ----
+// Mock provider
 
 pub struct MockProvider {
     results: Mutex<Vec<ProviderResult<ModelResponse>>>,
@@ -74,7 +74,7 @@ impl Provider for MockProvider {
     }
 }
 
-// ---- response builders ----
+// Response builders
 
 pub fn write_result_response(result: &str) -> ModelResponse {
     write_result_response_named("finish", result)
@@ -182,7 +182,7 @@ pub fn text_response_with_usage(text: &str, usage: TokenUsage) -> ModelResponse 
     }
 }
 
-// ---- error builders ----
+// Error builders
 
 pub fn rate_limit() -> ProviderError {
     ProviderError::RateLimited {
@@ -198,7 +198,7 @@ pub fn connection_failed(message: &str) -> ProviderError {
     }
 }
 
-// ---- event filters ----
+// Event filters
 
 pub fn retries_in(events: &[Event]) -> Vec<(u32, u32, String)> {
     events
@@ -256,7 +256,7 @@ pub fn user_text(messages: &[Message]) -> String {
     out
 }
 
-// ---- agent / event builders ----
+// Agent / event builders
 
 pub fn interactive_chatbot(provider: &Arc<MockProvider>) -> Agent {
     Agent::new()
@@ -287,7 +287,7 @@ pub fn collect_events(tickets: &TicketSystem) -> Arc<Mutex<Vec<Event>>> {
     collected
 }
 
-// ---- harnesses ----
+// Harnesses
 
 pub async fn run_one(
     provider: Arc<MockProvider>,

--- a/crates/agentwerk/src/agents/loop/tool_call.rs
+++ b/crates/agentwerk/src/agents/loop/tool_call.rs
@@ -1,5 +1,5 @@
-//! Tool execution: dispatches tool calls, offloads large outputs, and counts
-//! consecutive tool failures toward the retry budget.
+//! Runs the tools a model asks for, writes out oversized results, and counts
+//! consecutive failures against the retry budget.
 
 use std::collections::HashMap;
 use std::path::PathBuf;

--- a/crates/agentwerk/src/agents/mod.rs
+++ b/crates/agentwerk/src/agents/mod.rs
@@ -1,4 +1,4 @@
-//! Agent implementations.
+//! Agents, the tickets they work from, and the loop that drives them.
 
 pub mod agent;
 pub(crate) mod compaction;

--- a/crates/agentwerk/src/agents/policy.rs
+++ b/crates/agentwerk/src/agents/policy.rs
@@ -1,5 +1,4 @@
-//! Policy bundle: limits and retry tuning the loop reads through the
-//! ticket system state.
+//! The execution limits, read by the loop before each turn.
 
 use std::time::Duration;
 

--- a/crates/agentwerk/src/agents/retry.rs
+++ b/crates/agentwerk/src/agents/retry.rs
@@ -1,7 +1,6 @@
-//! Retry strategy: exponential backoff for transient provider errors.
-//! The strategy owns its own attempt counter; callers consume one
-//! attempt at a time via [`Retry::try_consume`] and never track the
-//! count themselves.
+//! Growing waits between retries of a transient LLM provider error.
+//!
+//! [`Retry`] tracks the attempts, so callers never have to.
 
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -25,13 +24,13 @@ pub(crate) trait Retry {
     }
 }
 
-/// Cap on per-attempt backoff so exponential growth doesn't run away
+/// Limit on the wait before one attempt, so it cannot grow without bound
 /// past a few attempts. Matches claude-code's `maxDelayMs` default.
 const MAX_RETRY_DELAY: Duration = Duration::from_millis(32_000);
 
 /// Exponential backoff `base_delay * 2^attempt`, clamped at 32 s,
 /// extended by additive jitter in `[0, 25%]` of the clamped value. A
-/// `server_hint` bypasses the cap and jitter: the server is explicit
+/// `server_hint` skips the limit and the jitter: the server is explicit
 /// about what it wants.
 pub(crate) struct ExponentialRetry {
     base_delay: Duration,

--- a/crates/agentwerk/src/agents/stats.rs
+++ b/crates/agentwerk/src/agents/stats.rs
@@ -1,13 +1,5 @@
-//! Run-time stats. One [`Stats`] struct records every observable event and
-//! exposes inherent read accessors. Callers reach it through
-//! `TicketSystem::stats()`.
-//!
-//! `Stats::record_event` is the single writer for event-derived stats:
-//! every [`EventKind`] is counted by its name automatically, so new events
-//! are covered without touching this file; only payload-bearing measures
-//! (token sums, per-subject maps) have explicit arms. Ticket lifecycle
-//! counters are written directly by the store, since transitions carry
-//! duration data events do not.
+//! Deep insights into how agents behave: working time, tickets, failure rates,
+//! and bottlenecks.
 
 use std::collections::{BTreeMap, HashMap};
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -21,9 +13,9 @@ use crate::agents::tickets::Status;
 use crate::event::{EventKind, KnowledgeOp, ToolFailureKind};
 use crate::providers::types::TokenUsage;
 
-/// Run-time statistics for tickets, tokens, and activity. Reached
-/// through [`TicketSystem::stats()`](crate::TicketSystem::stats);
-/// available during the run and after it finishes.
+/// `Stats` holds the metrics about tickets, tokens, and time. Reach it through
+/// [`TicketSystem::stats()`](crate::TicketSystem::stats), during execution or
+/// after it finishes.
 ///
 /// ```no_run
 /// use agentwerk::TicketSystem;
@@ -41,9 +33,8 @@ use crate::providers::types::TokenUsage;
 /// # }
 /// ```
 pub struct Stats {
-    /// Count per event kind, keyed by [`EventKind::name`]. Every emitted
-    /// event lands here automatically; the named accessors (`turns()`,
-    /// `requests()`, …) are lookups into this map.
+    /// Count per event kind, keyed by [`EventKind::name`]. Every emitted event
+    /// lands here, and the named accessors are lookups into this map.
     event_counts: Mutex<HashMap<String, u64>>,
     input_tokens: AtomicU64,
     output_tokens: AtomicU64,
@@ -51,47 +42,39 @@ pub struct Stats {
     tickets_finished: AtomicU64,
     tickets_failed: AtomicU64,
 
-    /// Run-start wall clock (millis since epoch). 0 = unset; first
-    /// `record_started` wins via CAS.
+    /// When execution started, in milliseconds since the epoch. 0 until then,
+    /// and the first writer wins.
     started_at: AtomicU64,
-    /// Run-end wall clock (millis since epoch). 0 = still running;
-    /// `mark_finished` stamps it when the watcher fires.
+    /// When execution ended, in milliseconds since the epoch. 0 while it is
+    /// still running.
     finished_at: AtomicU64,
-    /// Sum of finished tickets' creation→terminal durations, seconds.
+    /// Sum of finished tickets' time from creation to resolution, in seconds.
     total_ticket_duration: AtomicU64,
-    /// Sum of finished tickets' started→terminal durations, seconds.
-    /// With concurrent agents this can exceed the run's wall-clock
-    /// duration.
+    /// Sum of finished tickets' time from claim to resolution, in seconds. With
+    /// agents working in parallel this can exceed the elapsed duration.
     total_work_duration: AtomicU64,
-    /// Lazy-init map of nested counter slices keyed by ticket label.
-    /// Always empty on a slice itself; populated only on the run-wide
-    /// `Stats` owned by `TicketSystem`.
+    /// Nested slices keyed by ticket label, filled on demand. Only the run-wide
+    /// `Stats` holds them; a slice's own map stays empty.
     label_stats: Mutex<HashMap<String, Arc<Stats>>>,
-    /// Lazy-init map of nested counter slices keyed by agent name. Kept
-    /// apart from `label_stats` because a claim stamps the agent's name
-    /// onto the ticket's labels, so one map would merge an agent with a
-    /// label that happens to share its name.
+    /// Nested slices keyed by agent name, filled on demand. Kept apart from
+    /// `label_stats` because claiming a ticket adds the agent's name to its
+    /// labels, so one map would merge an agent with a label of the same name.
     agent_stats: Mutex<HashMap<String, Arc<Stats>>>,
-    /// Per-ticket append-only series of provider-reported token usages.
-    /// Feeds the proactive-compaction predictor; cleared on compaction.
-    /// Always empty on a label slice.
+    /// Token usage per ticket, oldest first. It feeds the estimate that decides
+    /// when to compact, and is cleared once that happens.
     usage_history: Mutex<HashMap<String, Vec<TokenUsage>>>,
-    /// Per-tool call and failure tallies keyed by tool name. Populated
-    /// only on the run-wide `Stats`; always empty on a label slice.
+    /// Call and failure tallies keyed by tool name, run-wide only.
     tool_stats: Mutex<HashMap<String, ToolCounters>>,
-    /// Per-path open and failure tallies keyed by the file a tool opened.
-    /// Populated only on the run-wide `Stats`; always empty on a label slice.
+    /// Open and failure tallies keyed by the path a tool opened, run-wide only.
     file_stats: Mutex<HashMap<String, FileCounters>>,
-    /// Run-wide Knowledge-store operation tally. Populated only on the run-wide
-    /// `Stats`; a label slice never records here, so it stays zero.
+    /// Knowledge usage tallies, run-wide only.
     knowledge_stats: Mutex<KnowledgeCounters>,
-    /// Per-model request and token tallies keyed by model name. Populated
-    /// only on the run-wide `Stats`; always empty on a label slice.
+    /// Request and token tallies keyed by model name, run-wide only.
     model_stats: Mutex<HashMap<String, ModelCounters>>,
 }
 
-/// Raw per-tool tallies behind the `tool_stats` map. `errors` is derived
-/// from the three kinds, never stored.
+/// The stored per-tool tallies. `errors` is derived from the three failure
+/// kinds, never stored.
 #[derive(Default, Clone)]
 struct ToolCounters {
     calls: u64,
@@ -100,14 +83,14 @@ struct ToolCounters {
     schema_failed: u64,
 }
 
-/// Raw per-path tallies behind the `file_stats` map.
+/// The stored per-path tallies.
 #[derive(Default, Clone)]
 struct FileCounters {
     opens: u64,
     failed: u64,
 }
 
-/// Raw run-wide tallies behind the `knowledge` field.
+/// The stored knowledge tallies.
 #[derive(Default, Clone)]
 struct KnowledgeCounters {
     writes: u64,
@@ -117,7 +100,7 @@ struct KnowledgeCounters {
     misses: u64,
 }
 
-/// Raw per-model tallies behind the `model_stats` map.
+/// The stored per-model tallies.
 #[derive(Default, Clone)]
 struct ModelCounters {
     requests: u64,
@@ -125,31 +108,30 @@ struct ModelCounters {
     output_tokens: u64,
 }
 
-/// Call and failure tallies for one tool, broken down by failure kind.
-/// Returned by [`Stats::tool_stats`] to measure how often the model
-/// misuses a given tool: a high error rate or `schema_failed`/`not_found`
-/// count points at the tool's description or input schema.
+/// A `ToolStat` counts one tool's calls and failures, split by how each failed.
+///
+/// Returned by [`Stats::tool_stats`]. A high error rate, or many `schema_failed`
+/// or `not_found` calls, points at the tool's description or its input schema.
 #[derive(Debug, Clone, Serialize)]
 pub struct ToolStat {
-    /// Every invocation attempt, including calls that named an unknown tool.
+    /// Every call, including calls that named an unknown tool.
     pub calls: u64,
-    /// Model named a tool the registry does not have.
+    /// Calls naming a tool that is not registered.
     pub not_found: u64,
-    /// The tool ran but returned an error (bad arguments, non-zero exit, IO).
+    /// Calls where the tool ran and returned an error.
     pub execution_failed: u64,
-    /// The tool rejected the input on schema validation. Overlaps the
-    /// `SchemaRetried` event and the `max_schema_retries` policy: this is
-    /// the same population the retry budget governs, surfaced per tool.
+    /// Calls the tool rejected as malformed. This is the same population
+    /// `max_schema_retries` governs, reported per tool.
     pub schema_failed: u64,
 }
 
 impl ToolStat {
-    /// Total failures across the three kinds.
+    /// Get the total failures across the three kinds.
     pub fn errors(&self) -> u64 {
         self.not_found + self.execution_failed + self.schema_failed
     }
 
-    /// `errors / calls`. `None` when the tool was never called.
+    /// Get `errors / calls`, or `None` when the tool was never called.
     pub fn error_rate(&self) -> Option<f64> {
         if self.calls == 0 {
             None
@@ -170,16 +152,16 @@ impl From<&ToolCounters> for ToolStat {
     }
 }
 
-/// Open and failure tallies for one path, returned by
-/// [`Stats::file_stats`]. Records how often a file-opening tool named this
-/// path: `opens` counts successful opens, `failed` counts attempts that
-/// errored. For `grep` the path may be a directory rather than a file, since
-/// its `path` argument searches under a directory or file.
+/// A `FileStat` counts how often a tool opened one path, and how often it could
+/// not. Returned by [`Stats::file_stats`].
+///
+/// The path may name a directory rather than a file, since `grep` searches
+/// under either.
 #[derive(Debug, Clone, Serialize)]
 pub struct FileStat {
-    /// Calls that opened this path successfully.
+    /// Calls that opened this path.
     pub opens: u64,
-    /// Calls that named this path and errored.
+    /// Calls that named this path and failed.
     pub failed: u64,
 }
 
@@ -192,22 +174,22 @@ impl From<&FileCounters> for FileStat {
     }
 }
 
-/// Run-wide Knowledge-store usage, returned by [`Stats::knowledge_stats`].
-/// Counts successful operations by action; `misses` counts `KnowledgeMissed`
-/// events: a `read` or `remove` that named a slug the store does not have. A
-/// high `misses` count points at a stale index or a prompt that over-promises
-/// what knowledge holds.
+/// A `KnowledgeStat` counts what agents did to the knowledge pages. Returned by
+/// [`Stats::knowledge_stats`].
+///
+/// A high `misses` count points at a stale index, or at a prompt promising more
+/// than the store holds.
 #[derive(Debug, Clone, Serialize)]
 pub struct KnowledgeStat {
-    /// Successful `write` operations.
+    /// Pages written.
     pub writes: u64,
-    /// Successful `read` operations that returned a page.
+    /// Pages read.
     pub reads: u64,
-    /// Successful `remove` operations.
+    /// Pages removed.
     pub removes: u64,
-    /// `list` operations.
+    /// Times the pages were listed.
     pub lists: u64,
-    /// `read`/`remove` operations naming a slug not in the store.
+    /// Reads and removes naming a page the store does not have.
     pub misses: u64,
 }
 
@@ -223,16 +205,15 @@ impl From<&KnowledgeCounters> for KnowledgeStat {
     }
 }
 
-/// Request and token tallies for one model, returned by
-/// [`Stats::model_stats`]. Lets a run using several models (one per agent)
-/// compare their request volume and token cost.
+/// A `ModelStat` counts one model's requests and token usage. Returned by
+/// [`Stats::model_stats`], so agents running different models can be compared.
 #[derive(Debug, Clone, Serialize)]
 pub struct ModelStat {
-    /// Provider responses received for this model.
+    /// Responses received for this model.
     pub requests: u64,
-    /// Input tokens summed across this model's responses.
+    /// Input tokens across this model's responses.
     pub input_tokens: u64,
-    /// Output tokens summed across this model's responses.
+    /// Output tokens across this model's responses.
     pub output_tokens: u64,
 }
 
@@ -269,9 +250,10 @@ impl Stats {
         }
     }
 
-    /// Statistics scoped to one ticket label. Reads use the same
-    /// accessors as the run-wide `Stats`; `run_duration()` is always
-    /// `None` on a slice (run timing stays global).
+    /// Get statistics scoped to one label.
+    ///
+    /// Reads use the same accessors as the run-wide `Stats`. `run_duration()`
+    /// is always `None` here, since timing stays global.
     pub fn stats_for_label(&self, label: &str) -> Arc<Stats> {
         let mut map = self.label_stats.lock().unwrap();
         map.entry(label.to_string())
@@ -279,12 +261,11 @@ impl Stats {
             .clone()
     }
 
-    /// Statistics scoped to one agent, by the name it was registered
-    /// under. `tickets_created()` counts the tickets that agent filed.
-    /// The rest count the tickets it claimed. Tickets the host filed
-    /// report as `user`, matching `Ticket::reporter`.
-    /// Like the per-label slices, these are written to `stats.json` for
-    /// readers and not restored by `TicketSystem::load`.
+    /// Get statistics scoped to one agent, by the name it was registered under.
+    ///
+    /// `tickets_created()` counts the tickets that agent filed; the rest count
+    /// the tickets it claimed. Like the per-label slices, these are written to
+    /// `stats.json` for readers and not restored by `TicketSystem::load`.
     pub fn stats_for_agent(&self, agent_name: &str) -> Arc<Stats> {
         let mut map = self.agent_stats.lock().unwrap();
         map.entry(agent_name.to_string())
@@ -292,7 +273,7 @@ impl Stats {
             .clone()
     }
 
-    /// Cloned per-ticket usage series, oldest first.
+    /// Get a ticket's token usage, oldest first.
     pub fn usage_history(&self, ticket_key: &str) -> Vec<TokenUsage> {
         self.usage_history
             .lock()
@@ -312,16 +293,15 @@ impl Stats {
             .push(usage);
     }
 
-    /// Drop the per-ticket series. Called after a compaction commits,
-    /// since the post-summary transcript breaks the pre-summary trend.
+    /// Drop a ticket's usage history, once its older messages are summarized
+    /// and the earlier trend no longer predicts the next request.
     pub(crate) fn reset_usage(&self, ticket_key: &str) {
         self.usage_history.lock().unwrap().remove(ticket_key);
     }
 
-    /// Per-tool call and failure tallies, sorted by tool name. Empty on a
-    /// label slice. The `schema_failed` field overlaps the `SchemaRetried`
-    /// event and `max_schema_retries` policy: it counts the same population
-    /// the retry budget governs, surfaced per tool.
+    /// Get per-tool call and failure counts, sorted by tool name.
+    ///
+    /// Empty on a label slice.
     pub fn tool_stats(&self) -> BTreeMap<String, ToolStat> {
         self.tool_stats
             .lock()
@@ -331,7 +311,7 @@ impl Stats {
             .collect()
     }
 
-    /// Count one invocation attempt against `name`.
+    /// Count one call against `name`.
     pub(crate) fn record_tool_call_named(&self, name: &str) {
         self.tool_stats
             .lock()
@@ -352,9 +332,10 @@ impl Stats {
         }
     }
 
-    /// Per-path open and failure tallies, sorted by path. Empty on a label
-    /// slice. Entries are the paths file-opening tools named; for the search
-    /// tools a path may be a directory rather than a file.
+    /// Get per-path open and failure counts, sorted by path.
+    ///
+    /// A path may name a directory rather than a file, since the search tools
+    /// accept either. Empty on a label slice.
     pub fn file_stats(&self) -> BTreeMap<String, FileStat> {
         self.file_stats
             .lock()
@@ -384,13 +365,14 @@ impl Stats {
             .failed += 1;
     }
 
-    /// Run-wide Knowledge-store usage. Zero on a label slice.
+    /// Get knowledge usage: write, read, remove, list, and miss counts.
+    ///
+    /// Zero on a label slice.
     pub fn knowledge_stats(&self) -> KnowledgeStat {
         (&*self.knowledge_stats.lock().unwrap()).into()
     }
 
-    /// Count one Knowledge-store operation, reported by the `manage_knowledge`
-    /// tool as it runs.
+    /// Count one knowledge operation, as `manage_knowledge` reports it.
     pub(crate) fn record_knowledge(&self, op: KnowledgeOp) {
         let mut counters = self.knowledge_stats.lock().unwrap();
         match op {
@@ -401,13 +383,14 @@ impl Stats {
         }
     }
 
-    /// Count one `read`/`remove` that named a slug the store does not have.
+    /// Count one read or remove naming a page the store does not have.
     pub(crate) fn record_knowledge_miss(&self) {
         self.knowledge_stats.lock().unwrap().misses += 1;
     }
 
-    /// Per-model request and token tallies, sorted by model name. Empty on
-    /// a label slice.
+    /// Get per-model requests and token usage, sorted by model name.
+    ///
+    /// Empty on a label slice.
     pub fn model_stats(&self) -> BTreeMap<String, ModelStat> {
         self.model_stats
             .lock()
@@ -417,7 +400,7 @@ impl Stats {
             .collect()
     }
 
-    /// Count one provider response against `model`.
+    /// Count one response against `model`.
     pub(crate) fn record_model_request(&self, model: &str, usage: &TokenUsage) {
         let mut map = self.model_stats.lock().unwrap();
         let counters = map.entry(model.to_string()).or_default();
@@ -426,8 +409,10 @@ impl Stats {
         counters.output_tokens += usage.output_tokens;
     }
 
-    /// Record an event: every kind is counted by name automatically, so a
-    /// future variant needs no arm here; only payload-bearing measures do.
+    /// Record an event.
+    ///
+    /// Every kind is counted by its name, so a new variant needs no arm here.
+    /// Only the measures that read an event's payload do.
     pub(crate) fn record_event(&self, kind: &EventKind, key: &str, labels: &[String], agent: &str) {
         self.record_scoped(labels, agent, |s| s.count_event(kind.name()));
         match kind {
@@ -450,8 +435,8 @@ impl Stats {
         }
     }
 
-    /// Apply `f` to the run-wide stats, to each per-label slice, and to
-    /// the agent's slice. Run-level events carry no agent name.
+    /// Apply `f` to the run-wide statistics, to each label slice, and to the
+    /// agent's slice. An event about execution itself carries no agent name.
     fn record_scoped(&self, labels: &[String], agent: &str, f: impl Fn(&Stats)) {
         f(self);
         for label in labels {
@@ -462,7 +447,7 @@ impl Stats {
         }
     }
 
-    /// Bump the per-name event count by one.
+    /// Add one to this event kind's count.
     fn count_event(&self, name: &str) {
         *self
             .event_counts
@@ -472,16 +457,15 @@ impl Stats {
             .or_default() += 1;
     }
 
-    /// Add a response's token counts to the running sums.
+    /// Add a response's token counts to the totals.
     fn record_tokens(&self, input_tokens: u64, output_tokens: u64) {
         self.input_tokens.fetch_add(input_tokens, Ordering::Relaxed);
         self.output_tokens
             .fetch_add(output_tokens, Ordering::Relaxed);
     }
 
-    /// Dispatch the run-wide recorders that match a ticket transition.
-    /// `prev → next` of `Todo → InProgress` stamps `started_at`;
-    /// terminal transitions add to the duration totals.
+    /// Record a ticket transition. Going from `Todo` to `InProgress` sets the
+    /// start time, and reaching a terminal status adds to the duration totals.
     pub(crate) fn record_transition(
         &self,
         prev: Status,
@@ -502,10 +486,10 @@ impl Stats {
         }
     }
 
-    /// Mirror a terminal transition onto every per-label slice the
-    /// ticket carries. `record_started` is intentionally not mirrored:
-    /// per-label `started_at` stays zero so `elapsed()` reads `None` on
-    /// a slice.
+    /// Mirror a terminal transition onto every label slice the ticket carries.
+    ///
+    /// The start time is deliberately not mirrored, so `run_duration()` reads
+    /// `None` on a slice.
     pub(crate) fn record_transition_for(
         &self,
         labels: &[String],
@@ -529,27 +513,27 @@ impl Stats {
         }
     }
 
-    /// Count of times an agent picked up a ticket to process.
+    /// Get how many turns ran.
     pub fn turns(&self) -> u64 {
         self.event_count("turn_started")
     }
 
-    /// Total provider responses received.
+    /// Get how many responses arrived.
     pub fn requests(&self) -> u64 {
         self.event_count("request_finished")
     }
 
-    /// Total tool calls.
+    /// Get the tool-call count.
     pub fn tool_calls(&self) -> u64 {
         self.event_count("tool_call_started")
     }
 
-    /// Total provider errors.
+    /// Get the failed-request count.
     pub fn errors(&self) -> u64 {
         self.event_count("request_failed")
     }
 
-    /// Count of one event kind, by its snake_case name.
+    /// Get one event kind's count, by its snake_case name.
     fn event_count(&self, name: &str) -> u64 {
         self.event_counts
             .lock()
@@ -559,7 +543,7 @@ impl Stats {
             .unwrap_or(0)
     }
 
-    /// All per-event counts recorded so far, sorted by event name.
+    /// Get per-event counts, sorted by event name.
     pub fn event_counts(&self) -> BTreeMap<String, u64> {
         self.event_counts
             .lock()
@@ -569,33 +553,33 @@ impl Stats {
             .collect()
     }
 
-    /// Total input tokens across all provider responses.
+    /// Get the input tokens across requests.
     pub fn input_tokens(&self) -> u64 {
         self.input_tokens.load(Ordering::Relaxed)
     }
 
-    /// Total output tokens across all provider responses.
+    /// Get the output tokens across requests.
     pub fn output_tokens(&self) -> u64 {
         self.output_tokens.load(Ordering::Relaxed)
     }
 
-    /// Count of tickets created.
+    /// Get how many tickets were created.
     pub fn tickets_created(&self) -> u64 {
         self.tickets_created.load(Ordering::Relaxed)
     }
 
-    /// Count of tickets that finished successfully.
+    /// Get how many tickets finished successfully.
     pub fn tickets_finished(&self) -> u64 {
         self.tickets_finished.load(Ordering::Relaxed)
     }
 
-    /// Count of tickets that failed.
+    /// Get how many tickets failed.
     pub fn tickets_failed(&self) -> u64 {
         self.tickets_failed.load(Ordering::Relaxed)
     }
 
-    /// Elapsed duration of the run, live while agents work and frozen
-    /// once the run finishes. `None` until the first ticket starts.
+    /// Get the elapsed duration, which keeps growing while agents work and
+    /// stops when execution ends. `None` until the first ticket starts.
     pub fn run_duration(&self) -> Option<Duration> {
         let s = self.started_at.load(Ordering::Relaxed);
         if s == 0 {
@@ -612,8 +596,8 @@ impl Stats {
         Some(Duration::from_millis(now.saturating_sub(s)))
     }
 
-    /// `tickets_finished / (tickets_finished + tickets_failed)`. `None` when
-    /// no ticket has reached a terminal state.
+    /// Get `finished / (finished + failed)`, or `None` before any ticket is
+    /// resolved.
     pub fn tickets_success_rate(&self) -> Option<f64> {
         let done = self.tickets_finished.load(Ordering::Relaxed);
         let failed = self.tickets_failed.load(Ordering::Relaxed);
@@ -625,13 +609,13 @@ impl Stats {
         }
     }
 
-    /// Sum of finished tickets' creation→terminal spans.
+    /// Get the total time from creation to resolution.
     pub fn total_ticket_duration(&self) -> Duration {
         Duration::from_secs(self.total_ticket_duration.load(Ordering::Relaxed))
     }
 
-    /// Mean of finished tickets' creation→terminal spans. `None`
-    /// while no ticket has finished.
+    /// Get the average time from creation to resolution, or `None` before any
+    /// ticket finishes.
     pub fn avg_ticket_duration(&self) -> Option<Duration> {
         let n = self.tickets_finished.load(Ordering::Relaxed)
             + self.tickets_failed.load(Ordering::Relaxed);
@@ -643,15 +627,14 @@ impl Stats {
         }
     }
 
-    /// Sum of finished tickets' started→terminal spans. With
-    /// concurrent agents this aggregates work across all of them, so
-    /// it can exceed `run_duration`.
+    /// Get the total time agents held tickets. With agents working in
+    /// parallel this can exceed the elapsed duration.
     pub fn total_work_duration(&self) -> Duration {
         Duration::from_secs(self.total_work_duration.load(Ordering::Relaxed))
     }
 
-    /// Mean of finished tickets' started→terminal spans. `None` while
-    /// no ticket has finished.
+    /// Get the average time an agent held a ticket, or `None` before any
+    /// ticket finishes.
     pub fn avg_work_duration(&self) -> Option<Duration> {
         let n = self.tickets_finished.load(Ordering::Relaxed)
             + self.tickets_failed.load(Ordering::Relaxed);
@@ -663,16 +646,13 @@ impl Stats {
         }
     }
 
-    /// Stamp the run's finish wall-clock. Idempotent in practice
-    /// (the watcher fires once); successive calls overwrite, which
-    /// is fine.
+    /// Record when execution ended. A later call overwrites the earlier one.
     pub(crate) fn mark_finished(&self, when: u64) {
         self.finished_at.store(when, Ordering::Relaxed);
     }
 
-    /// Rebuild from already-loaded tickets. Used as the fallback when
-    /// the stats file is absent or unreadable; otherwise `Stats::load`
-    /// is preferred to keep observability continuous across restarts.
+    /// Rebuild the statistics from tickets already read off disk, for when
+    /// `stats.json` is missing or unreadable.
     pub(crate) fn derive(tickets: &HashMap<String, crate::agents::tickets::Ticket>) -> Self {
         let stats = Stats::new();
         for t in tickets.values() {
@@ -694,7 +674,7 @@ impl Stats {
         stats
     }
 
-    /// Sugar over the `Persist` impl for the keyless case.
+    /// Save to `<dir>/stats.json`.
     pub(crate) fn load(dir: &std::path::Path) -> std::io::Result<Self> {
         <Self as crate::persistence::Persist>::load(dir, &())
     }
@@ -929,15 +909,15 @@ impl Default for Stats {
     }
 }
 
-/// Ticket-lifecycle recorders. Driven by the store on ticket mutations, not
-/// by events: transitions carry duration data events do not.
+/// Ticket lifecycle. The store writes these directly rather than through
+/// events, since a transition carries a duration no event reports.
 impl Stats {
     pub(crate) fn record_created(&self) {
         self.tickets_created.fetch_add(1, Ordering::Relaxed);
     }
 
-    /// First call wins (CAS into `started_at`); later claims (Path A
-    /// reclaim, late bind) leave the original run-start untouched.
+    /// The first call wins. A later claim leaves the original start time
+    /// untouched.
     pub(crate) fn record_started(&self, when: u64) {
         let _ = self
             .started_at
@@ -1172,7 +1152,7 @@ mod tests {
 
     #[test]
     fn total_work_duration_can_exceed_run_duration_with_concurrency() {
-        // Two tickets, each 5s of work, finished in a 6s window —
+        // Two tickets, each 5s of work, finished in a 6s window:
         // models 2 agents working in parallel.
         let s = Stats::new();
         s.record_started(1_000);

--- a/crates/agentwerk/src/agents/tickets/error.rs
+++ b/crates/agentwerk/src/agents/tickets/error.rs
@@ -1,4 +1,4 @@
-//! Errors raised by ticket-store mutations.
+//! What can go wrong changing a ticket.
 
 use std::fmt;
 

--- a/crates/agentwerk/src/agents/tickets/mod.rs
+++ b/crates/agentwerk/src/agents/tickets/mod.rs
@@ -1,7 +1,4 @@
-//! Ticket queue and run orchestration. Exposes the value types
-//! ([`Ticket`], [`Status`], [`Reply`], [`ReplyContent`], [`TicketError`])
-//! and the [`TicketSystem`] orchestrator that owns the shared queue,
-//! registered agents, policies, cancellation signals, and run stats.
+//! The ticket queue agents coordinate through, and the tickets themselves.
 
 use std::time::{SystemTime, UNIX_EPOCH};
 

--- a/crates/agentwerk/src/agents/tickets/reply.rs
+++ b/crates/agentwerk/src/agents/tickets/reply.rs
@@ -1,4 +1,4 @@
-//! Per-ticket transcript entries and their projection back into
+//! One ticket's replies and how they become
 //! provider [`Message`] values. [`ReplyContent`] mirrors
 //! [`ContentBlock`] so the ticket surface stays free of provider types.
 
@@ -9,7 +9,7 @@ use crate::providers::{ContentBlock, Message};
 
 use super::now_millis;
 
-/// Originator of a transcript entry. The agent loop writes `System`
+/// Who wrote a reply. The agent loop writes `System`
 /// entries for the system prompt and for compaction boundaries; those
 /// are filtered when projecting replies back into `Message` values for
 /// the provider.
@@ -21,7 +21,7 @@ pub enum Author {
     Assistant,
 }
 
-/// One entry in a ticket's transcript.
+/// One entry in a ticket's replies.
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct Reply {
     pub author: Author,

--- a/crates/agentwerk/src/agents/tickets/store.rs
+++ b/crates/agentwerk/src/agents/tickets/store.rs
@@ -1,6 +1,5 @@
-//! Store mutations for [`TicketSystem`]: insertion, claiming,
-//! status transitions, reply appends, result attachment,
-//! in-place reply rewrites, and the matching observational events.
+//! Every change a [`TicketSystem`] makes to its tickets, and the events each
+//! change emits.
 
 use std::path::{Path, PathBuf};
 
@@ -32,7 +31,7 @@ fn max_existing_ticket_id(dir: &Path) -> u64 {
 }
 
 impl TicketSystem {
-    /// Insert `ticket`, stamping system fields. The ticket is always born
+    /// Insert `ticket`, filling in the fields agentwerk owns. The ticket is always born
     /// `Todo`; to pin it to a specific agent, label it with the agent's
     /// name. Returns the inserted ticket's key.
     pub(crate) fn insert(&self, mut ticket: Ticket, reporter: String) -> String {
@@ -95,7 +94,7 @@ impl TicketSystem {
     }
 
     /// Append one JSON line to `<dir>/tickets.jsonl` and refresh
-    /// `<dir>/stats.json` from the current counters. Both writes happen
+    /// `<dir>/stats.json` from the current statistics. Both writes happen
     /// under the same lock so a concurrent reader sees consistent
     /// observational state. Errors are swallowed: persistence is
     /// best-effort, not load-bearing for run correctness.
@@ -844,7 +843,7 @@ mod tests {
         assert_eq!(lines[1]["parent"], "TICKET-1");
     }
 
-    // ---- resumption: TicketSystem::load ----
+    // Resumption: TicketSystem::load
 
     #[test]
     fn load_creates_tickets_dir_when_missing() {

--- a/crates/agentwerk/src/agents/tickets/ticket.rs
+++ b/crates/agentwerk/src/agents/tickets/ticket.rs
@@ -1,5 +1,4 @@
-//! The [`Ticket`] value type, its disk persistence, and the
-//! [`Replies`] reply-log helper.
+//! One unit of work an agent picks up, and how it is stored.
 
 use std::fmt;
 use std::io;
@@ -13,10 +12,10 @@ use crate::providers::{AsUserMessage, Message};
 
 use super::reply::{Author, Reply};
 
-/// A task plus the metadata that assigns it. Caller-settable fields:
-/// `task`, `labels`, `schema`, `parent`. System-managed fields (`key`,
-/// `status`, `reporter`, the lifecycle timestamps, `result`, `replies`)
-/// are set by the ticket system and the agent loop.
+/// A `Ticket` is a task plus what assigns and validates it.
+///
+/// You set `task`, `labels`, `schema`, and `parent`. The rest is set for you at
+/// insertion time and as the agent works.
 ///
 /// ```no_run
 /// use agentwerk::Ticket;
@@ -34,33 +33,32 @@ use super::reply::{Author, Reply};
 /// ```
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct Ticket {
-    /// Task body the agent is asked to perform, as arbitrary JSON.
+    /// What the agent is asked to do, as any JSON value.
     pub task: serde_json::Value,
     /// Labels carried by the ticket.
     pub labels: Vec<String>,
-    /// Schema the result must conform to, when set.
+    /// Schema the result must satisfy, when there is one.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub schema: Option<crate::schemas::Schema>,
-    /// Stable identifier (`TICKET-N`).
+    /// Stable key, of the form `TICKET-N`.
     pub key: String,
-    /// Lifecycle status (`Todo`, `InProgress`, `Finished`, `Failed`).
+    /// Where the ticket is in its lifecycle.
     pub status: Status,
     /// Name of the agent that opened the ticket.
     pub reporter: String,
-    /// Millisecond timestamp at which the ticket was created.
+    /// When the ticket was created, in milliseconds.
     pub created_at: u64,
-    /// Millisecond timestamp at which an agent claimed the ticket.
+    /// When an agent claimed the ticket, in milliseconds.
     pub started_at: Option<u64>,
-    /// Millisecond timestamp at which the ticket was marked finished.
-    /// Mutually exclusive with `failed_at`.
+    /// When the ticket finished, in milliseconds. Never set together with
+    /// `failed_at`.
     pub finished_at: Option<u64>,
-    /// Millisecond timestamp at which the ticket failed. Mutually
-    /// exclusive with `finished_at`.
+    /// When the ticket failed, in milliseconds. Never set together with
+    /// `finished_at`.
     pub failed_at: Option<u64>,
-    /// Raw JSON result payload.
+    /// What the agent produced.
     pub result: Option<serde_json::Value>,
-    /// Back-reference to another ticket, or `None` when the ticket
-    /// has no parent. Caller-settable via [`Ticket::parent`].
+    /// The ticket this one came from, when there is one.
     pub parent: Option<String>,
     /// Messages exchanged with the model.
     #[serde(skip)]
@@ -68,10 +66,10 @@ pub struct Ticket {
 }
 
 impl Ticket {
-    /// New ticket carrying `task` as its body. Use the chainable helpers
-    /// (`label`, `labels`, `schema`) to populate caller-settable fields.
-    /// System-managed fields are set by the ticket system at insertion
-    /// time; the placeholders set here are overwritten.
+    /// Create a ticket carrying `task`.
+    ///
+    /// Add labels and a schema with the chainable methods. Everything else is
+    /// filled in when the ticket is submitted.
     pub fn new<T: Serialize>(task: T) -> Self {
         let value = serde_json::to_value(task).expect("Ticket::new: value must serialize to JSON");
         Self {
@@ -91,13 +89,13 @@ impl Ticket {
         }
     }
 
-    /// Add a single label. Use [`Self::labels`] to add several at once.
+    /// Add one label.
     pub fn label(mut self, l: impl Into<String>) -> Self {
         self.labels.push(l.into());
         self
     }
 
-    /// Add many labels at once.
+    /// Add several labels.
     pub fn labels<I, S>(mut self, iter: I) -> Self
     where
         I: IntoIterator<Item = S>,
@@ -112,84 +110,79 @@ impl Ticket {
         self
     }
 
-    /// Record a back-reference to another ticket. The meaning is
-    /// caller-defined: a `finish` handover uses it to chain a
-    /// child to the ticket that handed off, but any code building a
-    /// ticket may set it to express a parent relationship.
+    /// Name the ticket this one came from.
+    ///
+    /// What the relationship means is up to you. A `finish` handover uses it to
+    /// chain a child to the ticket that handed off.
     pub fn parent(mut self, key: impl Into<String>) -> Self {
         self.parent = Some(key.into());
         self
     }
 
-    /// True when `label` is present on this ticket.
+    /// Check whether the ticket carries a label.
     pub fn has_label(&self, label: &str) -> bool {
         self.labels.iter().any(|l| l == label)
     }
 
-    /// True while the ticket sits unclaimed in the queue.
+    /// Check whether the ticket is still waiting to be claimed.
     pub fn is_todo(&self) -> bool {
         self.status == Status::Todo
     }
 
-    /// True when this ticket has reached `Status::Finished`.
+    /// Check whether the ticket finished.
     pub fn is_finished(&self) -> bool {
         self.status == Status::Finished
     }
 
-    /// True when this ticket has reached `Status::Failed`.
+    /// Check whether the ticket failed.
     pub fn is_failed(&self) -> bool {
         self.status == Status::Failed
     }
 
-    /// True while an agent holds the ticket.
+    /// Check whether an agent is working on the ticket.
     pub fn is_in_progress(&self) -> bool {
         self.status == Status::InProgress
     }
 
-    /// True while the ticket is still in flight: `Todo` or `InProgress`.
+    /// Check whether the ticket is still open, either `Todo` or `InProgress`.
     pub fn is_pending(&self) -> bool {
         matches!(self.status, Status::Todo | Status::InProgress)
     }
 
-    /// True once the ticket reached a terminal state: `Finished` or `Failed`.
+    /// Check whether the ticket is resolved, either `Finished` or `Failed`.
     pub fn is_resolved(&self) -> bool {
         matches!(self.status, Status::Finished | Status::Failed)
     }
 
-    /// Reduce the replies to just `summary_text`: every non-system
-    /// reply is dropped and a single `user` reply carrying
-    /// `summary_text` is appended. System-author replies (the system
-    /// prompt) survive unchanged. `task` is rewritten to the summary too,
-    /// so the persisted `ticket.json` reflects the post-compaction state.
-    /// Safe because `task` is read for the seed user message only when
-    /// `replies` is empty, which is never true after compaction. Used by
-    /// the loop after a successful compaction.
+    /// Replace the replies with one summary, keeping the system prompt.
+    ///
+    /// `task` is rewritten to the summary too, so the stored ticket matches. It
+    /// is only read to seed the first message, which cannot happen once replies
+    /// exist.
     pub(crate) fn summarize(&mut self, summary_text: String) {
         self.replies.retain(|r| r.author == Author::System);
         self.replies.push(Reply::user_text(summary_text.clone()));
         self.task = serde_json::Value::String(summary_text);
     }
 
-    /// False once the assistant has spoken: the loop pauses until the
-    /// next non-assistant reply lands (a tool-result append or an
-    /// external caller reply via [`TicketSystem::reply`]).
+    /// False once the model has spoken. The agent then waits for the next
+    /// reply, whether a tool result or one you add with
+    /// [`TicketSystem::reply`].
     pub(crate) fn is_waiting_for_response(&self) -> bool {
         self.replies
             .last()
             .is_none_or(|r| r.author != Author::Assistant)
     }
 
-    /// Project this ticket's transcript into the provider's
-    /// [`Message`] values. Skips `system`-author replies: the system
-    /// prompt is passed via `request.system_prompt`, and
-    /// compaction-boundary replies are audit markers only.
+    /// Turn this ticket's replies into the messages sent to the model.
+    ///
+    /// System-author replies are left out: the system prompt travels in its own
+    /// field, and a compaction marker is there for the record only.
     pub(crate) fn to_messages(&self) -> Vec<Message> {
         self.replies.iter().filter_map(Reply::as_message).collect()
     }
 
-    /// Stamp `started_at` / `finished_at` / `failed_at` on a ticket
-    /// whose status is about to flip to `next`. Called inside the
-    /// locked critical section before `self.status` is overwritten.
+    /// Record the timestamp for the status a ticket is about to reach.
     pub(crate) fn stamp_transition(&mut self, next: Status, now: u64) {
         if self.status == Status::Todo && next == Status::InProgress {
             self.started_at = Some(now);
@@ -205,10 +198,8 @@ impl Ticket {
         }
     }
 
-    /// Compute (ticket_duration, work_duration) for a ticket that just
-    /// reached a terminal status. `ticket_duration` is creation→terminal;
-    /// `work_duration` is started→terminal. Both default to zero if the
-    /// relevant timestamps aren't both set.
+    /// The time from creation to resolution, and the time an agent held the
+    /// ticket. Either is zero when its timestamps are not both set.
     pub(crate) fn terminal_durations(&self) -> (Duration, Duration) {
         let terminal = self.finished_at.or(self.failed_at);
         let ticket_duration = match terminal {
@@ -240,20 +231,21 @@ impl crate::persistence::Persist for Ticket {
     }
 }
 
-/// A ticket's replies on disk: one `tickets/<key>/replies.jsonl`, a JSON
-/// reply per line. [`Persist::save`] rewrites the whole file in place
-/// (compaction and edits); [`Replies::append`] adds a single line without
-/// loading the file.
+/// A ticket's replies on disk, one JSON reply per line in
+/// `tickets/<key>/replies.jsonl`.
+///
+/// [`Persist::save`] rewrites the whole file, and [`Replies::append`] adds one
+/// line without reading it.
 pub(crate) struct Replies {
     pub(crate) key: String,
     pub(crate) entries: Vec<Reply>,
 }
 
 impl Replies {
-    /// Append one reply as a single JSON line to `replies.jsonl`, without
-    /// loading or rewriting the file. Keyed by ticket, so it fits neither
-    /// [`Persist::save`] nor [`Append`](crate::persistence::Append), and
-    /// stays a free function.
+    /// Add one reply as a single line, without reading the file.
+    ///
+    /// It is keyed by ticket, so it fits neither [`Persist::save`] nor
+    /// [`Append`](crate::persistence::Append).
     pub(crate) fn append(dir: &Path, key: &str, reply: &Reply) -> io::Result<()> {
         let line = serde_json::to_string(reply).map_err(io::Error::other)?;
         crate::persistence::append_line(&replies_path(dir, key), &line)
@@ -263,8 +255,8 @@ impl Replies {
 impl Persist for Replies {
     type Key = String;
 
-    /// Overwrite `replies.jsonl` with all entries, so a dropped or
-    /// redacted reply leaves nothing behind on disk.
+    /// Rewrite `replies.jsonl` whole, so a dropped or redacted reply leaves
+    /// nothing behind.
     fn save(&self, dir: &Path) -> io::Result<()> {
         let mut body = String::new();
         for reply in &self.entries {
@@ -292,12 +284,12 @@ impl Persist for Replies {
     }
 }
 
-/// Path of the ticket's record file for `key`: `tickets/<key>/ticket.json`.
+/// Where `key`'s ticket is stored: `tickets/<key>/ticket.json`.
 pub(super) fn ticket_record_path(dir: &Path, key: &str) -> PathBuf {
     dir.join("tickets").join(key).join("ticket.json")
 }
 
-/// Path of the transcript file for `key`: `tickets/<key>/replies.jsonl`.
+/// Where `key`'s replies are stored: `tickets/<key>/replies.jsonl`.
 fn replies_path(dir: &Path, key: &str) -> PathBuf {
     dir.join("tickets").join(key).join("replies.jsonl")
 }
@@ -320,24 +312,25 @@ impl AsUserMessage for Ticket {
     }
 }
 
-/// Lifecycle status of a ticket.
+/// Where a ticket is in its lifecycle.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum Status {
-    /// Created but not yet claimed by an agent.
+    /// Created, waiting for an agent.
     Todo,
-    /// Claimed by an agent and running.
+    /// Claimed by an agent and under way.
     InProgress,
-    /// Finished with a result.
+    /// Finished, carrying a result.
     Finished,
-    /// Failed after a schema-retry trip, missing-finish-tool exhaustion,
-    /// or policy violation.
+    /// Failed after exhausted schema retries, exhausted missing-`finish`
+    /// retries, or a limit being breached.
     Failed,
 }
 
 impl fmt::Display for Status {
-    /// Lowercase wire form: `"todo"`, `"in_progress"`, `"finished"`, `"failed"`.
-    /// Single source of truth for the string rendering used by the
-    /// `tickets.jsonl` event log and any caller that prints a status.
+    /// The lowercase form: `"todo"`, `"in_progress"`, `"finished"`, `"failed"`.
+    ///
+    /// It is the one source for that spelling, used by the event log and by
+    /// anyone printing a status.
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let s = match self {
             Status::Todo => "todo",

--- a/crates/agentwerk/src/agents/tickets/ticket_system.rs
+++ b/crates/agentwerk/src/agents/tickets/ticket_system.rs
@@ -1,9 +1,4 @@
-//! The [`TicketSystem`] orchestrator: owns the shared ticket store,
-//! registered agents, policies, cancellation signals, and run stats.
-//! This file holds construction, configuration, the ticket-creation
-//! API, agent binding, the background-run lifecycle, and queries.
-//! Mutation impls (`claim`, `set_finished_by`, `summarize`, etc.) live
-//! next door in `store.rs`.
+//! The shared queue agents claim tickets from, and the lifecycle that drives them.
 
 use std::collections::{HashMap, HashSet};
 use std::future::Future;
@@ -31,20 +26,17 @@ type EventHandler = dyn Fn(&Event) + Send + Sync;
 
 type ReplyEditor = dyn Fn(&[Event], &mut Vec<Reply>) + Send + Sync;
 
-/// The reply-editing state, always touched together: the registered
-/// editor and the per-ticket events buffered for it since each ticket's
-/// previous request. An `on_event` handler installed with the first editor
-/// fills `pending`; `run_reply_editor` drains it.
+/// The registered reply editor and the per-ticket events buffered for it since
+/// each ticket's previous request. The two are always touched together.
 #[derive(Default)]
 pub(super) struct ReplyEditing {
     pub(super) editor: Option<Arc<ReplyEditor>>,
     pub(super) pending: HashMap<String, Vec<Event>>,
 }
 
-/// The shared work queue. Owns the ticket store, the registered
-/// agents, the policies, and the run statistics. Many agents share one
-/// `TicketSystem` and pick up tickets concurrently; labels and names
-/// assign work to the right agent.
+/// The core data structure of agentwerk, coordinating complex work across
+/// agents. Many agents share one `TicketSystem` and pick up tickets
+/// concurrently; labels and names assign work to the right agent.
 ///
 /// ```no_run
 /// use agentwerk::{Agent, Ticket, TicketSystem};
@@ -69,10 +61,10 @@ pub(super) struct ReplyEditing {
 ///
 /// # Sessions
 ///
-/// A `TicketSystem` writes every ticket, transcript, statistic, and
-/// lifecycle event to its working directory (default `./.agentwerk`).
-/// That directory is the session: stop the process, and `TicketSystem::load(dir)`
-/// reopens it from disk and continues from where it stopped.
+/// A `TicketSystem` writes every ticket, reply, statistic, and lifecycle
+/// event to its working directory (default `./.agentwerk`). That directory is
+/// the session: stop the process, and `TicketSystem::load(dir)` reopens it
+/// from disk and continues from where it stopped.
 ///
 /// ```no_run
 /// use agentwerk::TicketSystem;
@@ -89,14 +81,14 @@ pub(super) struct ReplyEditing {
 ///
 /// ```text
 /// .agentwerk/
-/// ├── stats.json                            run statistics
+/// ├── stats.json                            execution statistics
 /// ├── tickets.jsonl                         lifecycle events (one per line)
 /// ├── results.jsonl                         finished results (one per line)
 /// ├── tickets/
 /// │   └── TICKET-1/
-/// │       ├── ticket.json                   the ticket without its transcript
-/// │       ├── replies.jsonl                 the messages, one reply per line
-/// │       └── outputs/<tool_use_id>.txt     full tool outputs spilled out of the transcript
+/// │       ├── ticket.json                   the ticket without its messages
+/// │       ├── replies.jsonl                 every message exchanged with the model, one per line
+/// │       └── outputs/<tool_use_id>.txt     full tool outputs spilled out of the messages
 /// └── knowledge/
 ///     ├── pages/<slug>.md                   knowledge pages
 ///     └── index.md                          knowledge index
@@ -107,54 +99,47 @@ pub struct TicketSystem {
     pub(super) agents: Mutex<Vec<Agent>>,
     pub(super) policies: Mutex<Policies>,
     /// Set when `finish()` should stop polling: external cancel, policy
-    /// trip, or clean drain. Workers and tools also poll this; flipping
-    /// it walks them off the queue.
+    /// violation, or clean drain. The agent tasks and the tools poll it too,
+    /// and flipping it takes them off the queue.
     pub(crate) stop_signal: Mutex<Arc<AtomicBool>>,
     /// Set only by `cancel()`, `cancel_on`, and `cancel_on_event`. Read
     /// by `is_cancelled()` so observers can tell external cancel apart
     /// from policy stops and clean drains.
     pub(crate) cancel_signal: Mutex<Arc<AtomicBool>>,
-    /// Labels whose pool has been called off via `cancel_label`. The loop
-    /// skips claiming or resuming a ticket carrying one of these, and walks
-    /// an agent off a ticket whose label lands here mid-flight, stopping one
-    /// pool while the rest of the run continues.
+    /// Labels whose pool `cancel_label` has stopped. A ticket carrying one is
+    /// neither claimed nor resumed, and an agent already holding one is taken
+    /// off it, while the rest of the run continues.
     pub(crate) cancelled_labels: Mutex<HashSet<String>>,
-    /// Result schema stamped onto every ticket carrying a registered label
-    /// that was created without a schema of its own. Set via `schema_for_label`
-    /// and applied at insert time, so a ticket's result contract follows its
-    /// label no matter how the ticket was created.
+    /// Result schema applied at insert time to every ticket that carries a
+    /// registered label and no schema of its own, so a result contract follows
+    /// its label no matter how the ticket was created.
     pub(crate) label_schemas: Mutex<HashMap<String, Schema>>,
-    /// Count of `set_final_status` calls between their status flip and
-    /// the return of the terminal event's handlers. The drain check in
-    /// `finish()` treats a non-zero count as pending work, so a handler
-    /// minting a follow-up ticket always beats the drain.
+    /// How many terminal status transitions are between their status change and
+    /// the return of their event handlers. `finish()` counts a non-zero value as
+    /// pending work, so a handler creating a follow-up ticket always beats the drain.
     pub(crate) terminal_transitions_in_flight: AtomicUsize,
     /// Reason the most recent `finish()` returned. `None` before the
     /// first `finish()` and between `start()` and the next `finish()`.
     pub(crate) finish_reason: Mutex<Option<FinishReason>>,
     pub(crate) stats: Stats,
     pub(super) event_handlers: Mutex<Vec<Arc<EventHandler>>>,
-    /// The editor that rewrites a ticket's transcript before each provider
-    /// request, plus the per-ticket events buffered for it; see
-    /// `edit_replies_on_event`. No editor short-circuits buffering.
+    /// The editor that rewrites a ticket's replies before each request, plus the
+    /// per-ticket events buffered for it. Buffering runs whether or not an
+    /// editor is installed.
     pub(super) reply_editing: Mutex<ReplyEditing>,
     pub(super) dir: Mutex<PathBuf>,
     pub(super) tickets_log_lock: Mutex<()>,
     pub(super) results_log_lock: Mutex<()>,
     pub(super) join_handle: Mutex<Option<JoinHandle<()>>>,
-    /// Next `TICKET-<N>` id to hand out, or `None` until it's known.
-    /// `load()` seeds it directly from the tickets it just read off disk.
-    /// A system built via `new()` (with or without a later `.dir(path)`)
-    /// leaves it `None`; the first `insert()` scans for the highest
-    /// existing id then, since `new()` never reads the directory itself.
+    /// Next `TICKET-<N>` key to hand out, or `None` until it is known.
+    /// `load()` seeds it from the tickets it just read off disk. `new()` leaves
+    /// it `None` and the first `insert()` scans for the highest existing key,
+    /// since `new()` never reads the directory itself.
     pub(super) next_ticket_id: Mutex<Option<u64>>,
 }
 
 impl TicketSystem {
-    /// Build a fresh `TicketSystem` and return it inside an `Arc`. The
-    /// system captures its own `Weak<Self>` via `Arc::new_cyclic` so
-    /// `bind_agent` can hand out the back-reference each `Agent` needs
-    /// at run time.
+    /// Create an empty ticket system, shared through an `Arc`.
     pub fn new() -> Arc<Self> {
         Arc::new_cyclic(|weak| Self {
             weak_self: weak.clone(),
@@ -178,29 +163,20 @@ impl TicketSystem {
         })
     }
 
-    /// Open or create a ticket system rooted at `tickets_dir`. Loads each
-    /// `ticket.json` under `<tickets_dir>/tickets/` into the in-memory
-    /// store and seeds `Stats` from
-    /// `<tickets_dir>/stats.json` (or, when that file is missing or
-    /// malformed, by deriving from the loaded tickets) so success rate
-    /// and counters stay continuous across restarts.
+    /// Continue a session from `tickets_dir`, or start one there when it is empty.
     ///
-    /// Pointing this and `Knowledge::load` at the same dir co-locates the
-    /// `knowledge/` bundle with `results.jsonl` and `tickets.jsonl`.
+    /// Every ticket is read back with its status, result, and messages, and the
+    /// statistics resume from `stats.json`, so success rate and totals stay
+    /// continuous across restarts. Pointing this and `Knowledge::load` at the
+    /// same directory keeps the knowledge pages beside the session.
     ///
-    /// `InProgress` tickets keep their status and their transcript; the
-    /// loop's resume path (`agents/loop.rs`) picks them back up under
-    /// the agent whose name is already in the ticket's `labels`.
+    /// An unfinished ticket is picked up again by the agent whose name it
+    /// carries, so agent names must stay the same across restarts.
     ///
-    /// A ticket that cannot be read stops the load, and the returned
-    /// error names it. Leaving it out instead would hand back a store
-    /// quietly missing that ticket, its status, and its result. Files
-    /// written by an older version are the usual cause: delete the
-    /// session directory, or migrate it, and load again.
-    ///
-    /// Caller contracts:
-    /// - Agent names must stay stable across restarts; agentwerk
-    ///   matches `InProgress` tickets by name via the ticket's labels.
+    /// A ticket that cannot be read stops the load and the returned error names
+    /// it, rather than handing back a store quietly missing that ticket. Files
+    /// written by an older version are the usual cause: delete the session
+    /// directory, or migrate it, and load again.
     pub fn load(tickets_dir: impl Into<PathBuf>) -> io::Result<Arc<Self>> {
         let tickets_dir = tickets_dir.into();
         std::fs::create_dir_all(tickets_dir.join("tickets"))?;
@@ -262,7 +238,7 @@ impl TicketSystem {
         }))
     }
 
-    /// Run-time counters. Read after `run` / `finish` returns.
+    /// Get the execution statistics, available during execution and after it finishes.
     pub fn stats(&self) -> &Stats {
         &self.stats
     }
@@ -276,12 +252,11 @@ impl TicketSystem {
         self
     }
 
-    /// Observe every finished ticket together with its result. Fires on
-    /// `TicketFinished`, so the value handed over is the stored,
-    /// schema-validated result, already out of its `Option`: handlers never
-    /// reach into the finish tool's input shape. One more entry on the
-    /// [`Self::on_event`] chain, and the base every `_on_result` reactor
-    /// below is built from.
+    /// Read every finished ticket together with its result.
+    ///
+    /// The value handed over is the stored, schema-validated result, so a
+    /// handler never reaches into the finish tool's input shape. This is one
+    /// more entry on the [`Self::on_event`] chain.
     pub fn on_result<F>(&self, handler: F) -> &Self
     where
         F: Fn(&Ticket, &serde_json::Value) + Send + Sync + 'static,
@@ -304,15 +279,13 @@ impl TicketSystem {
         })
     }
 
-    /// Observe every failure together with the ticket it happened in:
+    /// Read every failure together with the ticket it happened in:
     /// `TicketFailed`, `RequestFailed`, `ToolCallFailed`, `FileOpenFailed`,
-    /// `CompactionFailed`. Match on `event.kind` to tell a failure that ends
-    /// the ticket from one the agent works around. One more entry on the
-    /// [`Self::on_event`] chain, and the base every `_on_failure` reactor
-    /// below is built from.
+    /// and `CompactionFailed`.
     ///
-    /// Resolving the ticket copies its replies, so an agent that fails many
-    /// tool calls pays that copy once per failure.
+    /// Match on `event.kind` to tell a failure that ends the ticket from one
+    /// the agent works around. Each call copies the ticket's replies, so an
+    /// agent that fails many tool calls pays that copy once per failure.
     pub fn on_failure<F>(&self, handler: F) -> &Self
     where
         F: Fn(&Event, &Ticket) + Send + Sync + 'static,
@@ -332,31 +305,29 @@ impl TicketSystem {
         })
     }
 
-    /// Register an editor that rewrites or drops a ticket's replies
-    /// before its next provider request. The editor receives the events
-    /// emitted for that ticket since its previous request and a mutable
-    /// view of its full transcript, and mutates the `Vec` in place: drop
-    /// a reply, rewrite one, or push a new one. Match on `event.kind` to
-    /// act only on the triggers you care about (a tool failure, a stalled
-    /// turn); keep the editor cheap, it runs inline in the loop.
+    /// Rewrite a ticket's replies before its next request.
     ///
-    /// The edit is persistent: it mutates the stored transcript and
-    /// rewrites the on-disk transcript in place, so a dropped message
-    /// stays gone from the model's transcript, now and across resumption,
-    /// and is left behind in no superseded file on disk. The editor must
-    /// keep the transcript well-formed: a `tool_use` and its `tool_result`
-    /// span two replies, so drop both sides together or the provider
+    /// Your function receives the events emitted for that ticket since its
+    /// previous request and the replies themselves, and changes them in place:
+    /// drop a reply, rewrite one, or add one. Match on `event.kind` to act only
+    /// on what you care about, such as a tool failure or a stalled turn, and
+    /// keep the work cheap, since it runs between requests.
+    ///
+    /// The edit is permanent. It changes the stored replies and rewrites them
+    /// on disk, so a dropped message stays gone from what the model sees, now
+    /// and after the session is continued, and no superseded file is left
+    /// behind. Keep the replies well-formed: a `tool_use` and its `tool_result`
+    /// span two replies, so drop both sides together or the LLM provider
     /// rejects the unpaired block.
     ///
-    /// One editor is held at a time: installing a second replaces the
-    /// first, the way [`Self::dir`] or [`Self::max_turns`] replace. Two
-    /// rewriters of one transcript would each see the other's output, so
-    /// stack edits inside a single editor instead. Observers compose;
-    /// editors do not.
+    /// One editor is held at a time, and installing a second replaces the
+    /// first, the way [`Self::dir`] or [`Self::max_turns`] do. Two rewriters of
+    /// one ticket's replies would each see the other's output, so stack edits
+    /// inside a single editor instead.
     ///
-    /// The editor should be event-gated: on a reactive-compaction retry
-    /// the request is reassembled, so an editor that ignores the (now
-    /// empty) event batch would act twice.
+    /// Act only when the event batch says so. A retry after compaction
+    /// reassembles the request, so an editor that ignores the now empty batch
+    /// would edit the same replies twice.
     ///
     /// ```no_run
     /// use agentwerk::TicketSystem;
@@ -438,10 +409,9 @@ impl TicketSystem {
         }
     }
 
-    /// Apply the registered editor to `key`'s transcript, handing it the
-    /// events buffered since the ticket's previous request and draining
-    /// that batch. Called at the top of the request round-trip; a no-op
-    /// until an editor is registered or when no events are pending.
+    /// Apply the registered editor to `key`'s replies, handing it the events
+    /// buffered since the ticket's previous request and draining that batch.
+    /// Does nothing until an editor is registered, or while no events are pending.
     pub(crate) fn run_reply_editor(&self, key: &str) {
         let (editor, events) = {
             let mut editing = self.reply_editing.lock().unwrap();
@@ -466,10 +436,10 @@ impl TicketSystem {
             .unwrap_or_default()
     }
 
-    /// Name of the model the currently bound agent named `agent_name`
-    /// runs. `None` when no such agent is bound. Pairs with
-    /// [`Self::on_ticket`]: the event names the agent, this names its model,
-    /// and [`Trajectory::from_ticket`] wants both.
+    /// Get the model that agent runs, or `None` when no agent of that name is bound.
+    ///
+    /// Pairs with [`Self::on_ticket`]: the event names the agent, this names
+    /// its model, and [`Trajectory::from_ticket`] needs both.
     ///
     /// [`Trajectory::from_ticket`]: super::Trajectory::from_ticket
     pub fn model_for_agent(&self, agent_name: &str) -> Option<String> {
@@ -485,91 +455,102 @@ impl TicketSystem {
         self.policies.lock().unwrap().clone()
     }
 
-    // ---- policy builders ----
-
+    /// Limit the total number of turns.
     pub fn max_turns(&self, n: u32) -> &Self {
         self.policies.lock().unwrap().max_turns = Some(n);
         self
     }
 
+    /// Limit the total input tokens.
     pub fn max_input_tokens(&self, n: u64) -> &Self {
         self.policies.lock().unwrap().max_input_tokens = Some(n);
         self
     }
 
+    /// Limit the total output tokens.
     pub fn max_output_tokens(&self, n: u64) -> &Self {
         self.policies.lock().unwrap().max_output_tokens = Some(n);
         self
     }
 
+    /// Limit the output tokens of a single request.
     pub fn max_request_tokens(&self, n: u32) -> &Self {
         self.policies.lock().unwrap().max_request_tokens = Some(n);
         self
     }
 
+    /// Limit how often a result may fail its schema before the ticket fails.
     pub fn max_schema_retries(&self, n: u32) -> &Self {
         self.policies.lock().unwrap().max_schema_retries = Some(n);
         self
     }
 
+    /// Limit how often a failing request is retried.
     pub fn max_request_retries(&self, n: u32) -> &Self {
         self.policies.lock().unwrap().max_request_retries = n;
         self
     }
 
+    /// Wait this long between retries.
     pub fn request_retry_delay(&self, d: Duration) -> &Self {
         self.policies.lock().unwrap().request_retry_delay = d;
         self
     }
 
-    /// Maximum elapsed duration the run is allowed to span. When the
-    /// elapsed duration reaches the limit, `finish` stops with
-    /// `FinishReason::PolicyViolated(PolicyKind::Time)` and emits the
-    /// matching `PolicyViolated` event.
+    /// Limit the total elapsed duration.
+    ///
+    /// On reaching it, `finish` stops with
+    /// `FinishReason::PolicyViolated(PolicyKind::Time)` and emits the matching
+    /// `PolicyViolated` event.
     pub fn max_time(&self, d: Duration) -> &Self {
         self.policies.lock().unwrap().max_time = Some(d);
         self
     }
 
-    // ---- policy readers ----
-    // `None` reads as "no limit"; the two that always hold a value carry
-    // the default from `Policies::default` until the caller overrides it.
-
+    /// Get the turn limit, or `None` when there is none.
     pub fn get_max_turns(&self) -> Option<u32> {
         self.policies.lock().unwrap().max_turns
     }
 
+    /// Get the input-token limit, or `None` when there is none.
     pub fn get_max_input_tokens(&self) -> Option<u64> {
         self.policies.lock().unwrap().max_input_tokens
     }
 
+    /// Get the output-token limit, or `None` when there is none.
     pub fn get_max_output_tokens(&self) -> Option<u64> {
         self.policies.lock().unwrap().max_output_tokens
     }
 
+    /// Get the per-request output-token limit, or `None` when there is none.
     pub fn get_max_request_tokens(&self) -> Option<u32> {
         self.policies.lock().unwrap().max_request_tokens
     }
 
+    /// Get the schema-retry limit, or `None` when there is none.
     pub fn get_max_schema_retries(&self) -> Option<u32> {
         self.policies.lock().unwrap().max_schema_retries
     }
 
+    /// Get the request-retry limit, which always holds a value.
     pub fn get_max_request_retries(&self) -> u32 {
         self.policies.lock().unwrap().max_request_retries
     }
 
+    /// Get the delay between retries, which always holds a value.
     pub fn get_request_retry_delay(&self) -> Duration {
         self.policies.lock().unwrap().request_retry_delay
     }
 
+    /// Get the elapsed-duration limit, or `None` when there is none.
     pub fn get_max_time(&self) -> Option<Duration> {
         self.policies.lock().unwrap().max_time
     }
 
-    /// Cancel the run when `trigger` resolves. The future's output is
-    /// discarded; only completion matters. Composes with any cancellation
-    /// source: ctrl-c, a deadline, a channel receive, an external signal.
+    /// Stop execution when another task you supply finishes.
+    ///
+    /// Its output is discarded; only finishing matters. Any source works:
+    /// ctrl-c, a deadline, a channel receive, an external signal.
     pub fn cancel_on<F>(&self, trigger: F) -> &Self
     where
         F: Future + Send + 'static,
@@ -586,9 +567,10 @@ impl TicketSystem {
         self
     }
 
-    /// Cancel the run when `predicate` first returns true for an event.
-    /// Implemented as one more entry on the [`Self::on_event`] chain;
-    /// composes with any logger the caller installed.
+    /// Stop execution when an event matches.
+    ///
+    /// This is one more entry on the [`Self::on_event`] chain, so it works
+    /// alongside any logger you installed.
     pub fn cancel_on_event<F>(&self, predicate: F) -> &Self
     where
         F: Fn(&Event) -> bool + Send + Sync + 'static,
@@ -604,10 +586,10 @@ impl TicketSystem {
         })
     }
 
-    /// Call off the `label` pool when `predicate` first returns true for an
-    /// event. The label-scoped sibling of [`Self::cancel_on_event`]: instead of
-    /// stopping the whole run it invokes [`Self::cancel_label`], so the other
-    /// pools keep going. One more entry on the [`Self::on_event`] chain.
+    /// Stop one label's agents when an event matches, while the rest keep working.
+    ///
+    /// The label-scoped counterpart of [`Self::cancel_on_event`]: it calls
+    /// [`Self::cancel_label`] rather than ending execution.
     pub fn cancel_label_on_event<F>(&self, label: impl Into<String>, predicate: F) -> &Self
     where
         F: Fn(&Event) -> bool + Send + Sync + 'static,
@@ -624,10 +606,11 @@ impl TicketSystem {
         })
     }
 
-    /// Enqueue a follow-up ticket whenever an event makes `make` return one.
-    /// The broadest of the three: `make` sees every kind, including the
-    /// streamed chunks, so match on `event.kind` first. Guard against a
-    /// follow-up that itself re-triggers `make`, or the run never drains.
+    /// Enqueue a follow-up ticket from any event.
+    ///
+    /// The broadest of the three: your function sees every kind, including each
+    /// piece of a reply as it arrives, so match on `event.kind` first. Guard
+    /// against a follow-up that triggers itself, or execution never ends.
     pub fn create_ticket_on_event<F>(&self, make: F) -> &Self
     where
         F: Fn(&Event) -> Option<Ticket> + Send + Sync + 'static,
@@ -643,8 +626,8 @@ impl TicketSystem {
         })
     }
 
-    /// Cancel the run when a finished ticket's result matches `predicate`.
-    /// Fail-fast for "stop the whole run on the first result that means stop".
+    /// Stop execution when a finished result matches.
+    ///
     /// Built on [`Self::on_result`], so the value passed is the stored,
     /// schema-validated result.
     pub fn cancel_on_result<F>(&self, predicate: F) -> &Self
@@ -662,12 +645,12 @@ impl TicketSystem {
         })
     }
 
-    /// Call off the `label` pool when a finished ticket's result matches
-    /// `predicate`. The label-scoped sibling of [`Self::cancel_on_result`]:
-    /// instead of stopping the whole run it invokes [`Self::cancel_label`],
-    /// so the other pools keep going. Any matching result calls off `label`,
-    /// whether or not the finished ticket carried it, matching
-    /// [`Self::cancel_label_on_event`].
+    /// Stop one label's agents when a finished result matches.
+    ///
+    /// The label-scoped counterpart of [`Self::cancel_on_result`]: it calls
+    /// [`Self::cancel_label`] rather than ending execution. Any matching result
+    /// stops `label`, whether or not the finished ticket carried it, which is
+    /// how [`Self::cancel_label_on_event`] behaves too.
     ///
     /// ```no_run
     /// # use agentwerk::TicketSystem;
@@ -690,11 +673,12 @@ impl TicketSystem {
         })
     }
 
-    /// Enqueue a follow-up ticket whenever a finished ticket makes `make`
-    /// return one. `make` reads the finished ticket's key, labels, and task
-    /// alongside its result, and can chain the follow-up via `Ticket::parent`.
-    /// Guard against a follow-up that itself re-triggers `make`, or the run
-    /// never drains.
+    /// Enqueue a follow-up ticket from a finished ticket.
+    ///
+    /// Your function reads the finished ticket's key, labels, and task
+    /// alongside its result, and can chain the follow-up through
+    /// `Ticket::parent`. Guard against a follow-up that triggers itself, or
+    /// execution never ends.
     pub fn create_ticket_on_result<F>(&self, make: F) -> &Self
     where
         F: Fn(&Ticket, &serde_json::Value) -> Option<Ticket> + Send + Sync + 'static,
@@ -710,10 +694,11 @@ impl TicketSystem {
         })
     }
 
-    /// Cancel the run when a failure matches `predicate`. Built on
-    /// [`Self::on_failure`], so the predicate sees all five failure kinds:
-    /// narrow it on `event.kind` to stop on a failed ticket only, or leave it
-    /// broad to stop on the first tool or provider error.
+    /// Stop execution when a failure matches.
+    ///
+    /// Built on [`Self::on_failure`], so your condition sees all five failure
+    /// kinds. Narrow it on `event.kind` to stop on a failed ticket only, or
+    /// leave it broad to stop on the first tool or LLM provider error.
     pub fn cancel_on_failure<F>(&self, predicate: F) -> &Self
     where
         F: Fn(&Event, &Ticket) -> bool + Send + Sync + 'static,
@@ -729,10 +714,10 @@ impl TicketSystem {
         })
     }
 
-    /// Call off the `label` pool when a failure matches `predicate`. The
-    /// label-scoped sibling of [`Self::cancel_on_failure`]: instead of stopping
-    /// the whole run it invokes [`Self::cancel_label`], so the other pools keep
-    /// going.
+    /// Stop one label's agents when a failure matches.
+    ///
+    /// The label-scoped counterpart of [`Self::cancel_on_failure`]: it calls
+    /// [`Self::cancel_label`] rather than ending execution.
     pub fn cancel_label_on_failure<F>(&self, label: impl Into<String>, predicate: F) -> &Self
     where
         F: Fn(&Event, &Ticket) -> bool + Send + Sync + 'static,
@@ -749,11 +734,11 @@ impl TicketSystem {
         })
     }
 
-    /// Enqueue a follow-up ticket whenever a failure makes `make` return one.
-    /// The retry path: `make` reads the failed ticket's task and labels and
-    /// hands back a fresh attempt, chained via `Ticket::parent`. Count the
-    /// attempts in the closure, or a ticket that fails every time re-queues
-    /// itself forever.
+    /// Enqueue a retry for a ticket that failed.
+    ///
+    /// Your function reads the failed ticket's task and labels and hands back a
+    /// fresh attempt, chained through `Ticket::parent`. Count the attempts
+    /// yourself, or a ticket that fails every time re-queues itself forever.
     ///
     /// ```no_run
     /// # use agentwerk::{Ticket, TicketSystem};
@@ -781,15 +766,13 @@ impl TicketSystem {
         })
     }
 
-    /// Observe a ticket at each of its lifecycle transitions: `TicketStarted`,
-    /// `TicketFinished`, `TicketFailed`. The handler receives the event plus
-    /// the ticket it names, already resolved, so it reads the result, labels,
-    /// and replies without a second lookup. One more entry on the
-    /// [`Self::on_event`] chain, like [`Self::cancel_on_event`].
+    /// Read a ticket as it starts, finishes, or fails.
     ///
-    /// No other kind reaches the handler: resolving a ticket copies its
-    /// transcript, which on `TextChunkReceived` would cost once per streamed
-    /// chunk.
+    /// The handler receives the event plus the ticket it names, already
+    /// resolved, so it reads the result, labels, and replies without a second
+    /// lookup. No other kind reaches the handler: resolving a ticket copies its
+    /// replies, which on `TextChunkReceived` would cost once per piece of the
+    /// reply.
     pub fn on_ticket<F>(&self, handler: F) -> &Self
     where
         F: Fn(&Event, &Ticket) + Send + Sync + 'static,
@@ -812,27 +795,25 @@ impl TicketSystem {
         })
     }
 
-    /// Override the directory under which the system writes
-    /// `results.jsonl`, `tickets.jsonl`, and per-ticket
-    /// `tickets/<key>/{ticket.json,replies.jsonl}`. Defaults to `./.agentwerk`.
-    /// Knowledge co-locates with these files when `Knowledge::open`
-    /// points at the same directory.
+    /// Define where a session is stored, `./.agentwerk` by default.
+    ///
+    /// Pointing `Knowledge::load` at the same directory keeps the knowledge
+    /// pages beside the session.
     pub fn dir(&self, dir: impl Into<PathBuf>) -> &Self {
         *self.dir.lock().unwrap() = dir.into();
         self
     }
 
-    /// Directory the system writes to, `./.agentwerk` until [`Self::dir`]
-    /// overrides it.
+    /// Get the session directory.
     pub fn get_dir(&self) -> PathBuf {
         self.dir.lock().unwrap().clone()
     }
 
-    /// Register the result schema every ticket carrying `label` validates
-    /// against, unless the ticket was created with a schema of its own. The
-    /// schema is stamped at creation, so the contract follows the label whether
-    /// the ticket came from `task`, `ticket`, or a `finish` handover
-    /// child. Mirrors `Stats::stats_for_label`.
+    /// Register a schema every ticket of that label validates against.
+    ///
+    /// A ticket created with a schema of its own keeps it. Otherwise the schema
+    /// is applied at creation, so the contract follows the label whether the
+    /// ticket came from `task`, from `ticket`, or from a `finish` handover.
     pub fn schema_for_label(&self, label: impl Into<String>, schema: Schema) -> &Self {
         self.label_schemas
             .lock()
@@ -841,28 +822,25 @@ impl TicketSystem {
         self
     }
 
-    // ---- ticket-creation API mirrored on Agent ----
-
-    /// Enqueue a ticket carrying `task` as its body. Returns the new
-    /// ticket's key.
+    /// Submit a task and return its ticket key.
     pub fn task<T: Serialize>(&self, task: T) -> String {
         self.dispatch(Ticket::new(task))
     }
 
-    /// Enqueue a fully-built `Ticket`. System-managed fields (key,
-    /// reporter, created_at, status, result) are overwritten. To pin the
-    /// ticket to a specific agent, label it with the agent's name.
-    /// Compose schema and label via `Ticket::new(...).schema(...).label(...)`.
-    /// Returns the inserted ticket's key.
+    /// Submit a `Ticket` with custom labels or schema, and return its key.
+    ///
+    /// Key, reporter, creation time, status, and result are set at insertion
+    /// and overwrite whatever the ticket carried. To pin the ticket to one
+    /// agent, label it with that agent's name.
     pub fn ticket(&self, ticket: Ticket) -> String {
         self.dispatch(ticket)
     }
 
-    /// Append a user-side text reply to an existing ticket. After the
-    /// assistant has spoken, the agent pauses on the ticket; this call
-    /// flips the gate by appending a non-assistant reply, and the next
-    /// turn is sent to the provider. Use this to continue multi-turn
-    /// chats on one ticket instead of creating a new ticket per turn.
+    /// Add a reply to a ticket.
+    ///
+    /// An agent that has just spoken waits on the ticket, and this reply is
+    /// what sends the next turn. Use it to continue a conversation on one
+    /// ticket instead of creating a new ticket per turn.
     pub fn reply(&self, key: &str, content: impl Into<String>) -> &Self {
         self.add_reply(key, Reply::user_text(content));
         self
@@ -872,14 +850,12 @@ impl TicketSystem {
         self.insert(ticket, "user".to_string())
     }
 
-    // ---- query methods ----
-
-    /// Clone of the ticket at `key`, if any.
+    /// Get one ticket by key.
     pub fn get_ticket(&self, key: &str) -> Option<Ticket> {
         self.tickets.lock().unwrap().get(key).cloned()
     }
 
-    /// Every ticket, sorted by creation time then numeric key.
+    /// Get every ticket in creation order.
     pub fn tickets(&self) -> Vec<Ticket> {
         let tickets = self.tickets.lock().unwrap();
         let mut out: Vec<Ticket> = tickets.values().cloned().collect();
@@ -887,10 +863,10 @@ impl TicketSystem {
         out
     }
 
-    /// Tickets matching `predicate`, sorted by creation time then numeric key.
+    /// Get every ticket matching a condition, in creation order.
     ///
-    /// The predicate runs while `self.tickets` is locked. It MUST NOT call
-    /// other `TicketSystem` methods that lock the same `Mutex`: deadlock.
+    /// Your condition MUST NOT call another `TicketSystem` method that reads
+    /// the ticket store, or the call deadlocks.
     pub fn find_tickets<F>(&self, predicate: F) -> Vec<Ticket>
     where
         F: Fn(&Ticket) -> bool,
@@ -901,10 +877,10 @@ impl TicketSystem {
         out
     }
 
-    /// First ticket matching `predicate`, by creation order. Short-circuits.
+    /// Get the earliest ticket matching a condition.
     ///
-    /// The predicate runs while `self.tickets` is locked. It MUST NOT call
-    /// other `TicketSystem` methods that lock the same `Mutex`: deadlock.
+    /// Your condition MUST NOT call another `TicketSystem` method that reads
+    /// the ticket store, or the call deadlocks.
     pub fn find_ticket<F>(&self, predicate: F) -> Option<Ticket>
     where
         F: Fn(&Ticket) -> bool,
@@ -915,19 +891,21 @@ impl TicketSystem {
         matching.into_iter().next().cloned()
     }
 
-    /// Call off the pool carrying `label`: the loop stops claiming or resuming its
-    /// tickets and walks any agent off one it already holds, leaving that ticket
-    /// `InProgress` (abandoned), just as [`Self::cancel`] leaves in-flight tickets.
-    /// Stops one pool while the rest of the run continues.
+    /// Stop one label's agents while the rest keep working.
+    ///
+    /// Its tickets are neither claimed nor resumed, and an agent already
+    /// holding one is taken off it. That ticket stays `InProgress`, exactly as
+    /// [`Self::cancel`] leaves the tickets in flight.
     pub fn cancel_label(&self, label: impl Into<String>) -> &Self {
         self.cancelled_labels.lock().unwrap().insert(label.into());
         self
     }
 
-    /// True when `label` names a pool called off via [`Self::cancel_label`]. Ask
-    /// before minting follow-up work: a ticket carrying a cancelled label is
-    /// never claimed. Locks only `cancelled_labels`, so it is safe to call from
-    /// a predicate that already holds the `tickets` lock.
+    /// Check whether one label's agents have been stopped.
+    ///
+    /// Ask before creating follow-up work: a ticket carrying a stopped label is
+    /// never claimed. It reads no ticket state, so it is safe to call from a
+    /// condition passed to [`Self::find_ticket`] or [`Self::find_tickets`].
     ///
     /// ```no_run
     /// # use agentwerk::{Ticket, TicketSystem};
@@ -944,17 +922,15 @@ impl TicketSystem {
         self.cancelled_labels.lock().unwrap().contains(label)
     }
 
-    /// True when any of `labels` names a pool called off via [`Self::cancel_label`].
-    /// The loop's claim/resume path reads this to keep a cancelled pool's tickets
-    /// off the queue. Locks only `cancelled_labels`, so it is safe to call from a
-    /// claim predicate that already holds the `tickets` lock.
+    /// True when any of `labels` has been stopped by [`Self::cancel_label`]. The
+    /// claim and resume path reads this to keep a stopped pool's tickets off the
+    /// queue. It reads no ticket state, so a claim check may call it.
     pub(crate) fn labels_cancelled(&self, labels: &[String]) -> bool {
         let cancelled = self.cancelled_labels.lock().unwrap();
         labels.iter().any(|l| cancelled.contains(l))
     }
 
-    /// Count of tickets the run watcher still considers in flight: every
-    /// ticket whose status is `Todo` or `InProgress`.
+    /// How many tickets are still `Todo` or `InProgress`.
     pub(crate) fn pending_count(&self) -> usize {
         self.tickets
             .lock()
@@ -964,13 +940,9 @@ impl TicketSystem {
             .count()
     }
 
-    // ---- agent binding ----
-
-    /// Wire `agent` to this system. Drains any tickets the agent had
-    /// queued in a prior private system into this one, then switches the
-    /// agent's `TicketSystemRef` to `Shared(weak_self)`. Any prior
-    /// `Private` arm is dropped at the reassignment, so the prior system
-    /// is freed once no other strong reference holds it.
+    /// Attach `agent` to this system, moving any tickets it queued in its own
+    /// private system across first. The prior system is freed once nothing else
+    /// holds it.
     pub(crate) fn bind_agent(&self, agent: &mut Agent) {
         if let Some(prior) = agent.ticket_system.upgrade() {
             if !Arc::ptr_eq(
@@ -994,36 +966,32 @@ impl TicketSystem {
         self.agents.lock().unwrap().push(agent.clone());
     }
 
-    /// Clone of the currently registered agent list. The list is
-    /// append-only by invariant: `bind_agent` is the sole mutator and
-    /// only calls `push`. `run_main_loop` relies on element indices
-    /// being stable across calls. Any new mutator that removes or
-    /// reorders entries would silently break late-add detection: route
-    /// additions through `bind_agent` only.
+    /// A copy of the registered agents.
+    ///
+    /// The list is append-only, and `bind_agent` is its only writer.
+    /// `run_main_loop` needs the positions to stay stable, so a writer that
+    /// removed or reordered entries would silently break detection of agents
+    /// added while execution is under way.
     pub(crate) fn clone_agents(&self) -> Vec<Agent> {
         self.agents.lock().unwrap().clone()
     }
 
-    /// Bind `agent` to this system: drain any tickets it queued in its
-    /// default system into this one and push a clone onto this system's
-    /// agents list. Returns `&self` so registration chains with
-    /// `.task(...)` and the policy builders. To keep a bound handle to
-    /// the agent itself, use [`Agent::ticket_system`] instead.
+    /// Add an agent to this ticket system.
     ///
-    /// May be called before or after `run()` / `finish()`. When called
-    /// after `run()`, the new agent starts polling for tickets within
-    /// roughly one `IDLE_POLL_INTERVAL` (~100 ms).
+    /// Any tickets the agent queued on its own move into this system. To keep a
+    /// handle on the agent itself, use [`Agent::ticket_system`] instead. An
+    /// agent added while execution is under way picks up its first ticket
+    /// within about 100 ms.
     pub fn agent(&self, mut agent: Agent) -> &Self {
         self.bind_agent(&mut agent);
         self
     }
 
-    // ---- run lifecycle ----
-
-    /// Start the agent loop on a background tokio task. Tickets queued
-    /// afterwards are picked up within ~`IDLE_POLL_INTERVAL`. Pair with
-    /// [`Self::finish`] to wait for the queue to empty, or with
-    /// [`Self::cancel`] to signal an early exit.
+    /// Begin processing tickets, on a background task.
+    ///
+    /// A ticket queued afterwards is picked up within about 100 ms. Pair this
+    /// with [`Self::finish`] to wait for the queue to empty, or with
+    /// [`Self::cancel`] to stop early.
     pub fn start(&self) -> &Self {
         // Reset both signals so a system can be re-started after a
         // previous finish left flags set, and clear the prior reason so
@@ -1052,14 +1020,12 @@ impl TicketSystem {
         self
     }
 
-    /// Process every queued ticket, then return. Starts a run if none
-    /// is in flight; otherwise watches the in-flight one. Polls every
-    /// 20 ms; the loop exits on cancel, policy violation, or clean
-    /// drain, in that precedence. The chosen reason is stashed for
-    /// [`Self::finish_reason`] and announced via
-    /// [`EventKind::RunFinished`]. Returns `&self` so callers can chain
-    /// [`Self::last_result`], [`Self::results`], or
-    /// [`Self::tickets`] without rebinding.
+    /// Process every queued ticket, then return.
+    ///
+    /// Execution begins here when it has not already, and otherwise this waits
+    /// on what is already running. It ends on cancel, on a policy violation, or
+    /// once the queue is empty, in that precedence. The reason is kept for
+    /// [`Self::finish_reason`] and announced as [`EventKind::RunFinished`].
     pub async fn finish(&self) -> &Self {
         if self.join_handle.lock().unwrap().is_none() {
             self.start();
@@ -1090,11 +1056,11 @@ impl TicketSystem {
         self
     }
 
-    /// Request cancellation. Sync, so it composes with ctrl-c handlers,
-    /// drop guards, and other sync callers. Flips both the cancel
-    /// signal (read by [`Self::is_cancelled`]) and the stop signal
-    /// (read by every worker and tool). [`Self::finish`] returns
-    /// shortly after with `FinishReason::Cancelled`.
+    /// Cancel the execution.
+    ///
+    /// This is not async, so it can be called from a ctrl-c handler, a drop
+    /// guard, or anywhere else. Every agent and tool stops shortly after, and
+    /// [`Self::finish`] returns with `FinishReason::Cancelled`.
     pub fn cancel(&self) -> &Self {
         self.cancel_signal
             .lock()
@@ -1114,28 +1080,31 @@ impl TicketSystem {
         }
     }
 
-    /// True once external cancellation has been requested through
-    /// [`Self::cancel`], [`Self::cancel_on`], or
-    /// [`Self::cancel_on_event`]. Clean drains and policy stops do not
-    /// flip this signal.
+    /// Check whether the execution was cancelled.
+    ///
+    /// True only after [`Self::cancel`], [`Self::cancel_on`], or
+    /// [`Self::cancel_on_event`]. An empty queue or a policy violation does not
+    /// count as cancelled.
     pub fn is_cancelled(&self) -> bool {
         self.cancel_signal.lock().unwrap().load(Ordering::Relaxed)
     }
 
-    /// Reason the most recent `finish()` returned. `None` before the
-    /// first `finish()` call and between `start()` and the next
+    /// Check the reason for the finishing.
+    ///
+    /// `None` before the first `finish()`, and between `start()` and the next
     /// `finish()`.
     pub fn finish_reason(&self) -> Option<FinishReason> {
         *self.finish_reason.lock().unwrap()
     }
 
-    /// Most recent finished ticket's result. Deserialize structured
-    /// results with `serde_json::from_value`.
+    /// Get the most recent ticket result.
+    ///
+    /// Read a structured result back with `serde_json::from_value`.
     pub fn last_result(&self) -> Option<serde_json::Value> {
         self.results().pop()
     }
 
-    /// Every finished ticket's result, in creation order.
+    /// Get every ticket's result in creation order.
     pub fn results(&self) -> Vec<serde_json::Value> {
         self.find_tickets(|t| t.status == Status::Finished && t.result.is_some())
             .into_iter()
@@ -1143,15 +1112,12 @@ impl TicketSystem {
             .collect()
     }
 
-    /// Every ticket carrying `label`, in creation order, whatever its
-    /// status. [`Self::results_for_label`] narrows the same set to the
-    /// finished ones and hands back their results.
+    /// Get every ticket carrying a specific label, whatever its status.
     pub fn tickets_for_label(&self, label: &str) -> Vec<Ticket> {
         self.find_tickets(|t| t.has_label(label))
     }
 
-    /// Every finished ticket carrying `label`'s result, in creation
-    /// order. Mirrors [`Self::schema_for_label`] and `Stats::stats_for_label`.
+    /// Get every ticket's result carrying a specific label.
     pub fn results_for_label(&self, label: &str) -> Vec<serde_json::Value> {
         self.find_tickets(|t| t.is_finished() && t.has_label(label))
             .into_iter()
@@ -1159,13 +1125,11 @@ impl TicketSystem {
             .collect()
     }
 
-    /// Resolve to the earliest ticket matching `predicate`, polling every
-    /// ~50 ms. Resolves to `None` if the run stops (cancel, policy, or
-    /// clean drain) before any ticket matches. Call after [`Self::start`].
+    /// Wait for one matching ticket instead of draining the queue.
     ///
-    /// The predicate runs while `self.tickets` is locked (via
-    /// `find_ticket`); it MUST NOT call other `TicketSystem` methods that
-    /// lock the same `Mutex`: deadlock.
+    /// Call it after [`Self::start`]. It gives back `None` when execution stops
+    /// before any ticket matches. Your condition MUST NOT call another
+    /// `TicketSystem` method that reads the ticket store, or the call deadlocks.
     pub async fn wait_for_ticket<F>(&self, predicate: F) -> Option<Ticket>
     where
         F: Fn(&Ticket) -> bool,
@@ -1614,7 +1578,7 @@ mod tests {
     }
 
     /// One editor at a time, the way `dir` or `max_turns` replace. Two
-    /// rewriters of one transcript would each see the other's output.
+    /// rewriters of one ticket's replies would each see the other's output.
     #[test]
     fn a_second_reply_editor_replaces_the_first() {
         use crate::agents::tickets::ReplyContent;

--- a/crates/agentwerk/src/agents/tickets/trajectory.rs
+++ b/crates/agentwerk/src/agents/tickets/trajectory.rs
@@ -1,4 +1,4 @@
-//! The [`Trajectory`] value type: a ticket's transcript captured as a
+//! The [`Trajectory`] value type: a ticket's replies captured as a
 //! single training example, plus its disk persistence.
 
 use std::io;
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 use super::{Author, Reply, ReplyContent, Ticket};
 
 /// A finished agent run reduced to the one thing a training example needs:
-/// the message transcript, in agentwerk's own [`Reply`] shape. Build one with
+/// the messages, in agentwerk's own [`Reply`] shape. Build one with
 /// [`Trajectory::from_ticket`] from an [`on_ticket`] handler and [`save`] it
 /// where the dataset belongs, leaving any ShareGPT / chat_template conversion
 /// to a downstream step.
@@ -15,13 +15,13 @@ use super::{Author, Reply, ReplyContent, Ticket};
 /// [`on_ticket`]: super::TicketSystem::on_ticket
 /// [`save`]: Trajectory::save
 ///
-/// Each save also writes an `.html` sibling rendering the transcript for
+/// Each save also writes an `.html` sibling rendering the messages for
 /// debugging.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct Trajectory {
     /// Example id `<agent>-<ticket>`; also the on-disk filename.
     pub key: String,
-    /// Name of the model that produced the transcript. `None` when the
+    /// Name of the model that produced the replies. `None` when the
     /// producing agent could not be resolved at capture time.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
@@ -30,7 +30,7 @@ pub struct Trajectory {
 }
 
 impl Trajectory {
-    /// Capture `ticket`'s transcript as an example produced by `agent`
+    /// Capture `ticket`'s replies as an example produced by `agent`
     /// using `model`. Keeps every reply, including the system prompt: a
     /// trainer wants it, where `Ticket::to_messages` would drop it.
     pub fn from_ticket(agent: &str, model: Option<&str>, ticket: &Ticket) -> Self {
@@ -47,10 +47,10 @@ impl Trajectory {
         <Self as crate::persistence::Persist>::save(self, dir.as_ref())
     }
 
-    /// Render the transcript as a self-contained, debug-readable HTML page:
+    /// Render the messages as a self-contained, readable HTML page:
     /// one role-colored card per turn, tool input and output folded into
     /// `<details>`. Message text is escaped, not parsed as markdown, so the
-    /// page stays dependency-free and shows the transcript verbatim.
+    /// page needs nothing else and shows every message as it was.
     fn to_html(&self) -> String {
         // Entity-escape so a payload containing `<script>` renders as text.
         fn escape(text: &str) -> String {

--- a/crates/agentwerk/src/event.rs
+++ b/crates/agentwerk/src/event.rs
@@ -1,20 +1,17 @@
-//! Structured events agentwerk emits so callers can observe a run
-//! without wrapping the agent.
+//! Insights into the lifecycle and activities of an agent's work.
 
 use std::fmt;
 use std::sync::Arc;
 
 use crate::providers::{RequestErrorKind, TokenUsage};
 
-/// Why the context-window compaction seam fired.
+/// Why the older messages were summarized.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CompactReason {
-    /// The next-request token estimate crossed the model's compaction
-    /// threshold before sending; the warning fired ahead of any failure.
+    /// The next request was estimated to be too long for the model, ahead of
+    /// any failure.
     Proactive,
-    /// The provider itself reported a context-window overflow, either as
-    /// a `ProviderError::ContextWindowExceeded` or via
-    /// `ResponseStatus::ContextWindowExceeded` on a successful reply.
+    /// The LLM provider reported the context window exceeded.
     Reactive,
 }
 
@@ -27,22 +24,20 @@ impl fmt::Display for CompactReason {
     }
 }
 
-/// Which configured policy a [`EventKind::PolicyViolated`] refers to.
+/// Which limit a [`EventKind::PolicyViolated`] refers to.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PolicyKind {
-    /// `max_turns` — the turn cap across all agents.
+    /// `max_turns`: the turn limit across all agents.
     Turns,
-    /// `max_input_tokens` — cumulative request-side token cap.
+    /// `max_input_tokens`: the total input-token limit.
     InputTokens,
-    /// `max_output_tokens` — cumulative reply-side token cap.
+    /// `max_output_tokens`: the total output-token limit.
     OutputTokens,
-    /// `max_schema_retries` — consecutive schema-validation failures
-    /// while processing one ticket. Resets after every successful
-    /// schema-checked tool call.
+    /// `max_schema_retries`: consecutive schema failures on one ticket. The
+    /// count resets after every result that validates.
     MaxSchemaRetries,
-    /// `max_time`: total elapsed-duration limit. The `limit` field on
-    /// the matching [`EventKind::PolicyViolated`] is reported in
-    /// milliseconds.
+    /// `max_time`: the elapsed-duration limit. The matching event reports its
+    /// `limit` in milliseconds.
     Time,
 }
 
@@ -58,16 +53,18 @@ impl fmt::Display for PolicyKind {
     }
 }
 
-/// Why a run ended. Carried by [`EventKind::RunFinished`] and readable
-/// after `finish().await` via `TicketSystem::finish_reason()`.
+/// Why execution ended.
+///
+/// Carried by [`EventKind::RunFinished`] and readable after `finish().await`
+/// through `TicketSystem::finish_reason()`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FinishReason {
-    /// No tickets remained pending; nothing more to do.
+    /// The queue emptied; nothing more to do.
     Drained,
-    /// A `Policies` limit was exceeded.
+    /// A limit was breached.
     PolicyViolated(PolicyKind),
-    /// An external party requested cancellation through `cancel()`,
-    /// `cancel_on`, or `cancel_on_event`.
+    /// Cancellation was requested through `cancel()`, `cancel_on`, or
+    /// `cancel_on_event`.
     Cancelled,
 }
 
@@ -83,15 +80,14 @@ impl fmt::Display for FinishReason {
     }
 }
 
-/// Categorical discriminant for [`EventKind::ToolCallFailed`].
+/// How a tool call failed, carried by [`EventKind::ToolCallFailed`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ToolFailureKind {
-    /// The registry had no tool with that name.
+    /// No tool of that name is registered.
     ToolNotFound,
-    /// The tool was invoked but its execution raised an error.
+    /// The tool ran and returned an error.
     ExecutionFailed,
-    /// A schema-checked tool rejected its input. Counted against
-    /// `policies.max_schema_retries`.
+    /// The tool rejected its input. Counted against `max_schema_retries`.
     SchemaValidationFailed,
 }
 
@@ -105,7 +101,7 @@ impl fmt::Display for ToolFailureKind {
     }
 }
 
-/// One Knowledge-store operation, carried by [`EventKind::KnowledgeUsed`].
+/// What was done to a knowledge page, carried by [`EventKind::KnowledgeUsed`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum KnowledgeOp {
     Write,
@@ -125,9 +121,8 @@ impl fmt::Display for KnowledgeOp {
     }
 }
 
-/// Observation emitted as agents work. Carries the name of the agent
-/// that produced it, the key of the ticket it concerns, plus a typed
-/// [`EventKind`].
+/// An `Event` reports one thing that happened as agents work. It names the
+/// agent that produced it, the ticket it concerns, and what happened.
 ///
 /// ```no_run
 /// use agentwerk::TicketSystem;
@@ -147,8 +142,8 @@ impl fmt::Display for KnowledgeOp {
 pub struct Event {
     /// Name of the agent that produced this event.
     pub agent_name: String,
-    /// Key of the ticket this event concerns. Empty for run-lifecycle
-    /// events (`RunStarted`, `RunFinished`), which no ticket owns.
+    /// Key of the ticket this event concerns. Empty on `RunStarted` and
+    /// `RunFinished`, which no ticket owns.
     pub ticket_key: String,
     /// What happened.
     pub kind: EventKind,
@@ -168,43 +163,37 @@ impl Event {
     }
 }
 
-/// Categorical discriminant of [`Event`].
+/// What an [`Event`] reports.
 ///
-/// Most variants are emitted by a per-agent loop and carry that agent's
-/// name on the wrapping [`Event`]. Two run-lifecycle variants
-/// (`RunStarted`, `RunFinished`) are emitted by the `TicketSystem`
-/// itself and arrive with an empty `agent_name`, as does `TicketFailed`
-/// when the host fails a ticket through `TicketSystem::set_failed`.
+/// Most kinds name the agent they came from on the wrapping [`Event`].
+/// `RunStarted` and `RunFinished` come from the `TicketSystem` itself and
+/// arrive with an empty `agent_name`, as does `TicketFailed` when the host
+/// fails a ticket through `TicketSystem::set_failed`.
 #[derive(Debug, Clone)]
 pub enum EventKind {
-    /// The `TicketSystem`'s background work loop has been spawned and
-    /// the run is live. Emitted by `TicketSystem::start`.
+    /// Execution began.
     RunStarted,
-    /// The `TicketSystem`'s run has stopped. Carries the reason
-    /// `finish()` returned. Emitted by `TicketSystem::finish` after the
-    /// worker tasks have joined.
+    /// Execution ended, carrying the reason.
     RunFinished { reason: FinishReason },
-    /// Agent claimed a ticket and began working on it.
+    /// An agent claimed a ticket.
     TicketStarted,
-    /// Ticket finished with `Status::Finished`.
+    /// A ticket finished successfully.
     TicketFinished,
-    /// Ticket failed with `Status::Failed`.
+    /// A ticket failed.
     TicketFailed,
-    /// Agent loop started a new turn.
+    /// The agent began another turn on its ticket.
     TurnStarted,
-    /// Provider request began.
+    /// A request went out to the model.
     RequestStarted { model: String },
-    /// Provider request finished successfully. Carries the model and the
-    /// token counts the provider reported for the response.
+    /// A request finished and reported its token usage.
     RequestFinished { model: String, usage: TokenUsage },
-    /// Provider request failed. The run is about to stop for this ticket.
+    /// A request failed and was not retried. The ticket is about to fail.
     RequestFailed {
         model: String,
         reason: RequestErrorKind,
         message: String,
     },
-    /// Provider request failed transiently; agentwerk is about to sleep
-    /// and retry. `attempt` is 1-based.
+    /// A transient provider error triggered a retry. `attempt` counts from one.
     RequestRetried {
         model: String,
         attempt: u32,
@@ -212,68 +201,59 @@ pub enum EventKind {
         reason: RequestErrorKind,
         message: String,
     },
-    /// A streamed text chunk arrived from the provider.
+    /// A piece of the reply arrived.
     TextChunkReceived { content: String },
-    /// Tool invocation began.
+    /// A tool invocation began.
     ToolCallStarted {
         tool_name: String,
         call_id: String,
         input: serde_json::Value,
     },
-    /// Tool invocation succeeded.
+    /// A tool invocation finished.
     ToolCallFinished {
         tool_name: String,
         call_id: String,
         output: String,
     },
-    /// Tool invocation failed. The error is sent back to the model as a
-    /// tool-result message; the run continues.
+    /// A tool invocation failed but the ticket continues. The message goes back
+    /// to the model as a tool result.
     ToolCallFailed {
         tool_name: String,
         call_id: String,
         reason: ToolFailureKind,
         message: String,
     },
-    /// A file-opening tool opened `path` successfully.
+    /// A tool opened a file.
     FileOpenFinished { path: String },
-    /// A file-opening tool failed on `path`.
+    /// A tool could not open a file.
     FileOpenFailed { path: String },
-    /// The knowledge tool performed `op`. The tool self-reports, since
-    /// only it sees which operation ran.
+    /// A page was written, read, removed, or listed.
     KnowledgeUsed { op: KnowledgeOp },
-    /// A knowledge `read` or `remove` named a slug the store does not
-    /// have. Self-reported like `KnowledgeUsed`: the miss returns Ok, so
-    /// the tool-call loop cannot see it.
+    /// A page the agent asked for was not there.
     KnowledgeMissed,
-    /// A configured policy was exceeded; the run is about to stop.
+    /// A limit was breached and execution stopped.
     PolicyViolated { policy: PolicyKind, limit: u64 },
-    /// A `done`-side schema validation failed; agentwerk is about to
-    /// re-prompt the model with a corrective directive. `attempt` is
-    /// 1-based.
+    /// A result missed its schema and the agent was asked again. `attempt`
+    /// counts from one.
     SchemaRetried {
         attempt: u32,
         max_attempts: u32,
         message: String,
     },
-    /// Compaction is about to run: agentwerk is about to call the
-    /// summarizer to collapse the message tail. `total` is the number
-    /// of summariser calls the algorithm intends to make.
+    /// Compaction is about to summarize the older messages. `total` is how many
+    /// summaries it intends to ask for.
     CompactionStarted { reason: CompactReason, total: u32 },
-    /// One summariser call finished. Fires once per chunk processed by
-    /// the algorithm; `completed` is the running count (1-based) and
-    /// `total` is the same value as the matching `CompactionStarted`'s
-    /// `total`.
+    /// Compaction finished part of the work. `completed` counts from one and
+    /// `total` repeats the matching `CompactionStarted`.
     CompactionProgress {
         reason: CompactReason,
         completed: u32,
         total: u32,
     },
-    /// Compaction finished successfully; the message tail has been
-    /// replaced with the model's summary.
+    /// Compaction replaced the older messages with a summary.
     CompactionFinished { reason: CompactReason },
-    /// Compaction failed: the summarizer call returned a provider
-    /// error. The ticket is about to fail via the usual
-    /// `RequestFailed` path.
+    /// Compaction could not finish. The ticket is about to fail the same way a
+    /// failed request ends it.
     CompactionFailed {
         reason: CompactReason,
         message: String,
@@ -281,9 +261,10 @@ pub enum EventKind {
 }
 
 impl EventKind {
-    /// Stable snake_case discriminant name; keys the per-event counts in
-    /// `Stats`. Exhaustive on purpose: a new variant must name itself here,
-    /// and that one line is its whole stats integration.
+    /// The stable snake_case name that keys the per-event counts in `Stats`.
+    ///
+    /// The match is exhaustive on purpose: a new variant must name itself here,
+    /// and that one line is everything its statistics need.
     pub(crate) fn name(&self) -> &'static str {
         match self {
             EventKind::RunStarted => "run_started",
@@ -334,9 +315,10 @@ impl fmt::Display for EventKind {
     }
 }
 
-/// Default observer. Prints ticket lifecycle, tool activity, policy
-/// violations, and request failures to stderr. Quiet variants
-/// (token counts, streaming chunks, request start/finish) are dropped.
+/// The handler that runs when you install none of your own.
+///
+/// It prints ticket lifecycle, tool activity, limit breaches, and failed
+/// requests to stderr, and drops the rest.
 pub fn default_logger() -> Arc<dyn Fn(&Event) + Send + Sync> {
     Arc::new(|event: &Event| {
         let agent = &event.agent_name;

--- a/crates/agentwerk/src/lib.rs
+++ b/crates/agentwerk/src/lib.rs
@@ -69,12 +69,12 @@
 //! # Main types
 //!
 //! - [`Agent`]: picks up tickets and produces results.
-//! - [`TicketSystem`]: orchestrates work across one or more agents.
-//! - [`Ticket`]: a task plus labels and schema for assignment and validation.
-//! - [`Knowledge`]: durable memory the agent curates and shares across tickets and other agents.
-//! - [`Stats`]: statistics for tickets, tokens, and activity.
-//! - [`Event`]: lifecycle events emitted as agents work.
-//! - [`tools`]: built-in tools agents call: file I/O, search, shell, web, knowledge, ticket finish tools.
+//! - [`TicketSystem`]: coordinates complex work across agents.
+//! - [`Ticket`]: a task plus the labels and schema that assign and validate it.
+//! - [`Knowledge`]: durable memory the agent shares across tickets and other agents.
+//! - [`Stats`]: statistics about tickets, tokens, and time.
+//! - [`Event`]: requests, tool usage, failures and more.
+//! - [`tools`]: the built-in tools agents call, for files, search, shell, web, knowledge, and tickets.
 
 pub mod agents;
 pub mod codegrep;

--- a/crates/agentwerk/src/persistence.rs
+++ b/crates/agentwerk/src/persistence.rs
@@ -1,8 +1,7 @@
-//! Persistence contracts used by every value that reads or writes a
-//! file in agentwerk. `Persist` covers whole-value state files;
-//! `Append` covers jsonl append-only logs. Each implementer encodes
-//! its own file location, so the wrong file cannot be reached through
-//! the wrong type.
+//! How every value in agentwerk reads and writes its file.
+//!
+//! Each type encodes its own location, so the wrong file cannot be reached
+//! through the wrong type.
 
 use std::fs;
 use std::io::{self, Write};
@@ -82,7 +81,7 @@ pub(crate) fn append_line(path: &Path, line: &str) -> io::Result<()> {
 
 /// Relative path of a tool's output file under a tickets dir:
 /// `tickets/<key>/outputs/<id>.txt`. Callers join with the tickets dir
-/// to write; storing the relative form keeps comment transcripts portable.
+/// to write; storing the relative form keeps the recorded paths portable.
 pub(crate) fn output_path(key: &str, id: &str) -> PathBuf {
     PathBuf::from("tickets")
         .join(key)

--- a/crates/agentwerk/src/prompts/builder.rs
+++ b/crates/agentwerk/src/prompts/builder.rs
@@ -7,9 +7,8 @@ use super::section::Section;
 
 /// Assembled prompt envelope. Field order follows the canonical spec
 /// section order: the system message (role + appended directives)
-/// first, then task. Tools are not present here — they reach the model
-/// as structured data via the registry, not as a section in the prompt
-/// envelope.
+/// first, then task. Tools are absent: they reach the model as structured data
+/// from the registry, not as a section of the prompt.
 #[allow(dead_code)]
 #[derive(Debug, Clone, Default)]
 pub struct Prompt {
@@ -120,19 +119,19 @@ mod tests {
     fn knowledge_appends_after_role_in_system() {
         let p = PromptBuilder::default()
             .role("You are an agent.")
-            .knowledge("- **config** — Port 8080")
+            .knowledge("- **config**: Port 8080")
             .build();
         assert_eq!(
             p.system,
-            "You are an agent.\n\n## Knowledge\n\n- **config** — Port 8080"
+            "You are an agent.\n\n## Knowledge\n\n- **config**: Port 8080"
         );
     }
 
     #[test]
     fn knowledge_alone_renders_in_system() {
         let p = PromptBuilder::default()
-            .knowledge("- **config** — Port 8080")
+            .knowledge("- **config**: Port 8080")
             .build();
-        assert_eq!(p.system, "## Knowledge\n\n- **config** — Port 8080");
+        assert_eq!(p.system, "## Knowledge\n\n- **config**: Port 8080");
     }
 }

--- a/crates/agentwerk/src/prompts/compaction.directive.md
+++ b/crates/agentwerk/src/prompts/compaction.directive.md
@@ -1,15 +1,15 @@
-Respond with plain text only. Do not call any tools — tool calls will be rejected and waste your only turn.
+Respond with plain text only. Do not call any tools: a tool call is rejected and wastes your only turn.
 
 Summarize the conversation above so the agent can continue the same task without losing context. Cover every section that applies:
 
 1. Primary request and intent
 2. Key technical concepts
-3. Files and code sections examined, modified, or created — include full snippets where they matter
+3. Files and code sections examined, modified, or created, with full snippets where they matter
 4. Errors encountered and how they were fixed
 5. Problem solving and ongoing troubleshooting
 6. All non-tool-result messages from the user, verbatim where their wording matters
 7. Pending tasks
-8. Current work — what was being worked on immediately before this summary
-9. Next step — quote directly from the most recent messages so the language stays anchored
+8. Current work: what was being worked on immediately before this summary
+9. Next step: quote directly from the most recent messages so the language stays anchored
 
 Reply with the summary only. Do not call any tools.

--- a/crates/agentwerk/src/prompts/mod.rs
+++ b/crates/agentwerk/src/prompts/mod.rs
@@ -1,5 +1,5 @@
-//! The body `{context}` expands to, and the `Section` / `PromptBuilder`
-//! that composes the role prompt and (caller-supplied) directives.
+//! Assembles what an agent is told: the role, the directives, and the facts
+//! `{context}` expands to.
 
 mod builder;
 mod section;

--- a/crates/agentwerk/src/prompts/section.rs
+++ b/crates/agentwerk/src/prompts/section.rs
@@ -1,11 +1,12 @@
-//! View-model for one section of an assembled prompt: a body of markdown plus an optional `## Heading` the builder injects at render time.
+//! One section of a prompt: its markdown body, and the heading the builder puts
+//! above it.
 
 use std::borrow::Cow;
 
 /// One section of an assembled prompt. Knows whether it should render under a
 /// `## Heading` (Knowledge) or as bare body (Role, Directive). Keeping
-/// this concern here means the source `.md` files contain only body content —
-/// the structural markdown is added by the builder.
+/// this concern here means the source `.md` files hold body content only, and
+/// the builder adds the surrounding markdown.
 #[derive(Debug, Clone)]
 pub(crate) struct Section {
     pub heading: Option<&'static str>,
@@ -44,8 +45,8 @@ impl Section {
     }
 
     /// Trim leading and trailing newlines off the body so the builder controls
-    /// section spacing — empty leading/trailing lines in source files do not
-    /// leak into the final prompt.
+    /// section spacing, so blank lines at either end of a source file do not
+    /// reach the final prompt.
     pub fn render(&self) -> String {
         let body = self.body.trim_matches('\n');
         match self.heading {
@@ -67,8 +68,8 @@ mod tests {
 
     #[test]
     fn knowledge_wraps_body_in_h2_heading() {
-        let s = Section::knowledge("- **config** — Port 8080");
-        assert_eq!(s.render(), "## Knowledge\n\n- **config** — Port 8080");
+        let s = Section::knowledge("- **config**: Port 8080");
+        assert_eq!(s.render(), "## Knowledge\n\n- **config**: Port 8080");
     }
 
     #[test]

--- a/crates/agentwerk/src/providers/environment.rs
+++ b/crates/agentwerk/src/providers/environment.rs
@@ -38,8 +38,8 @@ pub(crate) fn env_opt(name: &str) -> Option<String> {
 }
 
 /// Detect an LLM provider from environment variables and construct it from
-/// API key + base URL. Does not resolve a model — pair with
-/// [`model_from_env`] or set one explicitly on the agent.
+/// API key and base URL. It picks no model: pair it with [`model_from_env`], or
+/// set one on the agent.
 ///
 /// Detection order:
 ///   0. `LITELLM_PROVIDER` → explicit selection (`anthropic`, `mistral`, `openai`, `litellm`)
@@ -62,10 +62,10 @@ pub fn provider_from_env() -> ProviderResult<Arc<dyn Provider>> {
 /// Resolve a model name from environment variables.
 ///
 /// Priority:
-///   1. `MODEL`        — generic override, wins regardless of provider.
-///   2. `*_MODEL`      — provider-prefixed, selected by the same detection
-///      matrix as [`provider_from_env`] (e.g. `OPENAI_MODEL`).
-///   3. hosted default — the vendor's canonical model for the detected provider.
+///   1. `MODEL`: a generic override that wins whatever the LLM provider is.
+///   2. `*_MODEL`: named after the provider, chosen the same way
+///      [`provider_from_env`] chooses one, as in `OPENAI_MODEL`.
+///   3. The vendor's own default model for the detected provider.
 pub fn model_from_env() -> ProviderResult<String> {
     model_from_env_with(|name| std::env::var(name).ok())
 }

--- a/crates/agentwerk/src/providers/error.rs
+++ b/crates/agentwerk/src/providers/error.rs
@@ -1,4 +1,5 @@
-//! Errors a provider raises before producing a `ModelResponse`. Anything that maps to a valid response-with-status belongs on `ResponseStatus`, not here.
+//! What can go wrong before an LLM provider produces a response. A response
+//! that did arrive reports through `ResponseStatus` instead.
 
 use std::fmt;
 use std::time::Duration;
@@ -38,8 +39,8 @@ pub enum ProviderError {
     /// `ConnectionFailed` (pre-response) and `ResponseMalformed` (structurally
     /// broken payload): the transport broke while chunks were still in flight.
     StreamInterrupted { message: String },
-    /// The response arrived but its body couldn't be parsed — malformed
-    /// JSON, unexpected shape, or a broken SSE frame.
+    /// The response arrived but its body could not be read: malformed JSON, an
+    /// unexpected shape, or a broken frame.
     ResponseMalformed { message: String },
     /// Provider construction failed to resolve a provider from the
     /// environment: no provider was detected, a required env var was unset,

--- a/crates/agentwerk/src/providers/litellm.rs
+++ b/crates/agentwerk/src/providers/litellm.rs
@@ -1,4 +1,5 @@
-//! LiteLLM proxy provider. Points the OpenAI-compatible wire format at a local LiteLLM instance so callers can switch backend providers without touching agent code.
+//! The LiteLLM provider, which sends OpenAI-shaped requests to a local LiteLLM
+//! instance, so switching LLM providers changes no agent code.
 
 use std::future::Future;
 use std::pin::Pin;

--- a/crates/agentwerk/src/providers/mistral.rs
+++ b/crates/agentwerk/src/providers/mistral.rs
@@ -1,4 +1,4 @@
-//! Mistral provider. Thin wrapper that points the OpenAI-compatible wire format at api.mistral.ai.
+//! The Mistral provider, which sends OpenAI-shaped requests to api.mistral.ai.
 
 use std::future::Future;
 use std::pin::Pin;

--- a/crates/agentwerk/src/providers/mod.rs
+++ b/crates/agentwerk/src/providers/mod.rs
@@ -1,6 +1,8 @@
 //! The `Provider` trait and the vendor-specific implementations that speak to Anthropic, OpenAI-compatible APIs, Mistral, and LiteLLM.
 //!
-//! The request and response types passed across the `Provider` trait (`Message`, `ContentBlock`, `ModelRequest`, `ModelResponse`, `StreamEvent`, ...) are reachable by name but hidden from the rustdoc index: they only matter when implementing a custom [`Provider`].
+//! The types a request and a response are made of (`Message`, `ContentBlock`,
+//! `ModelRequest`, `ModelResponse`, `StreamEvent`) are reachable by name but
+//! kept out of the index: they matter only when implementing a [`Provider`].
 
 mod anthropic;
 pub mod environment;

--- a/crates/agentwerk/src/providers/model.rs
+++ b/crates/agentwerk/src/providers/model.rs
@@ -1,4 +1,5 @@
-//! Per-model knowledge of context window size and compaction thresholds. agentwerk consults this to decide when a conversation must be shrunk.
+//! What agentwerk knows about each model's context window, and when a
+//! conversation has to be summarized to fit.
 
 use super::{AnthropicProvider, MistralProvider, OpenAiProvider, ReasoningEffort};
 
@@ -17,8 +18,8 @@ pub struct Model {
 
 impl Model {
     /// Build a `Model` by asking each provider in turn for its known context
-    /// window. Unknown names produce a `Model` with `context_window: None`
-    /// — compaction stays dormant, no error.
+    /// window. An unknown name leaves `context_window` at `None`, so nothing is
+    /// compacted and nothing fails.
     pub fn from_name(name: impl Into<String>) -> Self {
         let name = name.into();
         let context_window = AnthropicProvider::lookup_context_window_size(&name)
@@ -31,7 +32,7 @@ impl Model {
         }
     }
 
-    /// Explicit override — skips the registry. Useful for local proxies or
+    /// Set the context window size for a model, skipping the known names. Useful for local proxies or
     /// private deployments whose name isn't in any provider's table.
     pub fn context_window(mut self, size: u64) -> Self {
         self.context_window = Some(size);

--- a/crates/agentwerk/src/providers/openai.rs
+++ b/crates/agentwerk/src/providers/openai.rs
@@ -1,4 +1,5 @@
-//! OpenAI's Chat Completions API. The sibling `mistral` and `litellm` providers reuse this wire format against different base URLs.
+//! OpenAI's Chat Completions API. The `mistral` and `litellm` providers send
+//! the same shape to a different base URL.
 
 use std::collections::HashMap;
 use std::future::Future;
@@ -750,7 +751,7 @@ mod tests {
 
     #[test]
     fn context_window_exceeded_by_message_fallback() {
-        // Mistral / LiteLLM path — `code` absent, classifier falls back to
+        // Mistral / LiteLLM path: `code` absent, classifier falls back to
         // matching the message text.
         let body = serde_json::json!({
             "error": {

--- a/crates/agentwerk/src/providers/patterns.rs
+++ b/crates/agentwerk/src/providers/patterns.rs
@@ -1,5 +1,5 @@
 //! Cross-provider error-body pattern bank. A vendor's per-code
-//! classifier only recognises that vendor's wording — but in practice
+//! classifier only recognises that vendor's wording, but in practice
 //! errors arrive WRAPPED: a LiteLLM (or any OpenAI-compatible) proxy
 //! returns an HTTP 400 whose body carries another provider's error
 //! verbatim inside its message text, with LiteLLM's own status/code
@@ -7,8 +7,8 @@
 //! gives up; the wrapped overflow signal is then lost and the agent
 //! loop treats the response as terminal instead of triggering
 //! compaction. This bank runs after the vendor returns None and
-//! before the generic fallback, so any of the substrings below — no
-//! matter how deeply wrapped — re-classifies the error correctly.
+//! before the generic fallback, so any of the substrings below re-classifies
+//! the error correctly, however deeply it is wrapped.
 
 use std::time::Duration;
 
@@ -31,7 +31,7 @@ const OVERFLOW_PATTERNS: &[&str] = &[
     // Mistral: distinctive wording, no overlap with the others.
     "too large for model with",
     // Vertex / Gemini: not a first-party provider here, but the user
-    // hit this exact wording through LiteLLM-passthrough — Gemini's
+    // hit this exact wording through LiteLLM-passthrough: Gemini's
     // 1 M-token limit phrases overflow this way and nothing else does.
     "input token count",
     "exceeds the maximum number of tokens",
@@ -52,7 +52,7 @@ const OVERFLOW_PATTERNS: &[&str] = &[
 /// Substrings that look overflow-ish but are actually throttling /
 /// rate-limit signals. Without this exclusion, bodies like
 /// `"Throttling error: too many tokens per minute"` would match the
-/// `"maximum context length"` family patterns and trip a useless
+/// `"maximum context length"` family patterns and cause a useless
 /// compaction. Checked FIRST so the rule "rate-limit beats overflow"
 /// is unambiguous.
 const NON_OVERFLOW_PATTERNS: &[&str] = &[
@@ -64,7 +64,7 @@ const NON_OVERFLOW_PATTERNS: &[&str] = &[
     // forward errors as `litellm.RateLimitError: ...`; lowercased the
     // class name has no space and the prose pattern above misses.
     "ratelimit",
-    // Google Vertex's RPC status for quota exhaustion — surfaces
+    // Google Vertex's RPC status for quota exhaustion, surfaces
     // through LiteLLM-passthrough when the upstream is Gemini.
     "resource_exhausted",
 ];
@@ -76,7 +76,7 @@ const NON_OVERFLOW_PATTERNS: &[&str] = &[
 ///   regardless of the outer HTTP status (LiteLLM occasionally wraps
 ///   a 429 inside a different outer code, so we can't trust status
 ///   alone to mean "this was a rate limit").
-/// - `None` when neither matches — the caller falls through to
+/// - `None` when neither matches, so the caller falls through to
 ///   `StatusUnclassified`, preserving existing behaviour for
 ///   genuinely unrecognised errors.
 pub(crate) fn refine(
@@ -92,7 +92,7 @@ pub(crate) fn refine(
 
     // Rate-limit exclusion runs FIRST. A body that says both
     // "throttling" and "maximum tokens" is a rate limit, not an
-    // overflow — the inverse would burn a compaction round-trip and
+    // overflow: the inverse would burn a compaction round-trip and
     // still hit the same throttle on the next request.
     let looks_like_rate_limit = NON_OVERFLOW_PATTERNS.iter().any(|p| lower.contains(p));
 
@@ -132,7 +132,7 @@ mod tests {
 
     /// LiteLLM wrapping a Vertex RESOURCE_EXHAUSTED behind its own
     /// `MidStreamFallbackError`. The outer status IS 429 so the
-    /// fallback path would handle it correctly — but `refine` must
+    /// fallback path would handle it correctly, but `refine` must
     /// also catch the rate-limit signal so a wrapped 429 returned with
     /// any other outer status still classifies correctly, AND so the
     /// `retry_delay` from headers propagates.
@@ -155,7 +155,7 @@ mod tests {
 
     /// Rule "rate-limit beats overflow". A throttling body that also
     /// contains "maximum context length" must NOT be classified as
-    /// overflow — compacting would not help and the next request would
+    /// overflow: compacting would not help and the next request would
     /// hit the same throttle.
     #[test]
     fn throttling_with_overflow_wording_classifies_as_rate_limited() {
@@ -167,7 +167,7 @@ mod tests {
     }
 
     /// First-party Anthropic overflow phrasing. The Anthropic vendor
-    /// classifier normally catches this — the test confirms the
+    /// classifier normally catches this, and the test confirms the
     /// shared bank is a correct defense-in-depth backstop if the
     /// vendor classifier ever regresses or misses a variant.
     #[test]

--- a/crates/agentwerk/src/providers/provider.rs
+++ b/crates/agentwerk/src/providers/provider.rs
@@ -1,4 +1,4 @@
-//! The `Provider` trait every backend implements, plus the request shape callers pass in. The one seam between the agent loop and any particular vendor API.
+//! Connects agents to LLMs, and the request they send.
 
 use std::fmt;
 use std::future::Future;
@@ -13,22 +13,22 @@ use super::environment;
 use super::error::ProviderResult;
 use super::types::{Message, ModelResponse, StreamEvent};
 
-/// Tool description sent to the provider as the `tools` parameter.
+/// One tool as the model is told about it.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProviderToolDefinition {
-    /// Unique name the model uses when calling the tool.
+    /// The name the model calls the tool by.
     pub name: String,
-    /// Human-readable description shown to the model.
+    /// What the tool does, in the words the model reads.
     pub description: String,
-    /// JSON Schema describing the tool's arguments.
+    /// What the tool accepts, as JSON Schema.
     pub input_schema: Value,
 }
 
-/// How much extended thinking to ask the model for. Each provider maps this
-/// to its own request field: Anthropic's `thinking` + `output_config.effort`,
-/// the OpenAI-compatible `reasoning_effort`. `Off` sends no such field and
-/// leaves thinking to the model's default. This controls only the request;
-/// reasoning the model returns is always captured as a `Thinking`
+/// How much reasoning to ask the model for.
+///
+/// Each LLM provider has its own field for it. `Off` sends none, leaving the
+/// model's own default. This shapes only the request: whatever reasoning comes
+/// back is always kept as a `Thinking`
 /// [`ContentBlock`](super::ContentBlock).
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ReasoningEffort {
@@ -40,9 +40,8 @@ pub enum ReasoningEffort {
 }
 
 impl ReasoningEffort {
-    /// The request string (`"low"` / `"medium"` / `"high"`), or `None` when
-    /// off. Both the Anthropic `output_config.effort` and the OpenAI
-    /// `reasoning_effort` take these same strings.
+    /// The value sent with the request, `"low"`, `"medium"`, or `"high"`, or
+    /// `None` when off. Every supported LLM provider takes these same words.
     pub(crate) fn label(self) -> Option<&'static str> {
         match self {
             ReasoningEffort::Off => None,
@@ -59,51 +58,52 @@ impl fmt::Display for ReasoningEffort {
     }
 }
 
-/// One request to a provider. Built by the agent loop from the agent's
-/// configuration and the running conversation; passed to [`Provider::respond`]
-/// together with a streaming event callback.
+/// One request to an LLM provider, assembled from the agent's configuration and
+/// the conversation so far.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ModelRequest {
-    /// Model name (e.g. `claude-sonnet-4-20250514`).
+    /// Which model to ask, such as `claude-sonnet-4-20250514`.
     pub model: String,
-    /// System prompt assembled from role, behavior, and environment.
+    /// The system prompt, assembled from the role, the behavior, and the
+    /// facts of the moment.
     pub system_prompt: String,
-    /// Conversation history including the latest user input.
+    /// Everything said so far, ending with the latest input.
     pub messages: Vec<Message>,
-    /// Tool definitions available to the model this turn.
+    /// The tools the model may call this turn.
     pub tools: Vec<ProviderToolDefinition>,
-    /// Cap on output tokens for this single request. `None` lets the
-    /// provider apply its default.
+    /// Limit on this request's output tokens, or `None` for the LLM provider's
+    /// own default.
     pub max_request_tokens: Option<u32>,
-    /// Constraint on which tool the model may pick this turn.
+    /// Which tool the model may pick this turn.
     pub tool_choice: Option<ToolChoice>,
-    /// Extended-thinking depth to request. Carried from the [`Model`](super::Model).
+    /// How much reasoning to ask for, taken from the [`Model`](super::Model).
     #[serde(default)]
     pub reasoning_effort: ReasoningEffort,
 }
 
-/// Constraint on which tool the model may pick on a given turn.
+/// Which tool the model may pick on one turn.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ToolChoice {
-    /// The model picks freely (or replies without a tool call).
+    /// The model picks freely, or replies without calling a tool.
     Auto,
-    /// Force the model to call this tool.
+    /// The model must call this tool.
     Specific { name: String },
 }
 
-/// Core provider trait every backend implements. Object-safe via boxed futures.
+/// Connect to a `Provider` to give agents access to LLMs.
 ///
-/// Build a provider with one of the vendor constructors
-/// ([`AnthropicProvider`](crate::providers::AnthropicProvider),
+/// agentwerk supports [`AnthropicProvider`](crate::providers::AnthropicProvider),
 /// [`OpenAiProvider`](crate::providers::OpenAiProvider),
-/// [`MistralProvider`](crate::providers::MistralProvider),
-/// [`LiteLlmProvider`](crate::providers::LiteLlmProvider)) or pick one from the
+/// [`MistralProvider`](crate::providers::MistralProvider), and
+/// [`LiteLlmProvider`](crate::providers::LiteLlmProvider), or read one from the
 /// environment with [`provider_from_env`](crate::providers::provider_from_env).
+/// Implement the trait for anything else.
 pub trait Provider: Send + Sync {
-    /// Drive one model turn. Emits incremental [`StreamEvent`]s via the
-    /// callback as the model generates, then returns the assembled reply.
-    /// Callers that don't care about incremental events pass a no-op closure
-    /// and wait for the final [`ModelResponse`].
+    /// Run one turn: send the request, forward each [`StreamEvent`] as it
+    /// arrives, and give back the assembled reply.
+    ///
+    /// Pass a handler that does nothing to wait only for the final
+    /// [`ModelResponse`].
     fn respond(
         &self,
         request: ModelRequest,
@@ -170,8 +170,8 @@ pub(crate) fn build_client(timeout: Duration) -> reqwest::Client {
 
 /// Load CA certificates from a PEM bundle file, a directory of PEM files, or
 /// both. Panics if either path is unreadable, contains invalid PEM data, or
-/// if the combined result is empty — with built-in roots disabled, an empty
-/// trust store would silently reject every connection.
+/// if the combined result is empty: with the built-in roots off, an empty trust
+/// store would quietly reject every connection.
 fn root_certificates_from(file: Option<&str>, dir: Option<&str>) -> Vec<reqwest::Certificate> {
     let mut certs = Vec::new();
     if let Some(path) = file {
@@ -197,13 +197,13 @@ fn root_certificates_from(file: Option<&str>, dir: Option<&str>) -> Vec<reqwest:
     }
     assert!(
         !certs.is_empty(),
-        "SSL_CERT_FILE/SSL_CERT_DIR set but no certificates loaded — every connection would be rejected"
+        "SSL_CERT_FILE/SSL_CERT_DIR set but no certificates loaded: every connection would be rejected"
     );
     certs
 }
 
 /// Fire-and-forget HEAD request to warm the TCP+TLS connection pool. Helper
-/// for `Provider::prewarm` overrides — call this with the provider's own
+/// for a `Provider::prewarm` of your own. Pass it that provider's
 /// `reqwest::Client` and base URL.
 pub(crate) async fn prewarm_with(client: &reqwest::Client, base_url: &str) {
     let _ = tokio::time::timeout(Duration::from_secs(10), client.head(base_url).send()).await;

--- a/crates/agentwerk/src/providers/stream.rs
+++ b/crates/agentwerk/src/providers/stream.rs
@@ -1,4 +1,5 @@
-//! Server-Sent Events parser for LLM streaming responses. Reassembles the byte stream into complete `data:` events regardless of where chunk boundaries fall.
+//! Reads Server-Sent Events from an LLM provider, reassembling whole `data:`
+//! events however the bytes arrive.
 
 use serde_json::Value;
 

--- a/crates/agentwerk/src/providers/types.rs
+++ b/crates/agentwerk/src/providers/types.rs
@@ -1,4 +1,5 @@
-//! Provider-agnostic shape of a chat exchange — messages, content blocks, token usage, stop reasons, streaming events. The lingua franca between agentwerk and every provider.
+//! What agentwerk and every LLM provider exchange: messages, content blocks,
+//! token usage, stop reasons, and the pieces of a reply as they arrive.
 
 use serde::{Deserialize, Serialize};
 
@@ -41,9 +42,8 @@ impl Message {
 }
 
 /// Render this value as a user-role `Message`. Implemented by anything
-/// that can sensibly become a single user turn — `Ticket` (the task
-/// seed agentwerk sends on the first turn), and future sources like
-/// `Comment` or peer-message notifications.
+/// that becomes one turn's input, such as `Ticket`, whose task agentwerk sends
+/// on the first turn.
 pub trait AsUserMessage {
     fn as_user_message(&self) -> Message;
 }

--- a/crates/agentwerk/src/schemas/mod.rs
+++ b/crates/agentwerk/src/schemas/mod.rs
@@ -1,15 +1,11 @@
-//! Hand-rolled JSON Schema validator for the keyword subset agentwerk
-//! needs to constrain agent replies. The public surface is
-//! [`Schema::parse`] and [`Schema::validate`].
+//! Constrains the result an agent produces for a ticket.
 //!
-//! The subset is deliberately small: structural keywords, the scalar
-//! value bounds the model APIs do not enforce, the logical and
-//! conditional applicators, and `pattern`. Any keyword outside the
-//! supported set is rejected at parse time rather than silently ignored,
-//! so a caller learns the limit instead of trusting a constraint that
-//! never ran. `pattern` compiles with the `regex` crate, whose dialect
-//! lacks the ECMA-262 backreferences, lookahead, and lookbehind that
-//! JSON Schema nominally allows.
+//! The supported subset of JSON Schema is deliberately small: structure, the
+//! scalar bounds the model APIs do not enforce, the logical and conditional
+//! keywords, and `pattern`. Anything outside it is rejected when the schema is
+//! parsed, so you learn the limit instead of trusting a constraint that never
+//! ran. `pattern` uses the `regex` crate, which has no backreferences,
+//! lookahead, or lookbehind.
 //!
 //! ```
 //! use agentwerk::schemas::Schema;
@@ -37,10 +33,11 @@ use std::sync::Arc;
 
 use serde_json::{Map, Number, Value};
 
-/// A compiled schema. Cheap to clone (Arc-backed); validation is
-/// read-only. Constructed via [`Schema::parse`] from a JSON-Schema
-/// document (the hand-rolled subset documented at the top of this
-/// module).
+/// A `Schema` constrains the result an agent produces for a ticket. A violation
+/// triggers a retry until `max_schema_retries` is exhausted.
+///
+/// Build one with [`Schema::parse`]. Copying it is cheap, and validating
+/// changes nothing.
 #[derive(Clone)]
 pub struct Schema {
     inner: Arc<SchemaBody>,
@@ -52,10 +49,11 @@ struct SchemaBody {
 }
 
 impl Schema {
-    /// Parse and compile a schema document. Compilation failures
-    /// (malformed schema, unsupported keyword, …) come back as
-    /// [`SchemaParseError`] and never feed the retry budget — they
-    /// are programming errors, not content violations.
+    /// Create a schema.
+    ///
+    /// A malformed document or an unsupported keyword comes back as a
+    /// [`SchemaParseError`] and never counts against the retry budget: it is a
+    /// mistake in your code, not in what an agent produced.
     ///
     /// ```
     /// use agentwerk::schemas::Schema;
@@ -77,11 +75,12 @@ impl Schema {
         })
     }
 
-    /// Validate `value` and return the value to keep. A conforming value is
-    /// returned unchanged; a JSON string an agent double-encoded (`"{...}"`
-    /// instead of `{...}`) is decoded once and returned if the decoded value
-    /// conforms. Otherwise the original violations are returned, so a retry
-    /// points at the real problem, not the decoding.
+    /// Validate content and give back the value to keep.
+    ///
+    /// A value that satisfies the schema comes back unchanged. A value an agent
+    /// wrote as a JSON string is decoded once and kept when the decoded form
+    /// satisfies the schema. Otherwise the original violations are reported, so
+    /// a retry points at the real problem rather than at the decoding.
     ///
     /// ```
     /// use agentwerk::schemas::Schema;
@@ -117,8 +116,8 @@ impl Schema {
         }
     }
 
-    /// Pure structural check against the compiled schema: `Ok(())`, or every
-    /// violation found, each tagged with its instance path.
+    /// Check `value` against the schema and report every violation, each
+    /// naming where in the value it occurred.
     fn check(&self, instance: &Value) -> Result<(), Vec<SchemaViolation>> {
         let mut violations = Vec::new();
         self.inner.compiled.check(instance, "", &mut violations);
@@ -149,16 +148,15 @@ impl<'de> serde::Deserialize<'de> for Schema {
     }
 }
 
-/// A single violation reported by [`Schema::validate`].
+/// One thing wrong with a value, reported by [`Schema::validate`].
 #[derive(Debug, Clone)]
 pub struct SchemaViolation {
-    /// JSON Pointer into the instance (e.g. `/items/0/name`).
-    /// Empty string means "the root value itself".
+    /// Where in the value the problem is, as a JSON Pointer such as
+    /// `/items/0/name`. Empty means the value itself.
     pub instance_path: String,
-    /// JSON Pointer into the schema (e.g.
-    /// `/properties/items/items/properties/name/type`).
+    /// Which part of the schema was violated, as a JSON Pointer.
     pub schema_path: String,
-    /// One-line message describing the violation.
+    /// What went wrong, in one line.
     pub message: String,
 }
 
@@ -174,10 +172,8 @@ impl fmt::Display for SchemaViolation {
     }
 }
 
-/// Every violation from one [`Schema::validate`] call. Its `Display` is
-/// the agent-facing feedback a tool returns on a schema failure: a
-/// header followed by one line per violation. Derefs to the underlying
-/// slice for inspection.
+/// Everything wrong with one value. Its `Display` is what the agent reads back:
+/// a header and one line per violation.
 #[derive(Debug, Clone)]
 pub struct SchemaViolations(Vec<SchemaViolation>);
 
@@ -200,9 +196,8 @@ impl fmt::Display for SchemaViolations {
 
 impl std::error::Error for SchemaViolations {}
 
-/// Schema compilation failure — the caller-supplied schema is itself
-/// invalid. Distinct from [`SchemaViolation`] (an instance failing a
-/// valid schema).
+/// The schema itself is invalid. A [`SchemaViolation`] is the other case: a
+/// value failing a schema that is fine.
 #[derive(Debug, Clone)]
 pub struct SchemaParseError {
     pub message: String,
@@ -216,7 +211,7 @@ impl fmt::Display for SchemaParseError {
 
 impl std::error::Error for SchemaParseError {}
 
-// ---------- compiled schema tree ----------
+// Compiled schema tree
 
 #[derive(Debug, Default)]
 struct Node {
@@ -253,10 +248,10 @@ struct Node {
 
 #[derive(Debug, Default)]
 enum AdditionalProperties {
-    /// `additionalProperties` not set or `true` — extra keys are permitted.
+    /// `additionalProperties` unset or `true`: extra keys are allowed.
     #[default]
     Allowed,
-    /// `additionalProperties: false` — extra keys produce a violation.
+    /// `additionalProperties: false`: an extra key is a violation.
     Forbidden,
 }
 
@@ -321,9 +316,9 @@ fn is_integer(n: &Number) -> bool {
         .is_some_and(|f| f.is_finite() && f.fract() == 0.0)
 }
 
-/// The keywords this validator understands. Anything outside this list is
-/// rejected at parse time, so an unsupported constraint surfaces as an
-/// error instead of passing silently.
+/// The keywords agentwerk understands. Anything else is rejected when the
+/// schema is parsed, so an unsupported constraint is reported rather than
+/// quietly ignored.
 const SUPPORTED_KEYWORDS: &[&str] = &[
     // assertions
     "type",
@@ -348,7 +343,7 @@ const SUPPORTED_KEYWORDS: &[&str] = &[
     "if",
     "then",
     "else",
-    // informational — accepted but not evaluated
+    // informational: accepted but not evaluated
     "$schema",
     "$id",
     "$comment",
@@ -574,7 +569,7 @@ fn compile(value: &Value, schema_path: &str) -> Result<Node, SchemaParseError> {
     })
 }
 
-/// Parse a single subschema keyword (object or boolean schema).
+/// Read one nested schema, written either as an object or as a boolean.
 fn parse_subschema(
     obj: &Map<String, Value>,
     key: &str,
@@ -595,7 +590,8 @@ fn parse_subschema(
     }
 }
 
-/// Parse a non-empty array of subschemas (`allOf`, `anyOf`, `oneOf`).
+/// Read the nested schemas of `allOf`, `anyOf`, or `oneOf`, of which there must
+/// be at least one.
 fn parse_subschema_array(
     obj: &Map<String, Value>,
     key: &str,
@@ -706,7 +702,7 @@ fn escape_pointer(segment: &str) -> String {
     segment.replace('~', "~0").replace('/', "~1")
 }
 
-// ---------- validation ----------
+// Validation
 
 impl Node {
     fn check(&self, instance: &Value, instance_path: &str, out: &mut Vec<SchemaViolation>) {
@@ -994,7 +990,7 @@ mod tests {
     use super::*;
     use serde_json::json;
 
-    // ---------- parse errors ----------
+    // Parse errors
 
     #[test]
     fn parse_rejects_malformed_schema() {
@@ -1048,7 +1044,7 @@ mod tests {
         assert!(err.message.contains("oneOf"));
     }
 
-    // ---------- type ----------
+    // Type
 
     #[test]
     fn validate_type_rejects_wrong_kind() {
@@ -1086,7 +1082,7 @@ mod tests {
         assert!(schema.validate(json!("anything")).is_err());
     }
 
-    // ---------- enum / const ----------
+    // Enum / const
 
     #[test]
     fn validate_enum_rejects_value_not_in_list() {
@@ -1102,7 +1098,7 @@ mod tests {
         assert!(schema.validate(json!(43)).is_err());
     }
 
-    // ---------- object ----------
+    // Object
 
     #[test]
     fn validate_passes_conforming_object() {
@@ -1161,7 +1157,7 @@ mod tests {
         assert!(violations.iter().any(|v| v.message.contains("`y`")));
     }
 
-    // ---------- array ----------
+    // Array
 
     #[test]
     fn validate_items_schema_validates_each_element() {
@@ -1193,7 +1189,7 @@ mod tests {
             .any(|v| v.schema_path.ends_with("/maxItems")));
     }
 
-    // ---------- string ----------
+    // String
 
     #[test]
     fn validate_string_length_bounds() {
@@ -1226,7 +1222,7 @@ mod tests {
         assert!(schema.validate(json!(42)).is_ok());
     }
 
-    // ---------- number ----------
+    // Number
 
     #[test]
     fn validate_minimum_and_maximum_bounds() {
@@ -1236,7 +1232,7 @@ mod tests {
         assert!(schema.validate(json!(11)).is_err());
     }
 
-    // ---------- logical combinators ----------
+    // Logical combinators
 
     #[test]
     fn validate_all_of_passes_when_all_schemas_match() {
@@ -1316,7 +1312,7 @@ mod tests {
         assert!(violations.iter().any(|v| v.schema_path.ends_with("/not")));
     }
 
-    // ---------- if / then / else ----------
+    // If / then / else
 
     #[test]
     fn validate_if_then_applies_then_when_if_passes() {
@@ -1351,7 +1347,7 @@ mod tests {
         assert!(schema.validate(json!(42)).is_ok());
     }
 
-    // ---------- decode fallback ----------
+    // Decode fallback
 
     #[test]
     fn validate_returns_a_conforming_value_unchanged() {
@@ -1396,7 +1392,7 @@ mod tests {
         assert!(schema.validate(json!(42)).is_err());
     }
 
-    // ---------- serde / clone ----------
+    // Serde / clone
 
     #[test]
     fn clone_shares_compiled_state() {
@@ -1436,7 +1432,7 @@ mod tests {
         assert!(none.is_none());
     }
 
-    // ---------- SchemaViolations display (agent-facing feedback) ----------
+    // SchemaViolations display (agent-facing feedback)
 
     #[test]
     fn violations_display_renders_one_line_per_violation() {

--- a/crates/agentwerk/src/tools/bash.rs
+++ b/crates/agentwerk/src/tools/bash.rs
@@ -169,7 +169,7 @@ When issuing multiple commands:
 
 # Anti-patterns
 - Do not sleep between commands that can run immediately.
-- Do not retry failing commands in a sleep loop — diagnose the root cause.
+- Do not retry failing commands in a sleep loop: diagnose the root cause.
 - Do not use interactive flags (-i) as they require input which is not supported.",
             default = Self::DEFAULT_TIMEOUT.as_millis(),
             max = Self::MAX_TIMEOUT.as_millis(),

--- a/crates/agentwerk/src/tools/code.rs
+++ b/crates/agentwerk/src/tools/code.rs
@@ -1,4 +1,4 @@
-//! Grep's code-shape matcher — the `syntax: "code"` mode. Matches by the
+//! Grep's code-shape matcher, the `syntax: "code"` mode. Matches by the
 //! shape of code (`fn $NAME(...)`) rather than by regex, driving the `codegrep`
 //! engine while reusing grep's file walk, output modes, and structured output.
 //! `run` is handed the already-collected file list by `grep::search_corpus`.
@@ -121,7 +121,7 @@ fn line_and_byte_column(content: &str, byte_offset: usize) -> (usize, usize) {
     (line, clamped - line_start + 1)
 }
 
-/// Collapse a matched span onto one line (escaping control chars) and cap it with
+/// Collapse a matched span onto one line (escaping control chars) and limit it with
 /// `grep`'s preview width so code and regex hits truncate alike.
 fn render_summary(substring: &str) -> String {
     let escaped: String = substring

--- a/crates/agentwerk/src/tools/error.rs
+++ b/crates/agentwerk/src/tools/error.rs
@@ -1,4 +1,5 @@
-//! Tool-system errors raised via `Err(...)` — distinct from the in-band `ToolResult::Error(String)` that most tool failures use to signal recoverable problems back to the model.
+//! Errors a tool raises with `Err(...)`, as opposed to the `ToolResult::Error`
+//! most failures use to tell the model what to fix.
 
 use std::fmt;
 

--- a/crates/agentwerk/src/tools/fetch_url.rs
+++ b/crates/agentwerk/src/tools/fetch_url.rs
@@ -111,7 +111,7 @@ impl ToolLike for FetchUrlTool {
     }
 }
 
-// -- Fetching -----------------------------------------------------------------
+// Fetching
 
 enum FetchedContent {
     Page {
@@ -211,7 +211,7 @@ fn format_output(
     output
 }
 
-// -- Redirect safety ----------------------------------------------------------
+// Redirect safety
 
 enum FollowResult {
     Ok(reqwest::Response),
@@ -336,7 +336,7 @@ fn resolve_redirect_location(base_url: &str, location: &str) -> String {
     }
 }
 
-// -- URL validation -----------------------------------------------------------
+// URL validation
 
 fn validate_url(url: &str) -> std::result::Result<String, String> {
     if url.len() > MAX_URL_LENGTH {
@@ -370,7 +370,7 @@ fn validate_url(url: &str) -> std::result::Result<String, String> {
     Ok(url.to_string())
 }
 
-// -- HTML-to-text -------------------------------------------------------------
+// HTML-to-text
 
 fn strip_html(html: &str) -> String {
     let mut text = String::with_capacity(html.len());
@@ -471,13 +471,13 @@ fn collapse_whitespace(text: &str) -> String {
     result.trim().to_string()
 }
 
-// -- Tests --------------------------------------------------------------------
+// Tests
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    // -- URL validation -------------------------------------------------------
+    // URL validation
 
     #[test]
     fn validate_url_valid_https() {
@@ -541,7 +541,7 @@ mod tests {
         assert!(err.contains("Unsupported scheme"));
     }
 
-    // -- Redirect safety ------------------------------------------------------
+    // Redirect safety
 
     #[test]
     fn redirect_same_host_permitted() {
@@ -623,7 +623,7 @@ mod tests {
         ));
     }
 
-    // -- Redirect resolution --------------------------------------------------
+    // Redirect resolution
 
     #[test]
     fn resolve_absolute_redirect() {
@@ -665,7 +665,7 @@ mod tests {
         );
     }
 
-    // -- HTML stripping -------------------------------------------------------
+    // HTML stripping
 
     #[test]
     fn strip_html_basic() {

--- a/crates/agentwerk/src/tools/grep.rs
+++ b/crates/agentwerk/src/tools/grep.rs
@@ -1,8 +1,5 @@
-//! Content search across a corpus, powered by ripgrep's engine (the `grep` and
-//! `ignore` crates) in-process. The `pattern` is a regular expression, matched
-//! the same way `rg pattern` would. The primary locate-where primitive: find
-//! where a pattern is mentioned before opening any single item. Read-only,
-//! bounded, and parallel-callable.
+//! Lets an agent search file contents by regular expression, so it can find
+//! where something is mentioned before opening any one file.
 
 use std::future::Future;
 use std::path::{Path, PathBuf};

--- a/crates/agentwerk/src/tools/manage_knowledge.rs
+++ b/crates/agentwerk/src/tools/manage_knowledge.rs
@@ -1,6 +1,5 @@
-//! `ManageKnowledgeTool`: the model's interface to a `Knowledge` store.
-//! The store lives in `agents::knowledge`; this file only wraps it
-//! with a `ToolLike` impl driven by the declarative `manage_knowledge.tool.md`.
+//! Lets an agent write, read, remove, and list the knowledge it shares across
+//! tickets and with other agents.
 
 use std::future::Future;
 use std::pin::Pin;
@@ -56,7 +55,7 @@ fn description() -> &'static str {
 fn usage_line(message: &str, store: &Knowledge) -> String {
     let (used, limit, pages) = store.index_usage();
     let pct = if limit > 0 { (used * 100) / limit } else { 0 };
-    format!("{message} ({pages} pages, {pct}% — {used}/{limit} chars)")
+    format!("{message} ({pages} pages, {pct}%, {used}/{limit} chars)")
 }
 
 impl ToolLike for ManageKnowledgeTool {
@@ -146,7 +145,7 @@ impl ToolLike for ManageKnowledgeTool {
                         Err(_) => {
                             record(EventKind::KnowledgeMissed);
                             Ok(ToolResult::success(format!(
-                                "No page found for `{slug}`. Check the knowledge index before reading — only slugs listed there exist."
+                                "No page found for `{slug}`. Check the knowledge index before reading: only slugs listed there exist."
                             )))
                         }
                     }

--- a/crates/agentwerk/src/tools/mod.rs
+++ b/crates/agentwerk/src/tools/mod.rs
@@ -1,5 +1,4 @@
-//! Tool system: the `ToolLike` trait, the ad-hoc `Tool` struct, and the
-//! registry agentwerk consults before each provider call.
+//! The actions agents can take to perform their work.
 
 mod error;
 mod tool;

--- a/crates/agentwerk/src/tools/read_file.rs
+++ b/crates/agentwerk/src/tools/read_file.rs
@@ -89,7 +89,7 @@ impl ToolLike for ReadFileTool {
             let content = match std::fs::read(&resolved) {
                 Ok(bytes) => {
                     // A NUL byte marks a true binary (image, archive, compiled
-                    // object); text — even minified or lightly obfuscated — never
+                    // object); text, even minified or lightly obfuscated, never
                     // contains one. Report it concisely instead of dumping decoded
                     // garbage that floods the transcript and breaks strict chat
                     // templates. Otherwise decode lossily so odd-encoded source

--- a/crates/agentwerk/src/tools/tickets/finish.rs
+++ b/crates/agentwerk/src/tools/tickets/finish.rs
@@ -1,9 +1,5 @@
-//! Single-purpose tool for finishing a ticket. Validates the agent's
-//! result against the ticket's schema (when set), appends an NDJSON
-//! line to `<dir>/results.jsonl`, attaches the `TicketResult`
-//! to the ticket, and transitions the ticket to `Finished`. An optional
-//! `handover` additionally inserts a child ticket pinned to the named
-//! agent or scope, so finishing and chaining happen in one call.
+//! Lets an agent write the result for its ticket and mark it finished, handing
+//! the work on to another agent in the same call when it needs to.
 
 use std::future::Future;
 use std::pin::Pin;
@@ -501,7 +497,7 @@ mod tests {
         assert_eq!(seen_tickets, expected_keys);
     }
 
-    // ---- handover ----
+    // Handover
 
     fn one_ticket_in(agent: &str, dir: PathBuf) -> (Arc<TicketSystem>, String) {
         let sys = TicketSystem::new();
@@ -925,7 +921,7 @@ mod tests {
     #[tokio::test]
     async fn substitution_is_single_pass() {
         // A `result` that itself contains the literal text `{parent_key}`
-        // must NOT be re-expanded — the substitution pass runs once
+        // must NOT be re-expanded: the substitution pass runs once
         // per placeholder, not recursively.
         let dir = crate::test_util::TempDir::new().unwrap();
         let (sys, parent_key) = one_ticket_in("alice", dir.path().to_path_buf());

--- a/crates/agentwerk/src/tools/tickets/manage_tickets.rs
+++ b/crates/agentwerk/src/tools/tickets/manage_tickets.rs
@@ -1,5 +1,4 @@
-//! Read + write access to the surrounding ticket queue:
-//! `get`, `list`, `search`, `create`, `edit`.
+//! Lets an agent read the ticket queue and create or edit tickets in it.
 
 use std::future::Future;
 use std::pin::Pin;

--- a/crates/agentwerk/src/tools/tickets/mod.rs
+++ b/crates/agentwerk/src/tools/tickets/mod.rs
@@ -1,8 +1,5 @@
-//! Ticket tools: give an agent a call surface for reading and mutating
-//! the surrounding `TicketSystem`. Two multi-action tools share one
-//! dispatch helper: `ReadTicketsTool` (read-only) and `ManageTicketsTool`
-//! (read + write). `FinishTool` (`finish`) is the sole way for an agent to
-//! finish its current ticket, with or without chaining a follow-up.
+//! The tools an agent reaches its own ticket queue through: reading it, adding
+//! to it, and finishing the ticket it holds.
 
 use serde_json::Value;
 
@@ -169,7 +166,7 @@ fn render_summary_list(tickets: &[SummaryRow<'_>]) -> String {
             format!("[{}] ", labels.join(","))
         };
         out.push_str(&format!(
-            "- {key} [{status}] {labels_label}— {task_preview}\n",
+            "- {key} [{status}] {labels_label}{task_preview}\n",
             status = status_label(*status),
         ));
     }

--- a/crates/agentwerk/src/tools/tickets/read_tickets.rs
+++ b/crates/agentwerk/src/tools/tickets/read_tickets.rs
@@ -1,4 +1,4 @@
-//! Read-only access to the surrounding ticket queue.
+//! Lets an agent read the ticket queue.
 
 use std::future::Future;
 use std::pin::Pin;

--- a/crates/agentwerk/src/tools/tool.rs
+++ b/crates/agentwerk/src/tools/tool.rs
@@ -1,4 +1,4 @@
-//! Core tool infrastructure: the `ToolLike` trait, the ad-hoc `Tool` struct, and the registry agentwerk consults before each provider call.
+//! The actions agents can take, and the registry an agent's tools live in.
 
 use std::collections::HashSet;
 use std::future::Future;
@@ -17,36 +17,32 @@ use crate::providers::{ProviderResult, ProviderToolDefinition};
 
 use super::error::ToolError;
 
-/// Per-tool ceiling on tool-result bytes. Outputs larger than this are
-/// offloaded to `<ticket-dir>/outputs/<tool_use_id>.txt` and replaced
-/// with a stub. ~12.5K tokens at the `bytes/4` estimator.
+/// The largest result one tool may return. Anything longer is written to
+/// `<ticket-dir>/outputs/<tool_use_id>.txt` and replaced with a short stub.
+/// Roughly 12 500 tokens.
 const PER_TOOL_CAP: usize = 50_000;
 
-/// Aggregate ceiling on a single turn's tool-result bytes. When parallel
-/// tools each return moderate but legal sizes, this cap offloads the
-/// largest until the turn is under budget. ~50K tokens.
+/// The largest total one turn's tool results may reach. When several tools each
+/// return an acceptable size, the largest are written out until the turn fits.
+/// Roughly 50 000 tokens.
 const PER_TURN_CAP: usize = 200_000;
 
-/// Bytes of original output retained in the stub preview. Snapped to
-/// the last newline within the window when one exists, otherwise
-/// floored to a UTF-8 boundary so multi-byte code points are never
-/// split.
+/// How much of the original output the stub still shows. It ends at the last
+/// newline in that window, or at a character boundary, so a multi-byte
+/// character is never cut in half.
 const PREVIEW_CHARS: usize = 2_000;
 
-/// Runtime context passed to a tool handler.
+/// What a tool receives when it runs.
 ///
-/// External tool authors use exactly three things:
+/// Writing your own tool, you need three of these:
 /// - `dir`: the agent's working directory.
-/// - `interrupt_signal`: set to true when agentwerk is shutting down.
-/// - `wait_for_cancel()`: resolves when the current call is cancelled.
+/// - `interrupt_signal`: true once agentwerk is shutting down.
+/// - `wait_for_cancel()`: finishes when the current call is cancelled.
 ///
-/// The remaining fields (`tool_registry`, ticket-side state, knowledge handle)
-/// are wired by agentwerk and consumed only by the built-in `FindToolsTool`
-/// and the ticket tools.
+/// agentwerk fills in the rest for the built-in tools.
 #[derive(Clone)]
 pub struct ToolContext {
-    /// Directory the tool runs in. Tools that touch the filesystem
-    /// should resolve relative paths against this.
+    /// Directory the tool runs in. Resolve a relative path against it.
     pub dir: PathBuf,
     pub interrupt_signal: Arc<AtomicBool>,
     pub(crate) tool_registry: Option<Arc<ToolRegistry>>,
@@ -57,10 +53,9 @@ pub struct ToolContext {
 }
 
 impl ToolContext {
-    /// A fresh context rooted at `dir`, with no registry handle and
-    /// a fresh never-firing cancel signal. Tools that search the registry
-    /// need a context agentwerk installs at call time; bare contexts are
-    /// for standalone use and tests.
+    /// A context rooted at `dir` that is never cancelled and knows about no
+    /// other tools. Use it standalone or in tests; agentwerk installs its own at
+    /// call time.
     pub fn new(dir: PathBuf) -> Self {
         Self {
             dir,
@@ -73,8 +68,8 @@ impl ToolContext {
         }
     }
 
-    /// Override the cancel signal — typically the one shared by the
-    /// `TicketSystem` so tools cooperate with run-level cancellation.
+    /// Use a different cancel signal, usually the one the `TicketSystem`
+    /// shares, so the tool stops when execution does.
     pub fn interrupt_signal(mut self, signal: Arc<AtomicBool>) -> Self {
         self.interrupt_signal = signal;
         self
@@ -113,11 +108,12 @@ impl ToolContext {
         self.agent_name.as_deref()
     }
 
-    /// Future that resolves once the current run is cancelled. Pair with
-    /// `tokio::select!` to drop the losing branch on cancel; dropped futures
-    /// cascade to `reqwest` aborts and (with `kill_on_drop(true)`) subprocess
-    /// kills. With a fresh context the future stays pending forever and the
-    /// `select!` degrades to a plain await.
+    /// Finishes once execution is cancelled.
+    ///
+    /// Pair it with `tokio::select!` so the losing branch is dropped, which
+    /// aborts an in-flight HTTP request and, with `kill_on_drop(true)`, ends a
+    /// subprocess. On a standalone context it never finishes, and the `select!`
+    /// behaves like a plain await.
     pub async fn wait_for_cancel(&self) {
         const POLL: std::time::Duration = std::time::Duration::from_millis(50);
         loop {
@@ -145,91 +141,87 @@ impl std::fmt::Debug for ToolContext {
     }
 }
 
-/// A tool call extracted from a provider response.
+/// One tool call the model asked for.
 #[derive(Debug, Clone)]
 pub struct ToolCall {
-    /// Provider-assigned call id, echoed back in the tool result block.
+    /// Identifier for this call, sent back with the result.
     pub id: String,
     /// Name of the tool the model chose.
     pub name: String,
-    /// Arguments the model supplied, conforming to the tool's input schema.
+    /// Arguments the model supplied, matching the tool's input schema.
     pub input: Value,
 }
 
-/// Outcome of a tool execution: a success payload, a generic error
-/// message, or a schema-validation failure. All three flow back to
-/// the model as ordinary content blocks; the [`SchemaError`] variant
-/// is distinguished so agentwerk can apply
-/// `policies.max_schema_retries` to it specifically.
+/// What a tool reports back: a result, an error the model should work around,
+/// or a rejection of its input.
+///
+/// All three reach the model the same way. The [`SchemaError`] variant is kept
+/// apart so `max_schema_retries` can govern it.
 ///
 /// [`SchemaError`]: ToolResult::SchemaError
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ToolResult {
-    /// Tool ran and produced this text payload.
+    /// The tool ran and produced this text.
     Success(String),
-    /// Tool failed; the message is shown to the model so it can recover.
+    /// The tool failed, and the message tells the model how to recover.
     Error(String),
-    /// Tool rejected the input because it failed schema validation.
-    /// The message lists the violations so the model can fix them.
+    /// The tool rejected its input, and the message names what was wrong.
     SchemaError(String),
 }
 
 impl ToolResult {
-    /// Build a successful result from a text payload.
+    /// Report a result.
     pub fn success(content: impl Into<String>) -> Self {
         Self::Success(content.into())
     }
 
-    /// Build an error result. The message is visible to the model.
+    /// Report a failure the model should work around.
     pub fn error(content: impl Into<String>) -> Self {
         Self::Error(content.into())
     }
 
-    /// Build a schema-validation failure. Mapped into
-    /// [`ToolError::SchemaValidationFailed`] by the registry and
-    /// counted against `policies.max_schema_retries`.
+    /// Report malformed input. It counts against `max_schema_retries`.
     pub fn schema_error(content: impl Into<String>) -> Self {
         Self::SchemaError(content.into())
     }
 }
 
-/// The core tool interface. Object-safe via boxed futures.
+/// What every tool implements.
 ///
-/// Implement this on any type you want an agent to be able to invoke. For
-/// ad-hoc tools defined inline, use the [`Tool`] struct's builder
-/// (`Tool::new(name, description).schema(...).handler(...)`).
+/// Implement it on any type an agent should be able to call. For a tool defined
+/// inline, use [`Tool`] and its builder instead.
 pub trait ToolLike: Send + Sync {
-    /// Unique name the model uses to call the tool.
+    /// The name the model calls the tool by.
     fn name(&self) -> &str;
 
-    /// Human-readable description shown to the model.
+    /// What the tool does, in the words the model reads.
     fn description(&self) -> &str;
 
     /// JSON Schema describing the tool's arguments.
     fn input_schema(&self) -> Value;
 
-    /// Whether this tool has no side effects. Read-only tools in the same
-    /// turn run concurrently; non-read-only tools run serially. Default: `false`.
+    /// Whether the tool changes nothing. Read-only tools in one turn run at the
+    /// same time; the rest run one after another. `false` by default.
     fn is_read_only(&self) -> bool {
         false
     }
 
-    /// Whether the tool's full definition is hidden until it is discovered
-    /// via `FindToolsTool`. Deferred tools appear to the model as
-    /// name-only stubs. Default: `false`.
+    /// Whether the tool is held back until the agent looks it up with
+    /// `FindToolsTool`, showing only its name until then. `false` by default.
     fn should_defer(&self) -> bool {
         false
     }
 
-    /// The file paths this call opens. Feeds the per-file open tally in
-    /// [`Stats`](crate::Stats). Default: empty (the tool opens no file).
+    /// The file paths this call opens, so they reach
+    /// [`Stats`](crate::Stats). Empty by default.
     fn opened_paths(&self, _input: &Value) -> Vec<String> {
         Vec::new()
     }
 
-    /// Run the tool. The future is held by the agent loop and dropped on
-    /// cancellation; pair long-running work with [`ToolContext::wait_for_cancel`]
-    /// in a `tokio::select!` to drop the losing branch promptly.
+    /// Run the tool.
+    ///
+    /// Cancellation drops the work in progress, so pair anything long-running
+    /// with [`ToolContext::wait_for_cancel`] in a `tokio::select!`.
     fn call<'a>(
         &'a self,
         input: Value,
@@ -237,9 +229,8 @@ pub trait ToolLike: Send + Sync {
     ) -> Pin<Box<dyn Future<Output = ProviderResult<ToolResult>> + Send + 'a>>;
 }
 
-/// Registry of tools available to an agent. Also owns the set of deferred
-/// tools discovered during the run: cloning the registry starts with an
-/// empty set.
+/// The tools one agent may call, plus the held-back tools it has looked up so
+/// far. A copy of the registry starts with none looked up.
 pub(crate) struct ToolRegistry {
     pub(crate) tools: Vec<Arc<dyn ToolLike>>,
     pub(crate) discovered: Mutex<HashSet<String>>,
@@ -264,18 +255,21 @@ impl Default for ToolRegistry {
 }
 
 impl ToolRegistry {
-    /// Add `tool`, replacing any tool already registered under its name. A
-    /// provider rejects a request carrying the same tool name twice, so the
-    /// last registration of a name is the one that counts.
+    /// Register a tool, replacing one already registered under that name.
+    ///
+    /// A request carrying one name twice is rejected, so the last registration
+    /// is the one that counts.
     pub(crate) fn register(&mut self, tool: impl ToolLike + 'static) {
         let tool: Arc<dyn ToolLike> = Arc::new(tool);
         self.tools.retain(|t| t.name() != tool.name());
         self.tools.push(tool);
     }
 
-    /// Look up the tool a call names. An exact name wins; failing that, a
-    /// spelling that folds onto the same key as exactly one registered tool
-    /// resolves to it, so a model that adds a `_tool` suffix still lands.
+    /// Find the tool a call names.
+    ///
+    /// An exact match wins. Otherwise a spelling that reduces to the same key as
+    /// exactly one registered tool resolves to it, so a model that adds a
+    /// `_tool` suffix still reaches the right tool.
     pub(crate) fn get(&self, name: &str) -> Option<Arc<dyn ToolLike>> {
         let name = name.trim();
         if let Some(tool) = self.tools.iter().find(|t| t.name() == name) {
@@ -288,8 +282,8 @@ impl ToolRegistry {
         folded.next().is_none().then(|| Arc::clone(tool))
     }
 
-    /// Registered names, sorted, for the error that names what the model could
-    /// have called instead.
+    /// The registered names, sorted, for the error that tells the model what it
+    /// could have called.
     fn tool_names(&self) -> Vec<String> {
         let mut names: Vec<String> = self.tools.iter().map(|t| t.name().to_string()).collect();
         names.sort();
@@ -300,9 +294,8 @@ impl ToolRegistry {
         self.discovered.lock().unwrap().insert(name.to_string());
     }
 
-    /// Tool definitions sent to the provider. Deferred tools that haven't
-    /// been discovered yet get name-only stubs; all others get full
-    /// definitions.
+    /// The tool definitions sent to the model. A held-back tool the agent has
+    /// not looked up yet appears as its name alone.
     pub(crate) fn definitions(&self) -> Vec<ProviderToolDefinition> {
         let discovered = self.discovered.lock().unwrap();
         self.tools
@@ -325,8 +318,7 @@ impl ToolRegistry {
             .collect()
     }
 
-    /// Search tools by query string. Returns matches sorted by relevance
-    /// (highest first).
+    /// Find tools matching a query, best match first.
     pub(crate) fn search(&self, query: &str) -> Vec<ProviderToolDefinition> {
         let query_lower = query.to_lowercase();
         let mut scored: Vec<(ProviderToolDefinition, u32)> = self
@@ -366,12 +358,10 @@ impl ToolRegistry {
         scored.into_iter().map(|(def, _)| def).collect()
     }
 
-    /// Execute tool calls with concurrent read-only batching and serial
-    /// write execution.
+    /// Run the calls, read-only ones together and the rest one at a time.
     ///
-    /// Returns `(ContentBlock, Result<String, ToolError>, Option<PathBuf>)`
-    /// triples so the caller can read the model-visible result block,
-    /// the typed verdict, and the offload path for oversized outputs.
+    /// Each result carries the block the model sees, the typed outcome, and the
+    /// file an oversized output was written to.
     pub(crate) async fn execute(
         &self,
         calls: &[ToolCall],
@@ -449,10 +439,11 @@ impl Clone for ToolRegistry {
     }
 }
 
-/// Fold a tool name onto the key dispatch matches on, so a model that
-/// capitalizes, hyphenates, or appends `_tool` still reaches the tool. The fold
-/// only ever removes information, so it cannot invent a name that was not asked
-/// for; where two tools share a key, [`ToolRegistry::get`] refuses instead.
+/// Reduce a tool name to the key lookups match on, so capitalization, hyphens,
+/// or a trailing `_tool` still reach the tool.
+///
+/// The reduction only removes information, so it cannot invent a name nobody
+/// asked for. Where two tools share a key, [`ToolRegistry::get`] refuses.
 fn lookup_key(name: &str) -> String {
     let key = name.trim().to_lowercase().replace('-', "_");
     match key.strip_suffix("_tool") {
@@ -470,9 +461,8 @@ type ToolHandler = Box<
         + Sync,
 >;
 
-/// Type-state builder for [`Tool`]. The `<H>` parameter tracks whether a
-/// handler has been installed: `.build()` is only available on
-/// `ToolBuilder<ToolHandler>`, so a handlerless tool cannot reach an agent.
+/// Collects what a [`Tool`] needs. `.build()` exists only once a handler is
+/// installed, so a tool that does nothing cannot reach an agent.
 pub struct ToolBuilder<H> {
     name: String,
     description: String,
@@ -483,8 +473,8 @@ pub struct ToolBuilder<H> {
     handler: H,
 }
 
-/// Ad-hoc tool defined inline with a closure handler. For tools with
-/// complex state, implement [`ToolLike`] directly on your own type instead.
+/// A `Tool` you define inline, for when a whole type would be too much. With
+/// state to carry, implement [`ToolLike`] on your own type instead.
 ///
 /// # Examples
 ///
@@ -519,9 +509,8 @@ pub struct Tool {
 }
 
 impl Tool {
-    /// Entry point for the fluent builder. The returned `ToolBuilder<()>` has
-    /// an empty-object input schema and no handler; install one with
-    /// `.handler(...)` and finalize with `.build()`.
+    /// Start building a tool. Add what it accepts with `.schema(...)`, what it
+    /// does with `.handler(...)`, and finish with `.build()`.
     pub fn new(name: impl Into<String>, description: impl Into<String>) -> ToolBuilder<()> {
         ToolBuilder {
             name: name.into(),
@@ -534,10 +523,9 @@ impl Tool {
         }
     }
 
-    /// Entry point for a builder seeded from a `.tool.md` definition. The
-    /// returned builder has its name, prose description, input schema, and
-    /// read-only flag populated from the markdown; install a handler with
-    /// `.handler(...)` and finalize with `.build()`. Panics on a malformed file.
+    /// Start building a tool from a `.tool.md` definition, which supplies its
+    /// name, description, input schema, and whether it is read-only. Panics when
+    /// the file is malformed.
     pub fn from_tool_file(definition: &str) -> ToolBuilder<()> {
         let tf = super::tool_file::ToolFile::parse(definition);
         Tool::new(tf.name.clone(), tf.render_markdown())
@@ -547,28 +535,28 @@ impl Tool {
 }
 
 impl<H> ToolBuilder<H> {
-    /// Replace the input schema (JSON Schema). Defaults to an empty-object schema.
+    /// Define what the tool accepts, as JSON Schema.
     pub fn schema(mut self, schema: Value) -> Self {
         self.schema = schema;
         self
     }
 
-    /// Mark the tool read-only so agentwerk runs it concurrently with
-    /// other read-only calls in the same turn.
+    /// Let the agent run this tool concurrently with other read-only calls in
+    /// the same turn.
     pub fn read_only(mut self, read_only: bool) -> Self {
         self.read_only = read_only;
         self
     }
 
-    /// Hide the tool's full definition until it is discovered via `FindToolsTool`.
+    /// Hold the tool back until the agent looks it up with `FindToolsTool`.
     pub fn defer(mut self, defer: bool) -> Self {
         self.defer = defer;
         self
     }
 
-    /// Name the input fields holding a file path, so the files this tool opens
-    /// reach [`Stats::file_stats`](crate::Stats::file_stats). A field missing
-    /// from the input, or holding anything but a string, is skipped.
+    /// Name the input fields holding a file path, so the files a call opens are
+    /// included in statistics. A field that is absent or not a string is
+    /// skipped.
     pub fn paths<I, S>(mut self, fields: I) -> Self
     where
         I: IntoIterator<Item = S>,
@@ -580,9 +568,8 @@ impl<H> ToolBuilder<H> {
 }
 
 impl ToolBuilder<()> {
-    /// Install the closure that runs when the model calls this tool. The
-    /// closure may be a bare `async` block: the builder boxes the returned
-    /// future internally.
+    /// Define what runs when the model calls this tool. A bare `async` block
+    /// works.
     pub fn handler<F, Fut>(self, f: F) -> ToolBuilder<ToolHandler>
     where
         F: Fn(Value, ToolContext) -> Fut + Send + Sync + 'static,
@@ -601,7 +588,7 @@ impl ToolBuilder<()> {
 }
 
 impl ToolBuilder<ToolHandler> {
-    /// Produce the final `Tool` ready for `Agent::tool(...)`.
+    /// Create the tool, ready for `Agent::tool(...)`.
     pub fn build(self) -> Tool {
         Tool {
             name: self.name,
@@ -683,10 +670,8 @@ async fn invoke(
     }
 }
 
-/// Substitute a placeholder when a tool returns an empty success
-/// payload. Empty `tool_result.content` has triggered provider sampling
-/// edge cases; the placeholder keeps the assistant turn well-formed.
-/// Errors and non-empty successes pass through.
+/// Put a placeholder in place of an empty result, since empty content has upset
+/// LLM providers. Everything else passes through.
 fn replace_empty_output(
     outcome: std::result::Result<String, ToolError>,
     tool_name: &str,
@@ -741,13 +726,11 @@ fn partition_tool_calls(calls: &[ToolCall], registry: &ToolRegistry) -> Vec<Tool
     batches
 }
 
-/// Replace `Ok(s)` with a stub when `s.len()` exceeds `per_tool_cap`,
-/// persisting the original output under the ticket's outputs folder.
-/// Returns the outcome plus the persisted file path (when offload
-/// happened). `Err(_)` outcomes pass through: tool errors are short by
-/// construction and never need offloading. When persistence fails (no
-/// ticket bound, write error), the raw content passes through
-/// unstubbed.
+/// Replace an oversized result with a stub, writing the original under the
+/// ticket's outputs directory and reporting where it went.
+///
+/// An error passes through, being short by construction, and so does the raw
+/// content when the write fails.
 fn cap_oversized_result(
     outcome: std::result::Result<String, ToolError>,
     ctx: &ToolContext,
@@ -768,11 +751,9 @@ fn cap_oversized_result(
     }
 }
 
-/// Aggregate-cap pass: while the total `ContentBlock::ToolResult` bytes
-/// in `results` exceed `per_turn_cap`, replace the largest non-stub
-/// result with a stub. Stops when no further offload would help (either
-/// the cap is met or persistence has failed for every remaining
-/// candidate).
+/// While one turn's results are too large together, write out the largest that
+/// is not already a stub. It stops once the turn fits, or once nothing left can
+/// be written out.
 fn cap_aggregate_outputs(
     results: &mut [(
         ContentBlock,
@@ -837,12 +818,11 @@ fn cap_aggregate_outputs(
     }
 }
 
-/// Offload `content` to the ticket's outputs folder via the bound
-/// `TicketSystem`. Returns the path relative to the tickets dir (for
-/// the comment transcript) and the on-disk path (for the model-facing
-/// stub); `None` when no ticket key is present on the context, no
-/// ticket system is bound, or the write fails. Best-effort, matching
-/// the surrounding observational-persistence contract.
+/// Write `content` under the ticket's outputs directory, reporting both the
+/// path relative to the session and the path on disk.
+///
+/// `None` when the context names no ticket, no ticket system is attached, or
+/// the write fails. Like the rest of the logging, it is best effort.
 fn persist_output(ctx: &ToolContext, tool_use_id: &str, content: &str) -> Option<PersistedOutput> {
     let system = ctx.ticket_system.as_ref()?;
     let key = ctx.ticket_key.as_deref()?;
@@ -859,9 +839,8 @@ struct PersistedOutput {
 const OVERSIZED_STUB_TAG_OPEN: &str = "<persisted-output>";
 const OVERSIZED_STUB_TAG_CLOSE: &str = "</persisted-output>";
 
-/// Render the stub the model sees in place of an oversized tool result.
-/// Wraps the size summary, the offload path, and a leading preview in
-/// `<persisted-output>...</persisted-output>` tags.
+/// Build the stub the model sees in place of an oversized result: how large it
+/// was, where it went, and how it starts.
 fn format_oversized_tool_result(original_len: usize, path: &Path, preview: &str) -> String {
     let size = format_bytes(original_len);
     let preview_size = format_bytes(preview.len());
@@ -874,11 +853,11 @@ fn format_oversized_tool_result(original_len: usize, path: &Path, preview: &str)
     )
 }
 
-/// Return a leading slice of `content` up to `PREVIEW_CHARS` bytes, snapped to
-/// the last newline within that window, or to a UTF-8 char boundary when no
-/// newline is present. The window is floored to a char boundary first, since
-/// `PREVIEW_CHARS` can land inside a multibyte char (binary tool output) and
-/// slicing there would panic.
+/// The first `PREVIEW_CHARS` bytes of `content`, ending at the last newline in
+/// that window or at a character boundary.
+///
+/// The window is moved to a character boundary first: `PREVIEW_CHARS` can land
+/// inside a multi-byte character, and slicing there would panic.
 fn truncate_preview(content: &str) -> &str {
     let window = utf8_boundary_floor(content, PREVIEW_CHARS.min(content.len()));
     let cut = content[..window]
@@ -900,9 +879,7 @@ fn format_bytes(n: usize) -> String {
     }
 }
 
-/// Floor an index to the largest UTF-8 char boundary `<= i`. Cheap when
-/// `i` already lands on a boundary; otherwise scans back at most three
-/// bytes.
+/// Move an index back to the nearest character boundary, at most three bytes.
 fn utf8_boundary_floor(s: &str, mut i: usize) -> usize {
     while i > 0 && !s.is_char_boundary(i) {
         i -= 1;
@@ -914,9 +891,8 @@ fn utf8_boundary_floor(s: &str, mut i: usize) -> usize {
 mod tests {
     use super::*;
 
-    /// Every built-in `.tool.md` must parse. Instantiating each tool and
-    /// reading its name, description, and schema forces `ToolFile::parse`, so
-    /// a malformed definition fails here rather than at the first model call.
+    /// Every built-in `.tool.md` must parse. Reading each tool's name,
+    /// description, and schema forces that here, rather than at the first call.
     #[test]
     fn every_builtin_tool_definition_parses() {
         let dir = crate::test_util::TempDir::new().unwrap();
@@ -973,7 +949,7 @@ mod tests {
         assert_eq!(tool.opened_paths(&input), vec!["src/lib.rs".to_string()]);
     }
 
-    /// Tiny mock used across registry tests.
+    /// The mock the registry tests share.
     struct MockTool {
         name: String,
         read_only: bool,
@@ -1292,7 +1268,7 @@ Do the demo thing.
         assert!(tool.should_defer());
     }
 
-    // ---- Layer 1: result-cap helpers ----
+    // Layer 1: result-cap helpers
 
     fn ticket_ctx() -> (
         ToolContext,

--- a/crates/agentwerk/src/tools/tool_file.rs
+++ b/crates/agentwerk/src/tools/tool_file.rs
@@ -1,7 +1,5 @@
-//! Single-file tool definition in markdown: `---` frontmatter (`name`,
-//! `read_only`), a free-form prose body shown to the model, and a `## Schema`
-//! section whose ` ```json ` fence holds the JSON Schema. Parsed once and
-//! handed to the `ToolLike` impl that includes it.
+//! Reads a tool's whole definition out of one markdown file: its name, what the
+//! model is told it does, and what it accepts.
 
 use serde_json::Value;
 

--- a/crates/agentwerk/src/tools/util.rs
+++ b/crates/agentwerk/src/tools/util.rs
@@ -1,4 +1,4 @@
-//! Shared helpers for the file and shell tools — glob matching and process invocation.
+//! Glob matching and process invocation, shared by the file and shell tools.
 
 use std::path::{Path, PathBuf};
 use std::time::Duration;
@@ -71,7 +71,7 @@ fn glob_match_bytes(pattern: &[u8], text: &[u8]) -> bool {
     }
 }
 
-/// Cap on entries listed for a directory. A package dir can hold thousands of
+/// Limit on entries listed for a directory. A package directory can hold thousands of
 /// files; an unbounded list would flood the model's context.
 pub(crate) const MAX_DIR_ENTRIES: usize = 100;
 
@@ -106,8 +106,8 @@ fn nearest_existing_dir(path: &Path) -> Option<&Path> {
 }
 
 /// Recovery tail appended to a not-found error from a file tool. Prefers listing
-/// the directory the model is guessing into — when it lies within the working
-/// directory — so a wrong guess becomes the real directory contents next turn.
+/// the directory the model is guessing into, when that lies within the working
+/// directory, so a wrong guess becomes the real directory contents next turn.
 /// Falls back to echoing the working directory plus a dropped-folder suggestion
 /// for paths that escape it.
 pub(crate) fn not_found_hint(ctx_dir: &Path, resolved: &Path) -> String {

--- a/crates/agentwerk/tests/integration/bash_usage.rs
+++ b/crates/agentwerk/tests/integration/bash_usage.rs
@@ -1,5 +1,5 @@
 //! End-to-end: a real LLM drives three pattern-restricted `BashTool`
-//! commands (`ls`, `cat`, `wc`) and settles its ticket with a
+//! commands (`ls`, `cat`, `wc`) and finishes its ticket with a
 //! JSON result validated against the ticket schema.
 
 use super::common;

--- a/crates/agentwerk/tests/integration/compaction.rs
+++ b/crates/agentwerk/tests/integration/compaction.rs
@@ -1,4 +1,4 @@
-//! Summariser smoke-test: the configured 4 096-token window makes
+//! Core check on summarizing: the configured 4 096-token window makes
 //! `compaction_threshold` saturate to 0, so proactive compaction fires
 //! between turns. The loop calls compact and the summariser must return
 //! non-empty text. The ticket does not need to complete: verifying the
@@ -68,7 +68,7 @@ pub async fn process_order(order: Order, ctx: Arc<AppContext>) -> Result<Receipt
     // Write receipt to DB.
     let receipt = ctx.db.insert_receipt(&charge).await?;
 
-    // Notify audit log — fire and forget.
+    // Notify audit log, fire and forget.
     let audit_tx = ctx.audit_tx.clone();
     tokio::spawn(async move {
         // BUG CANDIDATE: audit_tx is an unbounded channel created once at
@@ -88,7 +88,7 @@ pub async fn run_loop(mut rx: mpsc::Receiver<AuditEvent>) {
         // Writes to Postgres. Under load this blocks the receiver.
         if let Err(e) = db_write_audit(&event).await {
             error!('audit write failed: {e}');
-            // ERROR: receiver just fell behind — channel keeps filling.
+            // ERROR: receiver just fell behind, channel keeps filling.
         }
     }
 }
@@ -173,7 +173,7 @@ async fn summariser_produces_text_when_compaction_fires_against_live_llm() {
     );
     assert!(
         compaction_succeeded,
-        "CompactionFinished must fire — summariser must return text"
+        "CompactionFinished must fire: summariser must return text"
     );
 
     // The summary replaces all non-system comments in the ticket. Verify
@@ -206,7 +206,7 @@ async fn summariser_produces_text_when_compaction_fires_against_live_llm() {
     // `reset_usage` runs inside `summarize`, so the per-ticket history
     // can hold at most the entries recorded *after* compaction committed
     // (turn 2's reply). Without the reset, the pre-compaction entry
-    // would still be there too — length would be 2.
+    // would still be there too, length would be 2.
     for ticket in tickets.tickets() {
         let history = tickets.stats().usage_history(&ticket.key);
         assert!(

--- a/crates/agentwerk/tests/integration/edit_file_replaces_content.rs
+++ b/crates/agentwerk/tests/integration/edit_file_replaces_content.rs
@@ -32,7 +32,7 @@ async fn replaces_substring_in_place() -> std::result::Result<(), Box<dyn std::e
              Step 1: call `edit_file` to perform an exact substring \
              replacement in the existing file. Do not rewrite the whole file. \
              Step 2: immediately call `finish` to settle the \
-             ticket. Do not write any prose — your only output must be tool \
+             ticket. Do not write any prose: your only output must be tool \
              calls.",
         )
         .tool(EditFileTool)

--- a/crates/agentwerk/tests/integration/find_tools_discovers_deferred.rs
+++ b/crates/agentwerk/tests/integration/find_tools_discovers_deferred.rs
@@ -1,7 +1,7 @@
 //! End-to-end: a tool is deferred, so the model sees only its name (empty
 //! description, empty schema) in its definitions. A real LLM calls `find_tools`
 //! to surface it, and we assert the tool's *output* carries the deferred tool's
-//! full definition — name, the description (with its passphrase), and the
+//! full definition: name, the description (with its passphrase), and the
 //! `passphrase` schema field that were all hidden until discovery. Tests that
 //! `find_tools` renders a deferred definition the model could not otherwise see.
 
@@ -28,7 +28,7 @@ async fn surfaces_a_deferred_tool_definition() -> std::result::Result<(), Box<dy
 
     // Deferred: the model sees only the name `vault_unlock_tool` until it runs
     // `find_tools`. The passphrase lives in the description and the `passphrase`
-    // field lives in the schema — both hidden until surfaced.
+    // field lives in the schema: both hidden until surfaced.
     let vault = Tool::new(
         "vault_unlock_tool",
         "Unlock the vault. Required: pass `passphrase` set to exactly `open-sesame`.",

--- a/crates/agentwerk/tests/integration/glob_finds_nested_files.rs
+++ b/crates/agentwerk/tests/integration/glob_finds_nested_files.rs
@@ -2,7 +2,7 @@
 //! nested project tree. The role does NOT name `glob` and does NOT
 //! describe its argument shape. Proves the tool's *description* is good
 //! enough for a model to (1) pick filename pattern matching, and (2)
-//! produce a recursive `**/lib.rs` pattern instead of a flat `*.rs` —
+//! produce a recursive `**/lib.rs` pattern instead of a flat `*.rs`,
 //! which would miss every nested file.
 
 use std::fs;
@@ -93,7 +93,7 @@ async fn finds_every_lib_rs_in_nested_tree() -> std::result::Result<(), Box<dyn 
             .role(
                 "{context}\n\n\
                  Investigate the working directory and answer the user's question. \
-                 Use the available tools — pick whichever one fits the question. \
+                 Use the available tools: pick whichever one fits the question. \
                  When you have the answer, settle the ticket via \
                  `finish`.",
             )
@@ -112,7 +112,7 @@ async fn finds_every_lib_rs_in_nested_tree() -> std::result::Result<(), Box<dyn 
 
     let recorded = calls.lock().unwrap().clone();
 
-    // The model must call glob with a recursive pattern (`**`) — a
+    // The model must call glob with a recursive pattern (`**`), since a
     // flat `*.rs` would miss every nested file. Either `**/lib.rs` (tight)
     // or `**/*.rs` (broad, then filter) is acceptable; both prove the
     // model picked up `**` semantics from the description.
@@ -136,7 +136,7 @@ async fn finds_every_lib_rs_in_nested_tree() -> std::result::Result<(), Box<dyn 
             )
         });
 
-    // The tool's output must contain every nested `lib.rs` — proves the
+    // The tool's output must contain every nested `lib.rs`, which proves the
     // model's `**` pattern actually exercised the recursion through two
     // levels of nesting (`crate_b/src/internal/lib.rs`).
     let output = glob_call

--- a/crates/agentwerk/tests/integration/grep_content_output.rs
+++ b/crates/agentwerk/tests/integration/grep_content_output.rs
@@ -1,5 +1,5 @@
 //! End-to-end: a real LLM agent is asked to locate a unique string
-//! buried deep inside a long line — past column 100. The role does NOT
+//! buried deep inside a long line, past column 100. The role does NOT
 //! hint at grep or content mode. Proves the agent can find the match
 //! and that `grep` reports the correct column position.
 
@@ -29,7 +29,7 @@ async fn finds_string_buried_deep_in_line() -> std::result::Result<(), Box<dyn s
     let root = dir.path();
     fs::create_dir_all(root.join("src"))?;
 
-    // Decoy files — none containing the needle.
+    // Decoy files, none containing the needle.
     fs::write(root.join("src/main.rs"), "fn main() { run(); }\n")?;
     fs::write(root.join("src/server.rs"), "pub fn run() { loop {} }\n")?;
 
@@ -91,7 +91,7 @@ async fn finds_string_buried_deep_in_line() -> std::result::Result<(), Box<dyn s
             .role(
                 "{context}\n\n\
                  Investigate the working directory and answer the user's question. \
-                 Use the available tools — pick whichever one fits. \
+                 Use the available tools: pick whichever one fits. \
                  When you have the answer, settle the ticket via \
                  `finish`.",
             )
@@ -233,7 +233,7 @@ async fn reads_column_slice_after_grep_locates_needle(
             .role(
                 "{context}\n\n\
                  Investigate the working directory and answer the user's question. \
-                 Use the available tools — pick whichever one fits. \
+                 Use the available tools: pick whichever one fits. \
                  When you have the answer, settle the ticket via \
                  `finish`.",
             )

--- a/crates/agentwerk/tests/integration/grep_finds_by_shape.rs
+++ b/crates/agentwerk/tests/integration/grep_finds_by_shape.rs
@@ -1,6 +1,6 @@
 //! End-to-end: a real LLM is given only `grep` and asked to list function
 //! names it cannot know in advance. Proves `grep` answers a find-by-shape
-//! question end-to-end — the model locates the definitions and reports the
+//! question end-to-end: the model locates the definitions and reports the
 //! names. (The code `syntax` is exercised directly in the unit tests; a
 //! live model tends to reach for a regex `grep` here, and that is fine.)
 

--- a/crates/agentwerk/tests/integration/grep_finds_code_pattern.rs
+++ b/crates/agentwerk/tests/integration/grep_finds_code_pattern.rs
@@ -103,7 +103,7 @@ async fn finds_code_pattern_with_special_chars(
             .role(
                 "{context}\n\n\
                  Investigate the working directory and answer the user's question. \
-                 Use the available tools — pick whichever one fits the question. \
+                 Use the available tools: pick whichever one fits the question. \
                  When you have the answer, settle the ticket via \
                  `finish`.",
             )
@@ -125,7 +125,7 @@ async fn finds_code_pattern_with_special_chars(
 
     // The model must have located the signature with `grep`: a call whose output
     // names calc.rs. Under a regex `pattern`, that hit is only reachable if the
-    // model escaped the `(` and `)` — left raw they are groups and match nothing.
+    // model escaped the `(` and `)`: left raw they are groups and match nothing.
     let grep_hit = recorded
         .iter()
         .find(|c| {

--- a/crates/agentwerk/tests/integration/manage_tickets_creates_ticket.rs
+++ b/crates/agentwerk/tests/integration/manage_tickets_creates_ticket.rs
@@ -1,6 +1,6 @@
 //! End-to-end: a real LLM uses `manage_tickets` with `action: "create"`
 //! to add a new ticket to the queue. We verify a fresh ticket landed carrying
-//! the requested body — the queue state is the assertion. The role does not
+//! the requested body: the queue state is the assertion. The role does not
 //! name the action shape; the tool's description must carry it.
 
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -49,8 +49,8 @@ async fn creates_a_followup_ticket() -> std::result::Result<(), Box<dyn std::err
     );
 
     // A new ticket must carry the token. The agent's own ticket holds the
-    // instruction; the created one is any other ticket whose task — string or
-    // structured JSON — mentions the token. The exact body shape is the
+    // instruction; the created one is any other ticket whose task, string or
+    // structured JSON, mentions the token. The exact body shape is the
     // model's choice and not what this test pins down.
     let created = tickets.tickets().into_iter().find(|t| {
         t.task.as_str() != Some(instruction.as_str()) && t.task.to_string().contains(&body)

--- a/crates/agentwerk/tests/integration/read_tickets_finds_seeded.rs
+++ b/crates/agentwerk/tests/integration/read_tickets_finds_seeded.rs
@@ -2,7 +2,7 @@
 //! not own and report a secret recorded only in that ticket's body. The secret
 //! is absent from the agent's own task, so a correct answer proves the model
 //! read the queue. The seeded ticket carries a label the agent does not handle,
-//! so it stays `Todo` and unclaimed — readable but never executed.
+//! so it stays `Todo` and unclaimed: readable but never executed.
 
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 

--- a/crates/agentwerk/tests/integration/seeker_finds_planted.rs
+++ b/crates/agentwerk/tests/integration/seeker_finds_planted.rs
@@ -188,12 +188,12 @@ async fn seeker_pool_finds_planted_indicators(
     );
 
     let named_threats = [
-        "technology: Python\nobserved: app.py — a request handler evals a caller-supplied \
+        "technology: Python\nobserved: app.py, a request handler evals a caller-supplied \
          argument, execs a base64-decoded blob, and posts to a raw IP over HTTP\nhypothesis: \
          dynamic code execution chained into network exfiltration",
-        "technology: JavaScript\nobserved: index.js — a function evals its own input parameter \
+        "technology: JavaScript\nobserved: index.js, a function evals its own input parameter \
          and beacons to a raw IP\nhypothesis: dynamic code execution paired with C2 beaconing",
-        "technology: Rust\nobserved: lib.rs — a function spawns an external command against a \
+        "technology: Rust\nobserved: lib.rs, a function spawns an external command against a \
          remote URL and opens a raw TCP connection\nhypothesis: process spawning chained into \
          network exfiltration from a compiled binary",
     ];

--- a/crates/agentwerk/tests/integration/write_file_creates_file.rs
+++ b/crates/agentwerk/tests/integration/write_file_creates_file.rs
@@ -1,6 +1,6 @@
 //! End-to-end: a real LLM uses `WriteFileTool` to create a file containing
 //! a fresh random token, and we verify the file landed on disk with the
-//! expected contents. No JSON schema — the disk state is the assertion.
+//! expected contents. No JSON schema: the disk state is the assertion.
 
 use std::fs;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -30,7 +30,7 @@ async fn creates_file_with_token() -> std::result::Result<(), Box<dyn std::error
              Step 1: call `write_file` to create exactly the file the user \
              asks for, with exactly the content they specify (and nothing else). \
              Step 2: immediately call `finish` to settle the \
-             ticket. Do not write any prose — your only output must be tool \
+             ticket. Do not write any prose: your only output must be tool \
              calls.",
         )
         .tool(WriteFileTool)

--- a/crates/use-cases/src/deep_research/main.rs
+++ b/crates/use-cases/src/deep_research/main.rs
@@ -133,12 +133,8 @@ fn print_research_outcome(tickets: &TicketSystem, outcome: &Outcome) {
         }
         Outcome::Cancelled | Outcome::Stalled => {
             let label = match outcome {
-                Outcome::Cancelled => {
-                    "PARTIAL RESEARCH — run cancelled before report writer finished"
-                }
-                Outcome::Stalled => {
-                    "PARTIAL RESEARCH — chain stalled before report writer finished"
-                }
+                Outcome::Cancelled => "PARTIAL RESEARCH: cancelled before report writer finished",
+                Outcome::Stalled => "PARTIAL RESEARCH: chain stalled before report writer finished",
                 Outcome::Report(_) => unreachable!(),
             };
             eprintln!(" {label}");

--- a/crates/use-cases/src/deep_research/prompts/report-writer.role.md
+++ b/crates/use-cases/src/deep_research/prompts/report-writer.role.md
@@ -9,11 +9,11 @@ You are a senior decision analyst who synthesises a two-researcher chain into a 
 ## Behavior
 
 - MUST walk the parent chain before writing. Use `read_tickets` with `action="get"`:
-  1. First call: NO `key` argument. Returns YOUR current ticket. researcher_2's findings appear inline in the task body. Note the `parent:` value — it points at researcher_2's ticket.
+  1. First call: NO `key` argument. Returns YOUR current ticket. researcher_2's findings appear inline in the task body. Note the `parent:` value: it points at researcher_2's ticket.
   2. Second call: `key` set to that parent value. Returns researcher_2's ticket; its task body contains researcher_1's findings inline (the handover chain carries each researcher's findings into the next ticket's task).
 - MUST treat the inline findings as raw INPUT to synthesise, not text to quote. Paraphrase and consolidate; drop `Source:` URLs (they belong to the researchers, not the report).
-- MUST finish by calling `finish` — your only finishing tool.
-- NEVER pass a literal placeholder like `TICKET-N` to any tool — always use the real key from the previous tool call's output.
+- MUST finish by calling `finish`, your only finishing tool.
+- NEVER pass a literal placeholder like `TICKET-N` to any tool. Always use the real key from the previous tool call's output.
 - NEVER pass `handover`: you end the chain, and chaining would hand the report to nobody.
 - NEVER include markdown, bullets, headings, or newlines in the `research` field.
 - NEVER emit any text outside the `finish` call.
@@ -22,8 +22,8 @@ You are a senior decision analyst who synthesises a two-researcher chain into a 
 
 Call `finish` exactly once with exactly these two keys as its top-level arguments (not wrapped in `result`): `finish({"title": "...", "research": "..."})`.
 
-- `title` — a plain-text string under 80 characters summarising the question and outcome. No markdown.
-- `research` — a plain-text string summarising the synthesis. No markdown, no bullets, no headings, no newline characters, no inline URLs. Surface any disagreement between researchers.
+- `title`: a plain-text string under 80 characters summarising the question and outcome. No markdown.
+- `research`: a plain-text string summarising the synthesis. No markdown, no bullets, no headings, no newline characters, no inline URLs. Surface any disagreement between researchers.
 
 ## Verification
 

--- a/crates/use-cases/src/deep_research/prompts/researcher_1.role.md
+++ b/crates/use-cases/src/deep_research/prompts/researcher_1.role.md
@@ -4,7 +4,7 @@
 
 ## Role
 
-You are the first of two researchers in a chain. Your focus is establishing the KEY FACTS and EVENTS related to the ticket's question — the breadth of what happened. The second researcher will deepen and broaden your work. If you cannot find evidence for a claim, say so rather than guess.
+You are the first of two researchers in a chain. Your focus is establishing the KEY FACTS and EVENTS related to the ticket's question: the breadth of what happened. The second researcher will deepen and broaden your work. If you cannot find evidence for a claim, say so rather than guess.
 
 ## Behavior
 
@@ -15,17 +15,17 @@ Your turn ends with exactly one `finish` call carrying a `handover`. Any text yo
 - MUST finish the turn with `finish`. Do not stop talking until that call has been issued.
 - MUST always pass `handover`. A `finish` without it ends the chain and the research is never written up.
 - NEVER make a recommendation; the report writer makes the final call.
-- NEVER write findings as prose outside of `finish` — they will be lost.
+- NEVER write findings as prose outside of `finish`. They will be lost.
 
 ## Task
 
 You are step 1 of 2 in the researcher chain. You start fresh; your ticket has no parent.
 
-Call `finish` exactly once with these three arguments. Pay attention to the TYPES — the call is rejected if any type is wrong:
+Call `finish` exactly once with these three arguments. Pay attention to the TYPES: the call is rejected if any type is wrong:
 
-- `handover` — string. Always the literal text `"researcher_2"`.
-- `task` — string. Always the literal text `"Building on {parent_key}: {parent_result}\n\nDeepen and broaden these facts: causes, consequences, criticisms, alternative perspectives."`. The framework substitutes `{parent_key}` with your ticket key and `{parent_result}` with the value you pass as `result` before researcher_2 picks the child ticket up — keep these placeholders verbatim.
-- `result` — STRING of plain prose, several full sentences (target 400–1000 characters). NEVER a number, NEVER an array, NEVER a fragment. Real findings written as paragraphs, each factual claim followed by `Source: <url>`.
+- `handover`: string. Always the literal text `"researcher_2"`.
+- `task`: string. Always the literal text `"Building on {parent_key}: {parent_result}\n\nDeepen and broaden these facts: causes, consequences, criticisms, alternative perspectives."`. The framework substitutes `{parent_key}` with your ticket key and `{parent_result}` with the value you pass as `result` before researcher_2 picks the child ticket up. Keep these placeholders verbatim.
+- `result`: STRING of plain prose, several full sentences (target 400–1000 characters). NEVER a number, NEVER an array, NEVER a fragment. Real findings written as paragraphs, each factual claim followed by `Source: <url>`.
 
 All three arguments are required.
 

--- a/crates/use-cases/src/deep_research/prompts/researcher_2.role.md
+++ b/crates/use-cases/src/deep_research/prompts/researcher_2.role.md
@@ -4,7 +4,7 @@
 
 ## Role
 
-You are the second and final researcher in a two-stage chain. Your focus is deepening and broadening the prior researcher's work: causes, consequences, criticisms, alternative perspectives — whatever the first pass left under-covered. If you cannot find evidence for a claim, say so rather than guess.
+You are the second and final researcher in a two-stage chain. Your focus is deepening and broadening the prior researcher's work: causes, consequences, criticisms, alternative perspectives, whatever the first pass left under-covered. If you cannot find evidence for a claim, say so rather than guess.
 
 ## Behavior
 
@@ -18,19 +18,19 @@ Your turn ends with exactly one `finish` call carrying a `handover`. Any text yo
 - MUST always pass `handover`. A `finish` without it ends the chain and the research is never written up.
 - NEVER repeat coverage already present in the parent; deepen or complement it.
 - NEVER make a recommendation; the report writer makes the final call.
-- NEVER pass a literal placeholder like `TICKET-N` to any tool — always use the real key from the previous tool call's output.
-- NEVER write findings as prose outside of `finish` — they will be lost.
+- NEVER pass a literal placeholder like `TICKET-N` to any tool. Always use the real key from the previous tool call's output.
+- NEVER write findings as prose outside of `finish`. They will be lost.
 
 ## Task
 
 After your handover, the report writer synthesises both researchers' contributions into the final report.
 
-Call `finish` exactly once with these four arguments. Pay attention to the TYPES — the call is rejected if any type is wrong:
+Call `finish` exactly once with these four arguments. Pay attention to the TYPES: the call is rejected if any type is wrong:
 
-- `handover` — string. Always the literal text `"report"`.
-- `task` — string. Always the literal text `"Synthesize the chain into a structured final report. researcher_2 (from {parent_key}): {parent_result}"`. Keep `{parent_key}` and `{parent_result}` verbatim; the framework substitutes them when the report writer picks the child up.
-- `result` — STRING of plain prose, several full sentences (target 400–1000 characters). NEVER a number, NEVER an array, NEVER a fragment. Real findings written as paragraphs, each factual claim followed by `Source: <url>`. Extend the parent's coverage; do not repeat it.
-- `schema` — JSON OBJECT (NOT a stringified JSON). The object shown below, passed verbatim as a JSON value. This schema validates the REPORT WRITER's final result — it is NOT a schema for your own `result` argument. Do NOT invent your own schema; do NOT reuse the shape of your `result` description (`{"type":"string"}`) here.
+- `handover`: string. Always the literal text `"report"`.
+- `task`: string. Always the literal text `"Synthesize the chain into a structured final report. researcher_2 (from {parent_key}): {parent_result}"`. Keep `{parent_key}` and `{parent_result}` verbatim; the framework substitutes them when the report writer picks the child up.
+- `result`: STRING of plain prose, several full sentences (target 400–1000 characters). NEVER a number, NEVER an array, NEVER a fragment. Real findings written as paragraphs, each factual claim followed by `Source: <url>`. Extend the parent's coverage; do not repeat it.
+- `schema`: JSON OBJECT (NOT a stringified JSON). The object shown below, passed verbatim as a JSON value. This schema validates the REPORT WRITER's final result. It is NOT a schema for your own `result` argument. Do NOT invent your own schema; do NOT reuse the shape of your `result` description (`{"type":"string"}`) here.
 
 The schema to pass as `schema`:
 

--- a/crates/use-cases/src/divide_and_conquer/main.rs
+++ b/crates/use-cases/src/divide_and_conquer/main.rs
@@ -153,7 +153,7 @@ fn aggregate_and_report(
 
 /// Pull a `(idx, partial_sum)` pair off a finished ticket. The schema
 /// already guarantees the field shape; this also cross-checks `idx`
-/// against the `idx=` line in the task body so a misrouted result
+/// against the `idx=` line in the task body so a wrongly assigned result
 /// can't quietly slot into the wrong partition.
 fn extract_partial(ticket: &Ticket, total: usize) -> Result<(usize, i128), String> {
     if !ticket.is_finished() {

--- a/crates/use-cases/src/malware_scanner/knowledge/attack_patterns/gootloader-font-trick.md
+++ b/crates/use-cases/src/malware_scanner/knowledge/attack_patterns/gootloader-font-trick.md
@@ -3,7 +3,7 @@ type: AttackPattern
 description: A font file that holds readable JavaScript instead of only binary glyph data. Grep for the bare word `function` (no parentheses, no other terms), one extension per call so the glob stays a plain `*.woff2`, then `*.woff`, `*.ttf`, `*.eot`; any match is an embedded loader.
 tags: [binary-media-disguise]
 ---
-# GootLoader font trick (reported Nov 2025) — LOW CONFIDENCE, single source, unverified
+# GootLoader font trick (reported Nov 2025): LOW CONFIDENCE, single source, unverified
 
 ## Carrier
 a custom WOFF2 web font embedded directly in JavaScript on a compromised page

--- a/crates/use-cases/src/malware_scanner/main.rs
+++ b/crates/use-cases/src/malware_scanner/main.rs
@@ -463,7 +463,7 @@ async fn wait_for_report_inputs(tickets: &TicketSystem) {
 }
 
 /// Run the Reporter on its own `TicketSystem`, so nothing that stopped the scan
-/// (time cap, cancel) can stop the report. No max time: the schema-retry budget
+/// (time limit, cancel) can stop the report. No max time: the schema-retry budget
 /// bounds a Reporter that never finishes its ticket.
 async fn run_report_phase(
     provider: Arc<dyn Provider>,

--- a/crates/use-cases/src/malware_scanner/report.rs
+++ b/crates/use-cases/src/malware_scanner/report.rs
@@ -193,7 +193,7 @@ pub(crate) fn analyst_result_schema() -> Schema {
 /// Result schema for the Reporter ticket: an object carrying the lay-reader
 /// `summary` and the three-paragraph technical `details`. Attaching it makes
 /// `finish` reject a malformed or partial result and force a retry,
-/// the same guard the analyst verdict relies on. The length floors and caps
+/// the same guard the analyst verdict relies on. The length floors and limits
 /// sit outside the targets the prompt states, so a compliant result is never
 /// rejected while a skimped or runaway one is.
 pub(crate) fn reporter_result_schema() -> Schema {
@@ -425,7 +425,7 @@ pub(crate) fn log_event(event: &Event, tickets: &TicketSystem) {
         EventKind::TicketFailed => {
             eprintln!("{c}[{agent}]{r} ✗ failed {}", event.ticket_key)
         }
-        // Suppress "thinking..." — the tool-call lines show activity.
+        // Suppress "thinking...": the tool-call lines show activity.
         EventKind::RequestStarted { .. } => {}
         EventKind::ToolCallStarted {
             tool_name, input, ..
@@ -588,7 +588,7 @@ fn tool_call_summary(tool_name: &str, input: &Value) -> String {
                     if summary.is_empty() {
                         format!("noting {slug}")
                     } else {
-                        format!("noting {slug} — {}", truncate(summary, 60))
+                        format!("noting {slug}: {}", truncate(summary, 60))
                     }
                 }
                 "read" => format!("recalling {slug}"),
@@ -613,7 +613,7 @@ fn finish_summary(result: &Value) -> String {
         }
         if verdict != "benign" {
             if let Some(d) = result.get("description").and_then(|v| v.as_str()) {
-                out.push_str(&format!(" — {}", truncate(d, 80)));
+                out.push_str(&format!(": {}", truncate(d, 80)));
             }
         }
         return out;

--- a/crates/use-cases/src/malware_scanner/scan.rs
+++ b/crates/use-cases/src/malware_scanner/scan.rs
@@ -44,7 +44,7 @@ pub(crate) const CLUSTER_RADIUS: usize = 20;
 /// File paths per `file-map-NN` knowledge page.
 const FILE_MAP_PAGE_SIZE: usize = 30;
 
-/// Cap on file-map pages, so the injected index stays bounded on a large tree.
+/// Limit on file-map pages, so the injected index stays bounded on a large tree.
 const FILE_MAP_MAX_PAGES: usize = 40;
 
 /// `Pattern` queries run codegrep against file contents. `Substring`
@@ -448,7 +448,7 @@ fn locate(line_starts: &[usize], content: &str, byte_offset: usize) -> (usize, u
 
 /// Walk `root` and emit one `Hit` per (file, entry) whose `query` is a
 /// substring of the file's path relative to `root`. Reads paths only;
-/// no contents, no extension filter, no size cap.
+/// no contents, no extension filter, no size limit.
 pub(crate) fn find_paths(root: &Path, entries: &[IocEntry], mut on_hit: impl FnMut(Hit)) -> usize {
     let mut count: usize = 0;
     let mut stack: Vec<PathBuf> = vec![root.to_path_buf()];
@@ -721,7 +721,7 @@ impl<'a> Scanner<'a> {
 
         // Synchronous grep is fast; collect every `(priority, body)` first, then
         // enqueue lowest-rank (strongest-evidence) tickets first so the reachability
-        // and analyst pools — and a `--fail-fast` stop — reach a malicious verdict
+        // and analyst pools, and a `--fail-fast` stop, reach a malicious verdict
         // sooner.
         let collected: Arc<Mutex<Vec<(usize, String)>>> = Arc::new(Mutex::new(Vec::new()));
         let mut handles = Vec::with_capacity(known_pairs.len() * 3);

--- a/crates/use-cases/src/terminal_repl/main.rs
+++ b/crates/use-cases/src/terminal_repl/main.rs
@@ -3,16 +3,16 @@
 //! the first input creates the ticket via `tickets.task(...)`, every
 //! subsequent input lands as a user reply via `tickets.reply(&key, ...)`.
 //! The agent loop's wait-for-input branch picks each comment up and
-//! drives the next model turn on the same growing transcript. Tickets
+//! drives the next model turn on the same growing set of replies. Tickets
 //! and knowledge both persist to `./.agentwerk/`, so an existing chat
 //! resumes across process restarts.
 //! The model's response streams to stdout via
 //! `EventKind::TextChunkReceived`. Slash commands:
 //! `/new` starts a fresh chat ticket, `/list` lists every ticket,
-//! `/stats` prints run counters, `/clear` resets knowledge,
+//! `/stats` prints the statistics, `/clear` resets knowledge,
 //! `/bible [N]` injects N repetitions of Genesis (KJV) as a reply to
 //! drive context compaction (default N=1, ~52k tokens per repetition).
-//! `/scrub <word>` redacts that word from the transcript in place (via
+//! `/scrub <word>` redacts that word from the replies in place (via
 //! `edit_replies`) with no model turn; the word is gone on disk too.
 //! Ctrl-C at the prompt exits with code 130; Ctrl-D exits with
 //! code 0; Ctrl-C during a turn cancels that turn (a second Ctrl-C
@@ -20,7 +20,7 @@
 //!
 //! Every exit path goes through `std::process::exit` rather than a
 //! plain `return`: the stdin reader runs on a tokio blocking thread
-//! parked in `read(2)`, which the runtime can't cancel on shutdown.
+//! blocked in `read(2)`, which the runtime cannot cancel on shutdown.
 //! Exiting the process directly bypasses the runtime drop and avoids
 //! a hang on outstanding blocking tasks.
 
@@ -503,7 +503,7 @@ fn window_usage_suffix(window: Option<u64>, last_input: &AtomicU64) -> String {
     }
 }
 
-/// Replace every occurrence of `word` with `[redacted]` across the transcript.
+/// Replace every occurrence of `word` with `[redacted]` across the replies.
 fn redact(messages: &mut [Reply], word: &str) {
     for reply in messages.iter_mut() {
         for block in &mut reply.content {

--- a/crates/use-cases/src/terminal_repl/prompts/repl.role.md
+++ b/crates/use-cases/src/terminal_repl/prompts/repl.role.md
@@ -12,9 +12,9 @@ You are a senior local-repository search assistant who answers users' questions 
 
 Each user input is one short exchange: optionally gather (search/read tools, silently), then answer in prose. Cite `file:line` for every factual claim about repository contents. For casual inputs one short sentence is enough. Do NOT call `finish` after every reply: this is an interactive chat ticket that spans many turns, and a text-only reply already pauses the agent for the next input. Only call `finish` when the user explicitly asks to end the exchange ("we're done", "finish", "close this", "end this chat", "wrap up"). Until then, leave the ticket open.
 
-When the user asks you to remember, save, note, or persist something, call `manage_knowledge` with `{"action": "write", ...}`. Treat the phrase "in your knowledge" as naming the destination (the persistent knowledge store), never as a request to recall. The same store is what feeds the `## Knowledge` section in this prompt: the section is the read view, `manage_knowledge` is the write view, and both refer to the same thing the user calls "your knowledge".
+When the user asks you to remember, save, note, or persist something, call `manage_knowledge` with `{"action": "write", ...}`. Treat the phrase "in your knowledge" as naming the destination (the persistent knowledge store), never as a request to recall. Your knowledge is what that store holds: you read it in this prompt, you write it with `manage_knowledge`, and it is the same thing the user calls "your knowledge".
 
-When the user asks what you already know ("what do you know?", "what is in your knowledge?", "list your knowledge"), quote the `## Knowledge` section verbatim and do not call any tool.
+When the user asks what you already know ("what do you know?", "what is in your knowledge?", "list your knowledge"), quote your knowledge verbatim and do not call any tool.
 
 Prohibitions:
 
@@ -41,7 +41,7 @@ Examples (correct):
 - user: "list lock files" → call `glob` with `*lock*`, reply with text like "Found Cargo.lock at the repo root."
 - user: "what is in Cargo.toml?" → call `read_file` once, reply with a one-line summary citing `Cargo.toml:N`.
 - user: "remember the first file in the repo" / "remember the first file in your knowledge" / "save the first file" → call `list_directory` on `.`, wait for the result, then call `manage_knowledge` with `{"action": "write", "slug": "repo-first-file", "description": "First file in repo root: <name>", "content": "# Repo First File\n\nThe first file in the repo root is <name>."}` and reply with one short sentence confirming what was saved. "In your knowledge" here names the destination, not a recall.
-- user: "what do you know?" / "what is in your knowledge?" → quote the entries in your `## Knowledge` section verbatim (or "(knowledge empty)" if absent) in one short paragraph. Do not call any tool.
+- user: "what do you know?" / "what is in your knowledge?" → quote your knowledge verbatim (or "(knowledge empty)" if absent) in one short paragraph. Do not call any tool.
 - user: "we're done" / "finish" / "close this chat" / "end this" → call `finish` with no arguments and reply with one short sentence confirming the chat is closed.
 
 Examples (forbidden):
@@ -54,15 +54,15 @@ Examples (forbidden):
 
 ## Tools
 
-- `glob` — find files by glob pattern. Use when the user names a file pattern or asks "where is file X".
-- `grep` — search file contents for a regex. Use when the user asks "where is symbol X used" or "what files mention Y".
-- `list_directory` — list immediate children of a directory. Use when the user asks "what's in this folder" or to confirm structure before deeper exploration.
-- `read_file` — read file contents with optional line range. Use after locating the right file via glob, grep, or list.
-- `write_file` — create or overwrite a file with given content. Use only when the user explicitly asks to create or replace a file.
-- `manage_knowledge` — persist a fact across turns. Call it whenever the user asks you to remember, save, note, or persist something, regardless of whether they phrase the destination as "in your knowledge", "to your notes", or leave it implicit. The `## Knowledge` section in this prompt is the read view of the same store. Write a fact derived from a tool result only AFTER the tool has returned: do not emit `manage_knowledge` in parallel with the tool whose result you are saving. Use `read` to load full page content on demand.
-- `finish` — close the chat ticket and mark it done. Call ONLY when the user explicitly asks to end the exchange ("we're done", "finish", "close this", "end this chat", "wrap up"). Do NOT call it after every reply: the chat ticket is meant to span many turns, and a text-only reply already pauses the agent for the next input. Omit `result` for casual closings; pass a one-line summary as `result` if the user asks for a wrap-up.
-- `read_tickets` — read ticket state. Use when the user asks about past exchanges or the ticket queue.
-- `manage_tickets` — create or edit tickets. Use when the user asks to create a task, record work, or modify an existing ticket.
+- `glob`: find files by glob pattern. Use when the user names a file pattern or asks "where is file X".
+- `grep`: search file contents for a regex. Use when the user asks "where is symbol X used" or "what files mention Y".
+- `list_directory`: list immediate children of a directory. Use when the user asks "what's in this folder" or to confirm structure before deeper exploration.
+- `read_file`: read file contents with optional line range. Use after locating the right file via glob, grep, or list.
+- `write_file`: create or overwrite a file with given content. Use only when the user explicitly asks to create or replace a file.
+- `manage_knowledge`: persist a fact across turns. Call it whenever the user asks you to remember, save, note, or persist something, regardless of whether they phrase the destination as "in your knowledge", "to your notes", or leave it implicit. Your knowledge in this prompt is what that store already holds. Write a fact derived from a tool result only AFTER the tool has returned: do not emit `manage_knowledge` in parallel with the tool whose result you are saving. Use `read` to load full page content on demand.
+- `finish`: close the chat ticket and mark it done. Call ONLY when the user explicitly asks to end the exchange ("we're done", "finish", "close this", "end this chat", "wrap up"). Do NOT call it after every reply: the chat ticket is meant to span many turns, and a text-only reply already pauses the agent for the next input. Omit `result` for casual closings; pass a one-line summary as `result` if the user asks for a wrap-up.
+- `read_tickets`: read ticket state. Use when the user asks about past exchanges or the ticket queue.
+- `manage_tickets`: create or edit tickets. Use when the user asks to create a task, record work, or modify an existing ticket.
 
 Preference: `glob` before `list_directory` when the user names a file pattern; `grep` when the user names text content; `read_file` only after locating the right file.
 

--- a/crates/use-cases/tests/python-malware/README.md
+++ b/crates/use-cases/tests/python-malware/README.md
@@ -9,7 +9,7 @@ Run it:
 
     make run name=malware-scanner args="crates/use-cases/tests/python-malware --fail-fast --concurrency 1"
 
-`requests/_compat.py` carries two catalogue indicators — `exec(base64.b64decode(...))`
-and `os.system(...)` — so discovery raises an analyst ticket without relying on the
+`requests/_compat.py` carries two catalogue indicators, `exec(base64.b64decode(...))`
+and `os.system(...)`, so discovery raises an analyst ticket without relying on the
 Threat Researcher. `requests/__init__.py` is benign; it triggers the payload by
 importing `_compat` at package load.


### PR DESCRIPTION
## Apply the README's style to agentdocs and every doc comment

### Purpose

- The README is the one carefully written text in the repo, and `style.md` already recorded most of its rules, but nothing else followed them.
- The gap was measurable: 43 em dashes in doc comments against none in the README, "transcript" in 21 files, and the session directory documented twice in different words.
- A reader moving between docs.rs and the README met two different vocabularies for the same crate.
- `agentdocs/style.md` is now the one place the style lives, so none of it has to be re-derived from the README again.

### What changed

- `style.md` gains the rules the README only implied: sentence shape and its word budgets, second person for the reader, the `` `Type` `` plus one clause opening, the em dash ban at file scope, and the banned terms found in violation.
- Every doc comment leads with the verb its README row uses, so a builder, an accessor, and an event read the same way in both places. Module headers are one sentence again and no longer list their own contents.
- Internal mechanics left the rustdoc for `architecture.md`, which is where `style.md` says they belong: the `Arc::new_cyclic` back-reference, the two-signal cancel protocol, and the ticket-key seeding rule.
- The Python bindings and `__init__.pyi` follow the same rules, with "predicate", "callback", and "closure" gone from caller-facing prose and six undocumented policy setters filled in.
- agentdocs now lead with the rule, then a minimal example, then the bullets; `this.md` is rewritten in that shape, since it is the format's own specification.

### Examples

```rust
// before
/// Maximum elapsed duration the run is allowed to span. When the
/// elapsed duration reaches the limit, `finish` stops with ...

// after: the same words as the README's `max_time(duration)` row
/// Limit the total elapsed duration.
```

```markdown
<!-- an agentdocs section: rule, example, bullets -->
## Builders

**Builder methods are bare nouns. No `with_` prefix.**

`.name()`, `.model()`, `.tool()`, `.label()`, `.read_only()`
```

```bash
# verification
grep -rn "—" crates agentdocs README.md   # 0
make && make test                          # 881 + 41 doc + 43 tests, 0 failed
cargo doc --no-deps -p agentwerk           # no warnings
```

One README cell changed: `cancel_on` said "when the given future completes", which the terminology rule it sits under forbids. Prompt and `.tool.md` files took the punctuation and wording rules only, never the fold and table structure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
