### PR TITLE
scanner: select a model per agent from a JSON file

### DIFF
--- a/crates/use-cases/src/malware_scanner/cli.rs
+++ b/crates/use-cases/src/malware_scanner/cli.rs
@@ -1,7 +1,14 @@
 //! CLI argument parsing for the malware scanner.
 
-use std::path::PathBuf;
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
+
+use agentwerk::providers::{Model, ReasoningEffort};
+use serde_json::Value;
+
+use super::DEFAULT_MODEL;
 
 pub(crate) struct CliArgs {
     pub(crate) dir: PathBuf,
@@ -11,6 +18,7 @@ pub(crate) struct CliArgs {
     pub(crate) output_file: Option<PathBuf>,
     pub(crate) fail_fast: bool,
     pub(crate) instruction: Option<String>,
+    pub(crate) models: Option<ModelTable>,
 }
 
 impl CliArgs {
@@ -23,6 +31,7 @@ impl CliArgs {
         let mut output_file: Option<PathBuf> = None;
         let mut fail_fast: bool = false;
         let mut instruction: Option<String> = None;
+        let mut models: Option<ModelTable> = None;
 
         let mut i = 1;
         while i < args.len() {
@@ -69,6 +78,15 @@ impl CliArgs {
                             .unwrap_or_else(|| bad_arg("--instruction expects text")),
                     );
                 }
+                "--models" => {
+                    i += 1;
+                    let path = Path::new(
+                        args.get(i)
+                            .map(String::as_str)
+                            .unwrap_or_else(|| bad_arg("--models expects a path")),
+                    );
+                    models = Some(ModelTable::load(path).unwrap_or_else(|e| bad_arg(&e)));
+                }
                 "-h" | "--help" => {
                     Self::print_help();
                     std::process::exit(0);
@@ -90,6 +108,7 @@ impl CliArgs {
             output_file,
             fail_fast,
             instruction,
+            models,
         }
     }
 
@@ -113,10 +132,155 @@ impl CliArgs {
         eprintln!(
             "      --instruction <TEXT>     Append a custom instruction to every agent's prompt"
         );
+        eprintln!(
+            "      --models <FILE>          One model per agent as JSON, keyed by ticket label,"
+        );
+        eprintln!(
+            "                               pool name, or agent name. A value is a model name or"
+        );
+        eprintln!(
+            "                               an object of model, reasoning, and context_window"
+        );
+        eprintln!("                               (default: every agent runs {DEFAULT_MODEL})");
         eprintln!("  -h, --help                   Show this help\n");
         eprintln!("Example:");
         eprintln!("  malware-scanner ./src");
     }
+}
+
+/// The `--models` file, keyed by ticket label, pool, or single agent.
+#[derive(Debug)]
+pub(crate) struct ModelTable(BTreeMap<String, Model>);
+
+impl ModelTable {
+    fn load(path: &Path) -> Result<Self, String> {
+        let text = fs::read_to_string(path)
+            .map_err(|e| format!("--models: cannot read {}: {e}", path.display()))?;
+        Self::parse(&text).map_err(|e| format!("{e} (in {})", path.display()))
+    }
+
+    fn parse(text: &str) -> Result<Self, String> {
+        let entries: BTreeMap<String, Value> =
+            serde_json::from_str(text).map_err(|e| format!("--models: cannot parse JSON: {e}"))?;
+        entries
+            .iter()
+            .map(|(key, value)| model_from(key, value).map(|model| (key.clone(), model)))
+            .collect::<Result<_, _>>()
+            .map(Self)
+    }
+
+    /// One model per `(name, label)` agent. First match wins: name, pool, label.
+    ///
+    /// An uncovered agent and a key naming no agent are both errors, since the
+    /// file is the only model source and a typo has nothing to fall back to.
+    pub(crate) fn resolve_for(
+        &self,
+        roster: &[(String, &str)],
+    ) -> Result<BTreeMap<String, Model>, String> {
+        let mut resolved = BTreeMap::new();
+        let mut matched = BTreeSet::new();
+        let mut uncovered = Vec::new();
+        for (name, label) in roster {
+            let keys = [name.as_str(), pool_of(name), label];
+            matched.extend(keys.into_iter().filter(|key| self.0.contains_key(*key)));
+            match keys.into_iter().find(|key| self.0.contains_key(*key)) {
+                Some(key) => {
+                    resolved.insert(name.clone(), self.0[key].clone());
+                }
+                None => uncovered.push(format!("{name} ({label})")),
+            }
+        }
+
+        let unmatched: Vec<&str> = self
+            .0
+            .keys()
+            .map(String::as_str)
+            .filter(|key| !matched.contains(key))
+            .collect();
+        let mut problems = Vec::new();
+        if !uncovered.is_empty() {
+            problems.push(format!("--models: no model for {}", uncovered.join(", ")));
+        }
+        if !unmatched.is_empty() {
+            problems.push(format!(
+                "--models: no agent matches {}\nvalid keys: {}, or one agent such as \"{}\"",
+                unmatched.join(", "),
+                valid_keys(roster).join(", "),
+                roster[0].0,
+            ));
+        }
+        if problems.is_empty() {
+            Ok(resolved)
+        } else {
+            Err(problems.join("\n"))
+        }
+    }
+}
+
+fn model_from(key: &str, value: &Value) -> Result<Model, String> {
+    if let Some(name) = value.as_str() {
+        return Ok(Model::from_name(name));
+    }
+    let Some(fields) = value.as_object() else {
+        return Err(format!(
+            "--models: {key} expects a model name or an object with a \"model\" field"
+        ));
+    };
+    if let Some(unknown) = fields
+        .keys()
+        .find(|k| !matches!(k.as_str(), "model" | "reasoning" | "context_window"))
+    {
+        return Err(format!(
+            "--models: {key} has unknown field \"{unknown}\"; accepted: model, reasoning, context_window"
+        ));
+    }
+    let name = fields
+        .get("model")
+        .and_then(Value::as_str)
+        .ok_or_else(|| format!("--models: {key} needs a \"model\" field naming the model"))?;
+    let mut model = Model::from_name(name);
+    if let Some(value) = fields.get("reasoning") {
+        model = model.reasoning_effort(reasoning_from(key, value)?);
+    }
+    if let Some(value) = fields.get("context_window") {
+        let size = value.as_u64().filter(|n| *n > 0).ok_or_else(|| {
+            format!("--models: {key} expects \"context_window\" as a positive number of tokens")
+        })?;
+        model = model.context_window(size);
+    }
+    Ok(model)
+}
+
+fn reasoning_from(key: &str, value: &Value) -> Result<ReasoningEffort, String> {
+    match value.as_str() {
+        Some("off") => Ok(ReasoningEffort::Off),
+        Some("low") => Ok(ReasoningEffort::Low),
+        Some("medium") => Ok(ReasoningEffort::Medium),
+        Some("high") => Ok(ReasoningEffort::High),
+        _ => Err(format!(
+            "--models: {key} expects \"reasoning\" as off, low, medium, or high"
+        )),
+    }
+}
+
+/// `Analyst 2` belongs to pool `Analyst`.
+fn pool_of(name: &str) -> &str {
+    match name.rsplit_once(' ') {
+        Some((pool, number)) if number.chars().all(|c| c.is_ascii_digit()) => pool,
+        _ => name,
+    }
+}
+
+fn valid_keys<'a>(roster: &'a [(String, &'a str)]) -> Vec<&'a str> {
+    let mut keys: Vec<&str> = Vec::new();
+    for (name, label) in roster {
+        for key in [*label, pool_of(name)] {
+            if !keys.contains(&key) {
+                keys.push(key);
+            }
+        }
+    }
+    keys
 }
 
 /// Parse `30`, `30s`, `5m`, or `1h` into a `Duration`. Bare numbers are seconds.
@@ -161,5 +325,95 @@ mod tests {
         assert!(parse_duration("5d").is_none());
         assert!(parse_duration("90min").is_none());
         assert!(parse_duration("abc").is_none());
+    }
+
+    fn roster() -> Vec<(String, &'static str)> {
+        vec![
+            ("Analyst 1".to_string(), "security_analysis"),
+            ("Analyst 2".to_string(), "security_analysis"),
+            ("Reporter".to_string(), "reporter"),
+        ]
+    }
+
+    fn resolve(json: &str) -> Result<BTreeMap<String, Model>, String> {
+        ModelTable::parse(json)?.resolve_for(&roster())
+    }
+
+    #[test]
+    fn a_bare_string_entry_is_the_model_name() {
+        let models = resolve(r#"{"Analyst": "gpt-5", "reporter": "gpt-4o"}"#).unwrap();
+        assert_eq!(models["Analyst 1"].name, "gpt-5");
+        assert_eq!(models["Reporter"].name, "gpt-4o");
+    }
+
+    #[test]
+    fn an_object_entry_carries_reasoning_and_context_window() {
+        let models = resolve(
+            r#"{
+                "Analyst": {"model": "gpt-5", "reasoning": "high"},
+                "reporter": {"model": "my-local-model", "context_window": 65536}
+            }"#,
+        )
+        .unwrap();
+        assert_eq!(
+            models["Analyst 1"].get_reasoning_effort(),
+            ReasoningEffort::High
+        );
+        assert_eq!(models["Reporter"].get_context_window(), Some(65_536));
+    }
+
+    #[test]
+    fn an_agent_name_wins_over_its_pool_and_a_pool_over_its_label() {
+        let models = resolve(
+            r#"{
+                "Analyst 2": "gpt-4o",
+                "Analyst": "gpt-5",
+                "security_analysis": "mistral-medium-2508",
+                "reporter": "gpt-5"
+            }"#,
+        )
+        .unwrap();
+        assert_eq!(models["Analyst 2"].name, "gpt-4o");
+        assert_eq!(models["Analyst 1"].name, "gpt-5");
+    }
+
+    #[test]
+    fn a_key_every_agent_of_it_overrides_is_still_accepted() {
+        let models =
+            resolve(r#"{"Analyst": "gpt-5", "security_analysis": "gpt-4o", "reporter": "gpt-5"}"#);
+        assert!(models.is_ok(), "{:?}", models.unwrap_err());
+    }
+
+    #[test]
+    fn an_agent_no_key_covers_is_named_with_its_label() {
+        let error = resolve(r#"{"security_analysis": "gpt-5"}"#).unwrap_err();
+        assert!(error.contains("Reporter (reporter)"), "{error}");
+    }
+
+    #[test]
+    fn a_key_matching_no_agent_is_listed_with_the_valid_ones() {
+        let error = resolve(r#"{"security_analysis": "gpt-5", "reporting": "gpt-5"}"#).unwrap_err();
+        assert!(error.contains("reporting"), "{error}");
+        assert!(error.contains("Analyst"), "{error}");
+    }
+
+    #[test]
+    fn an_unknown_reasoning_word_names_the_accepted_ones() {
+        let error = ModelTable::parse(r#"{"Analyst": {"model": "gpt-5", "reasoning": "max"}}"#)
+            .unwrap_err();
+        assert!(error.contains("off, low, medium, or high"), "{error}");
+    }
+
+    #[test]
+    fn an_unknown_field_is_named() {
+        let error =
+            ModelTable::parse(r#"{"Analyst": {"model": "gpt-5", "effort": "high"}}"#).unwrap_err();
+        assert!(error.contains("effort"), "{error}");
+    }
+
+    #[test]
+    fn an_entry_without_a_model_field_is_rejected() {
+        let error = ModelTable::parse(r#"{"Analyst": {"reasoning": "high"}}"#).unwrap_err();
+        assert!(error.contains("model"), "{error}");
     }
 }

--- a/crates/use-cases/src/malware_scanner/main.rs
+++ b/crates/use-cases/src/malware_scanner/main.rs
@@ -14,6 +14,7 @@ mod cli;
 mod report;
 mod scan;
 
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -22,12 +23,12 @@ use std::time::Duration;
 
 use agentwerk::agents::Trajectory;
 use agentwerk::event::{Event, EventKind, PolicyKind};
-use agentwerk::providers::{model_from_env, provider_from_env, Provider};
+use agentwerk::providers::{provider_from_env, Model, Provider};
 use agentwerk::tools::{FinishTool, GlobTool, GrepTool, ListDirectoryTool, ReadFileTool};
 use agentwerk::{Agent, Knowledge, Ticket, TicketQueue};
 use serde_json::{json, Value};
 
-use cli::CliArgs;
+use cli::{CliArgs, ModelTable};
 use report::{
     analyst_result_schema, build_analysis, log_event, print_summary, render_findings_table,
     reporter_result_schema,
@@ -41,6 +42,19 @@ const TRACER_AGENT: &str = include_str!("agents/tracer.md");
 const EXPLORER_AGENT: &str = include_str!("agents/explorer.md");
 const REPORTER_AGENT: &str = include_str!("agents/reporter.md");
 const REPORTER_LABEL: &str = "reporter";
+const REPORTER_NAME: &str = "Reporter";
+
+/// Pool name and the label its tickets carry, shared by the built agents and
+/// the `--models` roster so the two cannot disagree.
+const POOLS: [(&str, &str); 4] = [
+    ("Analyst", ANALYSIS_LABEL),
+    ("Seeker", SEEKER_LABEL),
+    ("Tracer", TRACER_LABEL),
+    ("Explorer", EXPLORER_LABEL),
+];
+
+/// What every agent runs without `--models`; no model is read from the environment.
+const DEFAULT_MODEL: &str = "qwen3.6-35b-a3b";
 
 const REPORT_INPUT_LABELS: [&str; 4] = [ANALYSIS_LABEL, TRACER_LABEL, EXPLORER_LABEL, SEEKER_LABEL];
 
@@ -63,17 +77,27 @@ const WORK_DIR: &str = ".malware-scanner";
 #[tokio::main]
 async fn main() {
     let args = CliArgs::parse();
+    let concurrency = args.concurrency.max(1);
+    let roster = roster(concurrency);
+    let models = resolve_models(args.models.as_ref(), &roster);
     let provider = provider_from_env().expect("LLM provider required");
-    let model = model_from_env().expect("model name required");
 
     // Probe the config before any work: a wrong key, model, or endpoint fails
     // here with a clear message instead of failing every ticket downstream.
-    if let Err(error) = provider.verify(&model).await {
-        eprintln!(
-            "cannot reach model '{model}': {error}\n\
-             check the API key, model name, and endpoint for the configured provider."
-        );
-        std::process::exit(1);
+    let mut probed = BTreeSet::new();
+    for model in models.values() {
+        if !probed.insert(model.name.as_str()) {
+            continue;
+        }
+        if let Err(error) = provider.verify(&model.name).await {
+            eprintln!(
+                "cannot reach model '{}': {error}\n\
+                 check the API key and endpoint for the configured provider, \
+                 and the model names in --models.",
+                model.name,
+            );
+            std::process::exit(1);
+        }
     }
 
     let scan_dir = fs::canonicalize(&args.dir).unwrap_or_else(|e| {
@@ -92,7 +116,6 @@ async fn main() {
     }
 
     let files_walked = scan.files;
-    let concurrency = args.concurrency.max(1);
 
     // Start every run from a clean working folder: no tickets, knowledge, or
     // results carried over from a prior scan.
@@ -233,11 +256,12 @@ async fn main() {
 
     // Every pool shares one queue; labels route each ticket to its agent.
     for i in 0..concurrency {
+        let name = agent_name("Analyst", i);
         tickets.agent(
             Agent::new()
-                .name(format!("Analyst {}", i + 1))
                 .provider(Arc::clone(&provider))
-                .model(&model)
+                .model(models[&name].clone())
+                .name(name)
                 .role(ANALYST_AGENT.trim())
                 .template("instruction", &instruction_section)
                 .template("verdicts", ANALYST_VERDICTS.trim())
@@ -254,12 +278,13 @@ async fn main() {
 
     // Continuous discovery, refilled after every ticket.
     for i in 0..concurrency {
+        let name = agent_name("Seeker", i);
         tickets.agent(
             // Every ticket ends in a handover; seeker.md is what enforces it.
             Agent::new()
-                .name(format!("Seeker {}", i + 1))
                 .provider(Arc::clone(&provider))
-                .model(&model)
+                .model(models[&name].clone())
+                .name(name)
                 .role(SEEKER_AGENT.trim())
                 .template("instruction", &instruction_section)
                 .template("searches_per_ticket", SEARCHES_PER_TICKET.to_string())
@@ -274,12 +299,13 @@ async fn main() {
     // Demand-driven reachability. Shares exploration_knowledge to read the
     // Explorer's pages and record its own alongside.
     for i in 0..concurrency {
+        let name = agent_name("Tracer", i);
         tickets.agent(
             // Every ticket ends in a handover; tracer.md is what enforces it.
             Agent::empty()
-                .name(format!("Tracer {}", i + 1))
                 .provider(Arc::clone(&provider))
-                .model(&model)
+                .model(models[&name].clone())
+                .name(name)
                 .role(TRACER_AGENT.trim())
                 .template("instruction", &instruction_section)
                 .label(TRACER_LABEL)
@@ -296,11 +322,12 @@ async fn main() {
 
     // Bounded overview into exploration_knowledge; no handoff.
     for i in 0..concurrency {
+        let name = agent_name("Explorer", i);
         tickets.agent(
             Agent::new()
-                .name(format!("Explorer {}", i + 1))
                 .provider(Arc::clone(&provider))
-                .model(&model)
+                .model(models[&name].clone())
+                .name(name)
                 .role(EXPLORER_AGENT.trim())
                 .template("instruction", &instruction_section)
                 .template("explorer_time_budget", &explorer_time_budget)
@@ -395,7 +422,7 @@ async fn main() {
     let report_tickets = if has_findings || has_exploration {
         let report_tickets = run_report_phase(
             Arc::clone(&provider),
-            &model,
+            models[REPORTER_NAME].clone(),
             &exploration_knowledge,
             render_findings_table(&analysis, partial_coverage),
             &instruction_section,
@@ -439,6 +466,39 @@ async fn main() {
     }
 }
 
+fn agent_name(pool: &str, index: usize) -> String {
+    format!("{pool} {}", index + 1)
+}
+
+/// Every agent the run builds, with its label. The Reporter works alone, so it
+/// carries no member number.
+fn roster(concurrency: usize) -> Vec<(String, &'static str)> {
+    let mut agents: Vec<(String, &'static str)> = POOLS
+        .iter()
+        .flat_map(|(pool, label)| (0..concurrency).map(move |i| (agent_name(pool, i), *label)))
+        .collect();
+    agents.push((REPORTER_NAME.to_string(), REPORTER_LABEL));
+    agents
+}
+
+/// One model per agent name. A `--models` file covers the whole roster or the
+/// run stops here.
+fn resolve_models(
+    table: Option<&ModelTable>,
+    roster: &[(String, &str)],
+) -> BTreeMap<String, Model> {
+    let Some(table) = table else {
+        return roster
+            .iter()
+            .map(|(name, _)| (name.clone(), Model::from_name(DEFAULT_MODEL)))
+            .collect();
+    };
+    table.resolve_for(roster).unwrap_or_else(|error| {
+        eprintln!("{error}");
+        std::process::exit(1);
+    })
+}
+
 /// Block until the Reporter's inputs are ready. Polls rather than calling
 /// [`TicketQueue::finish`], which would wait on the entire queue. A called-off
 /// pool's tickets stay pending forever, so they are skipped.
@@ -467,7 +527,7 @@ async fn wait_for_report_inputs(tickets: &TicketQueue) {
 /// bounds a Reporter that never finishes its ticket.
 async fn run_report_phase(
     provider: Arc<dyn Provider>,
-    model: &str,
+    model: Model,
     knowledge: &Arc<Knowledge>,
     findings_table: String,
     instruction: &str,
@@ -483,7 +543,7 @@ async fn run_report_phase(
     report_tickets.on_event(move |e| log_event(e, &log_tickets));
     report_tickets.agent(
         Agent::new()
-            .name("Reporter")
+            .name(REPORTER_NAME)
             .provider(provider)
             .model(model)
             .role(REPORTER_AGENT.trim())
@@ -588,6 +648,35 @@ mod tests {
     }
 
     #[test]
+    fn roster_holds_every_pool_member_and_the_reporter() {
+        let roster = roster(2);
+        let names: Vec<&str> = roster.iter().map(|(name, _)| name.as_str()).collect();
+        assert_eq!(
+            names,
+            [
+                "Analyst 1",
+                "Analyst 2",
+                "Seeker 1",
+                "Seeker 2",
+                "Tracer 1",
+                "Tracer 2",
+                "Explorer 1",
+                "Explorer 2",
+                "Reporter",
+            ]
+        );
+        assert_eq!(roster.last().unwrap().1, REPORTER_LABEL);
+    }
+
+    #[test]
+    fn without_a_models_file_every_agent_runs_the_default_model() {
+        let roster = roster(1);
+        let models = resolve_models(None, &roster);
+        assert_eq!(models.len(), roster.len());
+        assert!(models.values().all(|m| m.name == DEFAULT_MODEL));
+    }
+
+    #[test]
     fn finding_verdict_matches_malicious_and_exploitable_but_not_benign() {
         assert!(is_finding_verdict(
             &json!({"status": "malicious", "path": "a.py"})
@@ -643,7 +732,7 @@ mod tests {
         let knowledge = Knowledge::load(&dir).expect("knowledge opens");
         let report_tickets = run_report_phase(
             provider,
-            "mock",
+            Model::from_name("mock"),
             &knowledge,
             "worst_status: malicious\nfindings: 1\n".to_string(),
             "",


### PR DESCRIPTION
## Give each malware-scanner agent its own model

### Purpose

- Every agent ran the same model, so the Seeker's grep loop cost the same as the Analyst's verdict
- A scan can now spend a strong model where quality is decided and a cheap one everywhere else
- Reasoning depth and context window are per agent too, not one setting for the whole run
- Model choice is stated in a file that travels with the scan instead of an ambient variable

### What changed

- `--models <FILE>` sets one model per agent, keyed by ticket label (`security_analysis`), pool (`Analyst`), or a single agent (`Analyst 2`)
- A value is a model name or an object of `model`, `reasoning` (`off`, `low`, `medium`, `high`), and `context_window`
- The first match wins: agent name, then pool, then label
- An agent no key covers and a key naming no agent both stop the run before its first request, listing what is wrong and the valid keys
- The scanner no longer reads a model from the environment: without `--models` every agent runs the built-in default, while the provider and API key still come from the environment

### Examples

```bash
malware-scanner ./package --models models.json
```

```json
{
  "security_analysis": { "model": "claude-opus-5", "reasoning": "high" },
  "Analyst 2":         { "model": "my-local-model", "context_window": 65536 },
  "tracing":           "claude-sonnet-5",
  "seeking":           "claude-haiku-4-5",
  "exploration":       "claude-haiku-4-5",
  "reporter":          "claude-sonnet-5"
}
```

```
--models: no model for Seeker 1 (seeking), Seeker 2 (seeking)
--models: no agent matches seaking
valid keys: security_analysis, Analyst, seeking, Seeker, tracing, Tracer, exploration, Explorer, reporter, Reporter, or one agent such as "Analyst 1"
```
