### PR TITLE
Update the examples to the current queue and stats API

### DIFF
--- a/crates/agentwerk-py/examples/divide_and_conquer.py
+++ b/crates/agentwerk-py/examples/divide_and_conquer.py
@@ -142,7 +142,8 @@ async def main(n, partitions, agents):
     stats = tickets.stats()
     print(
         f"\nfinished in {stats.execution_duration():.1f}s: "
-        f"{stats.tickets_finished()} done, {stats.tickets_failed()} failed, "
+        f"{stats.event_count('ticket_finished')} done, "
+        f"{stats.event_count('ticket_failed')} failed, "
         f"{stats.input_tokens()} in / {stats.output_tokens()} out tokens"
     )
     print(f"finish reason  : {finish_reason[-1]}")

--- a/crates/use-cases/src/deep_research/main.rs
+++ b/crates/use-cases/src/deep_research/main.rs
@@ -120,13 +120,9 @@ async fn main() {
 fn print_research_outcome(tickets: &TicketQueue, outcome: &Outcome) {
     eprintln!("\n══════════════════════════════════════════════════════════");
     match outcome {
-        Outcome::Report(ticket) => {
-            let report_value = ticket
-                .result
-                .as_ref()
-                .expect("done ticket carries a result");
-            let title = report_value["title"].as_str().unwrap_or("(no title)");
-            let research = report_value["research"].as_str().unwrap_or("(no body)");
+        Outcome::Report(report) => {
+            let title = report["title"].as_str().unwrap_or("(no title)");
+            let research = report["research"].as_str().unwrap_or("(no body)");
             eprintln!(" REPORT");
             eprintln!("══════════════════════════════════════════════════════════\n");
             println!("## {title}\n\n{research}\n");
@@ -139,25 +135,15 @@ fn print_research_outcome(tickets: &TicketQueue, outcome: &Outcome) {
             };
             eprintln!(" {label}");
             eprintln!("══════════════════════════════════════════════════════════\n");
-            let all = tickets.tickets();
-            let researcher_findings: Vec<_> = all
+            let researched: Vec<(String, String)> = tickets
+                .find_tickets(|t| t.is_finished() && !t.has_label("report"))
                 .iter()
-                .filter(|t| t.is_finished())
-                .filter(|t| !t.labels.iter().any(|l| l == "report"))
-                .filter_map(|t| {
-                    t.result
-                        .as_ref()
-                        .map(|v| match v {
-                            serde_json::Value::String(s) => s.clone(),
-                            other => other.to_string(),
-                        })
-                        .map(|r| (t.key.to_string(), r))
-                })
+                .filter_map(|t| Some((t.key.clone(), plain_text(t.result.as_ref()?))))
                 .collect();
-            if researcher_findings.is_empty() {
+            if researched.is_empty() {
                 eprintln!("(no researcher produced findings)");
             } else {
-                for (key, findings) in researcher_findings {
+                for (key, findings) in researched {
                     println!("### {key}\n\n{findings}\n");
                 }
             }
@@ -166,7 +152,7 @@ fn print_research_outcome(tickets: &TicketQueue, outcome: &Outcome) {
 }
 
 enum Outcome {
-    Report(Box<agentwerk::Ticket>),
+    Report(serde_json::Value),
     Cancelled,
     Stalled,
 }
@@ -175,8 +161,8 @@ enum Outcome {
 /// ticket wins, an external cancel is surfaced, anything else means the
 /// chain stopped without reaching the report step.
 fn classify_outcome(tickets: &TicketQueue) -> Outcome {
-    if let Some(ticket) = tickets.find_ticket(|t| t.has_label("report") && t.is_finished()) {
-        return Outcome::Report(Box::new(ticket));
+    if let Some(result) = tickets.results_for_label("report").pop() {
+        return Outcome::Report(result);
     }
     if tickets.is_cancelled() {
         return Outcome::Cancelled;
@@ -205,11 +191,7 @@ fn print_chain_summary(tickets: &TicketQueue) {
         let preview = t
             .result
             .as_ref()
-            .map(|v| match v {
-                serde_json::Value::String(s) => s.clone(),
-                other => other.to_string(),
-            })
-            .map(|s| truncate(&s, 100))
+            .map(|v| truncate(&plain_text(v), 100))
             .unwrap_or_else(|| "(no result)".into());
         eprintln!(
             "  {key} {status}{labels}{parent}\n      → {preview}",
@@ -425,12 +407,16 @@ fn format_tool_call(tool_name: &str, input: &serde_json::Value) -> Vec<String> {
 }
 
 fn preview_value(value: Option<&serde_json::Value>, max: usize) -> String {
-    let raw = match value {
-        Some(serde_json::Value::String(s)) => s.clone(),
-        Some(other) => other.to_string(),
-        None => String::new(),
-    };
-    truncate(&raw, max)
+    truncate(&value.map(plain_text).unwrap_or_default(), max)
+}
+
+/// A result as prose: a JSON string loses its quotes, anything else keeps
+/// its JSON form.
+fn plain_text(value: &serde_json::Value) -> String {
+    match value {
+        serde_json::Value::String(s) => s.clone(),
+        other => other.to_string(),
+    }
 }
 
 fn truncate(s: &str, max: usize) -> String {

--- a/crates/use-cases/src/divide_and_conquer/main.rs
+++ b/crates/use-cases/src/divide_and_conquer/main.rs
@@ -16,7 +16,6 @@
 use std::io::IsTerminal;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
-use std::time::Instant;
 
 use agentwerk::event::{Event, EventKind, EventName};
 use agentwerk::providers::{model_from_env, provider_from_env};
@@ -69,20 +68,12 @@ async fn main() {
         );
     }
 
-    let started = Instant::now();
     tickets.finish().await;
-    let elapsed = started.elapsed().as_secs_f64();
 
-    aggregate_and_report(&tickets, &partitions, args.n, elapsed, &style);
+    aggregate_and_report(&tickets, &partitions, args.n, &style);
 }
 
-fn aggregate_and_report(
-    tickets: &TicketQueue,
-    partitions: &[(u64, u64)],
-    n: u64,
-    elapsed: f64,
-    style: &Style,
-) {
+fn aggregate_and_report(tickets: &TicketQueue, partitions: &[(u64, u64)], n: u64, style: &Style) {
     let total = partitions.len();
     let mut partials: Vec<Option<i128>> = vec![None; total];
     let mut failures = 0usize;
@@ -114,6 +105,7 @@ fn aggregate_and_report(
     let total_sum: i128 = partials.iter().flatten().sum();
     let expected = closed_form(n);
     let stats = tickets.stats();
+    let elapsed = stats.execution_duration().unwrap_or_default().as_secs_f64();
 
     eprintln!(
         "{dim}└ aggregated in {elapsed:.1}s · {} done, {failures} failed · {} in / {} out tokens{reset}",

--- a/crates/use-cases/src/malware_scanner/main.rs
+++ b/crates/use-cases/src/malware_scanner/main.rs
@@ -175,20 +175,8 @@ async fn main() {
     tickets.on_event(move |e| log_event(e, &log_tickets));
 
     // A policy trip alone never flips `is_cancelled()`, so `--max-time` would
-    // otherwise just abandon tickets `InProgress` forever. `MaxSchemaRetries`
-    // is excluded: it's a per-ticket budget, not a run-wide one.
-    tickets.cancel_on_event(|e| {
-        matches!(
-            e.kind,
-            EventKind::PolicyViolated {
-                policy: PolicyKind::Time
-                    | PolicyKind::Turns
-                    | PolicyKind::InputTokens
-                    | PolicyKind::OutputTokens,
-                ..
-            }
-        )
-    });
+    // otherwise just abandon tickets `InProgress` forever.
+    tickets.cancel_on_event(is_run_wide_policy_stop);
 
     // A policy stop (time/turns/tokens) is a graceful end, not an abort: unlike a
     // ctrl-c cancel it must still produce the report. Record it so the abort check
@@ -196,16 +184,7 @@ async fn main() {
     let policy_stopped = Arc::new(AtomicBool::new(false));
     let policy_flag = Arc::clone(&policy_stopped);
     tickets.on_event(move |e| {
-        if matches!(
-            e.kind,
-            EventKind::PolicyViolated {
-                policy: PolicyKind::Time
-                    | PolicyKind::Turns
-                    | PolicyKind::InputTokens
-                    | PolicyKind::OutputTokens,
-                ..
-            }
-        ) {
+        if is_run_wide_policy_stop(e) {
             policy_flag.store(true, Ordering::Relaxed);
         }
     });
@@ -216,31 +195,29 @@ async fn main() {
     let malicious_found = Arc::new(AtomicBool::new(false));
     if args.fail_fast {
         let trip = Arc::clone(&malicious_found);
-        let queue = Arc::clone(&tickets);
-        tickets.on_ticket(move |event, ticket| {
-            if !matches!(event.kind, EventKind::TicketFinished)
-                || !ticket.result.as_ref().is_some_and(is_malicious_verdict)
-            {
-                return;
+        tickets.on_result(move |_, result| {
+            if is_malicious_verdict(result) {
+                trip.store(true, Ordering::Relaxed);
             }
-            trip.store(true, Ordering::Relaxed);
-            queue
-                .cancel_label(SEEKER_LABEL)
-                .cancel_label(TRACER_LABEL)
-                .cancel_label(ANALYSIS_LABEL);
         });
+        for label in [SEEKER_LABEL, TRACER_LABEL, ANALYSIS_LABEL] {
+            tickets.cancel_label_on_result(label, |_, result| is_malicious_verdict(result));
+        }
     }
 
-    // Capture the transcript of any ticket that lands a malicious or exploitable
+    // Capture the messages of any ticket that lands a malicious or exploitable
     // verdict as a training example under trajectories/, on every run (not just
     // fail-fast). Benign dismissals are skipped.
     let trajectory_queue = Arc::clone(&tickets);
-    tickets.on_ticket(move |event, ticket| {
-        if is_finding(event, ticket) {
-            let model = trajectory_queue.model_for_agent(&event.agent_name);
-            let _ =
-                Trajectory::from_ticket(&event.agent_name, model.as_deref(), ticket).save(WORK_DIR);
+    tickets.on_result(move |ticket, result| {
+        if !is_finding_verdict(result) {
+            return;
         }
+        let Some(agent) = ticket.assignee.as_deref() else {
+            return;
+        };
+        let model = trajectory_queue.model_for_agent(agent);
+        let _ = Trajectory::from_ticket(agent, model.as_deref(), ticket).save(WORK_DIR);
     });
 
     let instruction_section = match args.instruction.as_deref() {
@@ -604,11 +581,19 @@ fn merge_reporter_verdict(tickets: &TicketQueue, analysis: &mut Value) {
     }
 }
 
-/// True when `ticket` just finished with a finding worth keeping as a training
-/// example: a malicious or exploitable verdict, never a benign dismissal.
-fn is_finding(event: &Event, ticket: &Ticket) -> bool {
-    matches!(event.kind, EventKind::TicketFinished)
-        && ticket.result.as_ref().is_some_and(is_finding_verdict)
+/// True when a limit bounding the whole run was breached. `MaxSchemaRetries` is
+/// excluded: it's a per-ticket budget, so tripping it stops one ticket, not the run.
+fn is_run_wide_policy_stop(event: &Event) -> bool {
+    matches!(
+        event.kind,
+        EventKind::PolicyViolated {
+            policy: PolicyKind::Time
+                | PolicyKind::Turns
+                | PolicyKind::InputTokens
+                | PolicyKind::OutputTokens,
+            ..
+        }
+    )
 }
 
 /// True when a schema-validated result object carries `status: "malicious"`.

--- a/crates/use-cases/src/malware_scanner/report.rs
+++ b/crates/use-cases/src/malware_scanner/report.rs
@@ -17,10 +17,7 @@ pub(crate) fn build_analysis(tickets: &TicketQueue, scan_dir: &Path, total_files
     let mut index: HashMap<(String, Option<u64>, Option<u64>), usize> = HashMap::new();
     let mut unparsed: usize = 0;
 
-    for ticket in tickets.tickets() {
-        if !ticket.has_label(ANALYSIS_LABEL) {
-            continue;
-        }
+    for ticket in tickets.tickets_for_label(ANALYSIS_LABEL) {
         let Some(attached) = ticket.result.as_ref() else {
             unparsed += 1;
             continue;

--- a/crates/use-cases/src/terminal_repl/main.rs
+++ b/crates/use-cases/src/terminal_repl/main.rs
@@ -277,12 +277,7 @@ async fn main() {
         // breaks out before its own content.
         midstream.store(true, Ordering::Relaxed);
         let key = match chat_key.as_deref() {
-            Some(k)
-                if tickets
-                    .tickets()
-                    .iter()
-                    .any(|t| t.key == k && t.is_in_progress()) =>
-            {
+            Some(k) if tickets.get_ticket(k).is_some_and(|t| t.is_in_progress()) => {
                 tickets.reply(k, payload);
                 k.to_string()
             }
@@ -311,9 +306,7 @@ async fn main() {
 
         let stats = tickets.stats();
         let outcome = {
-            let chat = chat_key
-                .as_deref()
-                .and_then(|k| tickets.tickets().into_iter().find(|t| t.key == k));
+            let chat = chat_key.as_deref().and_then(|k| tickets.get_ticket(k));
             match chat {
                 Some(t) if t.is_finished() => {
                     chat_key = None;


### PR DESCRIPTION
## Update the examples to the current queue and stats API

### Purpose

- The Python example crashed after every run: it called ticket counters that were removed when each event began counting itself.
- Nothing in CI runs the examples, so that break stayed invisible.
- The Rust examples still scanned the whole queue to reach one ticket, one label, or one result.
- Two scanner hooks re-derived what `on_result` already hands over, and one timed the run itself.

### What changed

- Python: `stats.event_count("ticket_finished")` replaces the removed `stats.tickets_finished()` / `tickets_failed()`.
- Lookups go through the readers: `get_ticket(key)`, `tickets_for_label(label)`, `results_for_label(label)`.
- Elapsed time comes from `stats.execution_duration()` instead of a hand-held `Instant`.
- The malware scanner reacts through `on_result` and `cancel_label_on_result`, and names its agent from `Ticket.assignee`.
- No library code changes: the public API is untouched.

### Examples

```py
stats = tickets.stats()
print(f"{stats.event_count('ticket_finished')} done, {stats.event_count('ticket_failed')} failed")
```

```rust
let report = tickets.results_for_label("report").pop();
let chat = tickets.get_ticket(&key);
let elapsed = tickets.stats().execution_duration().unwrap_or_default();
```

```rust
tickets.cancel_label_on_result("seeking", |_, result| result["status"] == "malicious");
tickets.on_result(move |ticket, result| {
    let agent = ticket.assignee.as_deref().unwrap_or_default();
    let _ = Trajectory::from_ticket(agent, None, ticket).save(".agentwerk");
});
```
