### PR TITLE
Shorten the swarm example and unify README folds

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,22 +69,20 @@ async fn main() {
 Run many agents in parallel and let them share what they learn:
 
 ```rust
-use agentwerk::{Agent, Knowledge, Ticket, TicketQueue};
 use agentwerk::tools::{GrepTool, ManageTicketsTool, ReadFileTool};
+use agentwerk::{Agent, Knowledge, Ticket, TicketQueue};
 
 let tickets = TicketQueue::new();
-let store = Knowledge::load("./notes")?;
+let notes = Knowledge::load("./notes")?;
 
-for i in 0..4 {
+for _ in 0..4 {
     tickets.agent(
         Agent::new()
-            .name(format!("scout_{i}"))
             .label("scan")
-            .role("Find code that can panic. File a `report` ticket per finding, and note what you learn.")
-            .knowledge(&store)
+            .role("Grep for code that can panic. File a `report` ticket per finding, and note what you learn.")
+            .knowledge(&notes)
             .from_env()
             .tool(GrepTool)
-            .tool(ReadFileTool)
             .tool(ManageTicketsTool)
             .build(),
     );
@@ -92,10 +90,9 @@ for i in 0..4 {
 
 tickets.agent(
     Agent::new()
-        .name("writer")
         .label("report")
         .role("Read the cited file and explain the fix in two sentences.")
-        .knowledge(&store)
+        .knowledge(&notes)
         .from_env()
         .tool(ReadFileTool)
         .build(),
@@ -166,7 +163,7 @@ tickets.task("Compute (47 * 92) / 8, then round to the nearest integer.");
 ```
 
 <details>
-<summary>All agent builder methods</summary>
+<summary>All builder methods</summary>
 
 | Method | Description |
 |--------|-------------|
@@ -217,7 +214,7 @@ let agent = Agent::new().from_env();
 ```
 
 <details>
-<summary>Provider selection and endpoints</summary>
+<summary>All provider settings</summary>
 
 | Method | Description |
 |--------|-------------|
@@ -246,7 +243,7 @@ let agent = Agent::new().model(
 Claude, GPT, Mistral, and Qwen families are pre-configured.
 
 <details>
-<summary>Model settings</summary>
+<summary>All model settings</summary>
 
 | Method | Description |
 |--------|-------------|
@@ -268,13 +265,14 @@ You can use `context_window_from_env()` to read the context window size from env
 The `TicketQueue` is the core data structure of agentwerk allowing to coordinate complex interactions.
 
 ```rust
-tickets.agent(Agent::new().name("analyst").label("analysis").from_env().build());
+let analyst = Agent::new()
+    .name("analyst")
+    .label("analysis")
+    .from_env()
+    .build();
 
-tickets.ticket(
-    Ticket::new("Rank all products by value for a 10-person engineering team.")
-        .label("analysis")
-        .schema(comparison_schema),
-);
+tickets.agent(analyst);
+tickets.ticket(Ticket::new("Rank all products by value.").label("analysis"));
 ```
 
 <details>
@@ -306,7 +304,7 @@ let answer = tickets.results().pop();
 ```
 
 <details>
-<summary>Lifecycle</summary>
+<summary>All execution methods</summary>
 
 | Method | Description |
 |--------|-------------|
@@ -346,7 +344,7 @@ let report: Report = serde_json::from_value(ticket.result.clone().unwrap())?;
 ```
 
 <details>
-<summary>Working with results</summary>
+<summary>All result and ticket accessors</summary>
 
 | Method | Description |
 |--------|-------------|
@@ -391,7 +389,7 @@ tickets.ticket(Ticket::new("Write a report.").schema(schema));
 ```
 
 <details>
-<summary>Schema validation and retries</summary>
+<summary>All schema methods</summary>
 
 | Method | Description |
 |--------|-------------|
@@ -490,7 +488,7 @@ let greet = Tool::new("greet", "Say hello")
 ```
 
 <details>
-<summary>Tool options</summary>
+<summary>All tool options</summary>
 
 | Method | Description |
 |--------|-------------|
@@ -507,16 +505,13 @@ Return `ToolResult::error(message)` for a failure the model should work around.
 Events give you insights to the lifecycle and activities of your agents' work.
 
 ```rust
-use agentwerk::event::{Event, EventKind};
+use agentwerk::event::EventKind;
 
-tickets.on_event(|event: Event| {
+tickets.on_event(|event| {
     if let EventKind::TicketFinished = &event.kind {
         eprintln!("[{}] done {}", event.agent_name, event.ticket_key);
     }
 });
-
-// Stop execution at the first malicious verdict.
-tickets.cancel_on_result(|_, result| result["verdict"] == "malicious");
 ```
 
 <details>
@@ -553,8 +548,20 @@ See [`EventKind`](https://docs.rs/agentwerk/latest/agentwerk/event/enum.EventKin
 
 </details>
 
+### Hooks
+
+Hooks allow you to react to events:
+
+```rust
+tickets.cancel_on_result(|_, result| result["verdict"] == "malicious");
+
+tickets.create_ticket_on_failure(|_, ticket| {
+    Some(Ticket::new(ticket.task.clone()).label("retry"))
+});
+```
+
 <details>
-<summary>Hooks</summary>
+<summary>All hooks</summary>
 
 | | Method | Description |
 |-|--------|-------------|
@@ -649,7 +656,7 @@ let bob = Agent::new().knowledge(&store);
 ```
 
 <details>
-<summary>Reading and writing pages</summary>
+<summary>All knowledge methods</summary>
 
 | Method | Description |
 |--------|-------------|
@@ -690,7 +697,7 @@ tickets.start();
 ```
 
 <details>
-<summary>Session directory layout</summary>
+<summary>All session files</summary>
 
 ```
 .agentwerk/

--- a/agentdocs/style.md
+++ b/agentdocs/style.md
@@ -439,7 +439,7 @@ A `Schema` constrains the result an agent produces for a ticket.
 **Above the fold is what a reader needs. The exhaustive reference goes inside a `<details>` block at the end of the section.**
 
 - Nothing is deleted, only folded. A method that exists is documented somewhere, or the fold is not doing its job.
-- Folds are the last thing in a section. The `<summary>` names what it holds: `All event kinds`, `All statistics`. A section takes a second fold only when it covers two separate catalogues, as Events does with the kinds and the hooks that react to them.
+- Folds are the last thing in a section. Every `<summary>` reads `All <what the fold holds>`: `All event kinds`, `All hooks`, `All session files`. One section holds one fold; a second catalogue earns its own `h3` with its own lead example, as the hooks do under Events.
 - IMPORTANT: a blank line after `</summary>` and before `</details>`. `details` opens a raw-HTML block, so without the blank line every table inside renders as literal pipe characters on GitHub, crates.io, and PyPI alike.
 - Snippet budgets: eight lines for a section lead, five for a subsection lead. Quick Start gets sixteen.
 - Agent Swarms is the one exception and runs long, because it is the only place a whole system is shown at once: a pool working in parallel, a second pool the first hands tickets to, and one knowledge store between them. Every line there earns its place by carrying one of those three, and anything that does not belongs in a section below.
@@ -492,6 +492,7 @@ A `Schema` constrains the result an agent produces for a ticket.
 
 - Example models are `claude-haiku-4-5-20251001` or `claude-sonnet-4-20250514`.
 - Update triggers: a new builder method, a new tool, a new event kind, a new environment variable, or a changed default.
+- A chain of more than two calls breaks one call per line, even where it would fit the formatter's width. Packed onto one line the calls stop being scannable.
 - A code change edits only the doc sentences it made wrong. Surrounding prose is not rewritten unprompted.
 
 ## Rust and Python READMEs

--- a/crates/agentwerk-py/README.md
+++ b/crates/agentwerk-py/README.md
@@ -78,30 +78,27 @@ from agentwerk import Agent, Knowledge, Ticket, TicketQueue
 from agentwerk import GrepTool, ManageTicketsTool, ReadFileTool
 
 tickets = TicketQueue()
-store = Knowledge.load("./notes")
+notes = Knowledge.load("./notes")
 
-for i in range(4):
+for _ in range(4):
     tickets.agent(
         Agent()
-        .name(f"scout_{i}")
         .label("scan")
         .role(
-            "Find code that can panic. File a `report` ticket per finding, and note what you learn."
+            "Grep for code that can panic. File a `report` ticket per finding, and note what you learn."
         )
-        .knowledge(store)
+        .knowledge(notes)
         .from_env()
         .tool(GrepTool())
-        .tool(ReadFileTool())
         .tool(ManageTicketsTool())
         .build()
     )
 
 tickets.agent(
     Agent()
-    .name("writer")
     .label("report")
     .role("Read the cited file and explain the fix in two sentences.")
-    .knowledge(store)
+    .knowledge(notes)
     .from_env()
     .tool(ReadFileTool())
     .build()
@@ -171,7 +168,7 @@ tickets.task("Compute (47 * 92) / 8, then round to the nearest integer.")
 ```
 
 <details>
-<summary>All agent builder methods</summary>
+<summary>All builder methods</summary>
 
 | Method | Description |
 |--------|-------------|
@@ -213,14 +210,18 @@ Connect to a `Provider` to give agents access to LLMs. agentwerk supports: Anthr
 ```python
 from agentwerk import Agent, AnthropicProvider
 
-agent = Agent().provider(AnthropicProvider(key)).model("claude-sonnet-4-20250514")
+agent = (
+    Agent()
+    .provider(AnthropicProvider(key))
+    .model("claude-sonnet-4-20250514")
+)
 
 # Or read both from the environment.
 agent = Agent().from_env()
 ```
 
 <details>
-<summary>Provider selection and endpoints</summary>
+<summary>All provider settings</summary>
 
 | Method | Description |
 |--------|-------------|
@@ -247,7 +248,7 @@ agent = Agent().model(
 Claude, GPT, Mistral, and Qwen families are pre-configured.
 
 <details>
-<summary>Model settings</summary>
+<summary>All model settings</summary>
 
 | Method | Description |
 |--------|-------------|
@@ -269,15 +270,16 @@ You can use `context_window_from_env()` to read the context window size from env
 The `TicketQueue` is the core data structure of agentwerk allowing to coordinate complex interactions.
 
 ```python
-tickets.agent(Agent().name("analyst").label("analysis").from_env().build())
-
-tickets.ticket(
-    Ticket(
-        "Rank all products by value for a 10-person engineering team.",
-        labels=["analysis"],
-        schema=comparison_schema,
-    )
+analyst = (
+    Agent()
+    .name("analyst")
+    .label("analysis")
+    .from_env()
+    .build()
 )
+
+tickets.agent(analyst)
+tickets.ticket(Ticket("Rank all products by value.", labels=["analysis"]))
 ```
 
 <details>
@@ -309,7 +311,7 @@ answer = tickets.results()[-1]
 ```
 
 <details>
-<summary>Lifecycle</summary>
+<summary>All execution methods</summary>
 
 | Method | Description |
 |--------|-------------|
@@ -345,7 +347,7 @@ print(ticket.result["title"])
 ```
 
 <details>
-<summary>Working with results</summary>
+<summary>All result and ticket accessors</summary>
 
 | Method | Description |
 |--------|-------------|
@@ -392,7 +394,7 @@ tickets.ticket(Ticket("Write a report.", schema=schema))
 ```
 
 <details>
-<summary>Schema validation and retries</summary>
+<summary>All schema methods</summary>
 
 | Method | Description |
 |--------|-------------|
@@ -441,7 +443,12 @@ Tools allow agents to perform their work.
 ```python
 from agentwerk import Agent, BashTool, GrepTool, ReadFileTool
 
-agent = Agent().tool(ReadFileTool()).tool(GrepTool()).tool(BashTool("git", "git *"))
+agent = (
+    Agent()
+    .tool(ReadFileTool())
+    .tool(GrepTool())
+    .tool(BashTool("git", "git *"))
+)
 ```
 
 `FinishTool()` and `ManageKnowledgeTool(store)` are special tools, registered automatically on every agent. They are used for interacting with the `TicketQueue`.
@@ -489,7 +496,7 @@ def greet(name: str) -> str:
 ```
 
 <details>
-<summary>Tool options</summary>
+<summary>All tool options</summary>
 
 | Method | Description |
 |--------|-------------|
@@ -512,9 +519,6 @@ def log(event):
 
 
 tickets.on_event(log)
-
-# Stop execution at the first malicious verdict.
-tickets.cancel_on_result(lambda ticket, result: result["verdict"] == "malicious")
 ```
 
 <details>
@@ -551,8 +555,20 @@ See [`EventKind`](https://docs.rs/agentwerk/latest/agentwerk/event/enum.EventKin
 
 </details>
 
+### Hooks
+
+Hooks allow you to react to events:
+
+```python
+tickets.cancel_on_result(lambda ticket, result: result["verdict"] == "malicious")
+
+tickets.create_ticket_on_failure(
+    lambda event, ticket: Ticket(ticket.task, labels=["retry"])
+)
+```
+
 <details>
-<summary>Hooks</summary>
+<summary>All hooks</summary>
 
 | | Method | Description |
 |-|--------|-------------|
@@ -639,7 +655,7 @@ bob = Agent().knowledge(store)
 ```
 
 <details>
-<summary>Reading and writing pages</summary>
+<summary>All knowledge methods</summary>
 
 | Method | Description |
 |--------|-------------|
@@ -681,7 +697,7 @@ tickets.start()
 ```
 
 <details>
-<summary>Session directory layout</summary>
+<summary>All session files</summary>
 
 ```
 .agentwerk/


### PR DESCRIPTION
## Shorten the swarm example and unify README folds

### Purpose

- The Agent Swarms example was the longest snippet in the README and repeated two near-identical builder chains
- Fold titles named their contents fifteen different ways, so no reader could predict what was behind one
- Hooks were reference-only: the catalogue listed twenty methods with no example of a single one
- The event example did not compile, annotating `|event: Event|` where `on_event` takes `&Event`

### What changed

- Agent Swarms drops nine lines: no generated scout names, no writer name, no unused tool
- Events gains a `### Hooks` subsection with a lead example above its fold
- Every fold is now titled `All <what it holds>`, e.g. `All execution methods`, `All hooks`, `All session files`
- Chains of more than two calls break one call per line in both the Rust and Python README
- `agentdocs/style.md` records the fold-title shape and the chain-breaking rule

### Examples

```rust
tickets.cancel_on_result(|_, result| result["verdict"] == "malicious");

tickets.create_ticket_on_failure(|_, ticket| {
    Some(Ticket::new(ticket.task.clone()).label("retry"))
});
```

```python
tickets.cancel_on_result(lambda ticket, result: result["verdict"] == "malicious")

tickets.create_ticket_on_failure(
    lambda event, ticket: Ticket(ticket.task, labels=["retry"])
)
```
