### PR TITLE
docs: show the demo at the top and the belt under Tickets

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 ---
 
 <div align="center">
-  <img src="https://raw.githubusercontent.com/canvascomputing/agentwerk/main/tickets.gif" width="800" />
+  <img src="https://raw.githubusercontent.com/canvascomputing/agentwerk/main/demo.gif" width="800" />
 </div>
 <div align="center"><a href="crates/agentwerk-py/examples/apparat_fabrik.py">Apparat Fabrik</a></div>
 <div align="center"><em>agentwerk pairs "agent" with the German "Werk", a word for both factory and artwork: machinery for building agentic systems.</em></div>
@@ -224,7 +224,7 @@ Claude, GPT, Mistral, and Qwen families are pre-configured.
 ## Tickets
 
 <div align="left">
-  <img src="https://raw.githubusercontent.com/canvascomputing/agentwerk/main/tickets.jpg" width="600" />
+  <img src="https://raw.githubusercontent.com/canvascomputing/agentwerk/main/tickets.gif" width="600" />
 </div>
 
 The `TicketQueue` is the core data structure of agentwerk allowing to coordinate complex interactions.

--- a/crates/agentwerk-py/README.md
+++ b/crates/agentwerk-py/README.md
@@ -21,7 +21,7 @@
 ---
 
 <div align="center">
-  <img src="https://raw.githubusercontent.com/canvascomputing/agentwerk/main/tickets.gif" width="800" />
+  <img src="https://raw.githubusercontent.com/canvascomputing/agentwerk/main/demo.gif" width="800" />
 </div>
 <div align="center"><a href="https://github.com/canvascomputing/agentwerk/blob/main/crates/agentwerk-py/examples/apparat_fabrik.py">Apparat Fabrik</a></div>
 <div align="center"><em>agentwerk pairs "agent" with the German "Werk", a word for both factory and artwork: machinery for building agentic systems.</em></div>
@@ -230,7 +230,7 @@ Claude, GPT, Mistral, and Qwen families are pre-configured.
 ## Tickets
 
 <div align="left">
-  <img src="https://raw.githubusercontent.com/canvascomputing/agentwerk/main/tickets.jpg" width="600" />
+  <img src="https://raw.githubusercontent.com/canvascomputing/agentwerk/main/tickets.gif" width="600" />
 </div>
 
 The `TicketQueue` is the core data structure of agentwerk allowing to coordinate complex interactions.


### PR DESCRIPTION
## Show the demo at the top and the belt under Tickets

### Purpose

- The top of both READMEs stands for a whole shift, which `demo.gif` records
- The Tickets section had a still, `tickets.jpg`, for a queue that moves

### What changed

- Both READMEs open with `demo.gif` again, at 800px
- The Tickets section shows `tickets.gif`, at 600px
- `tickets.jpg` has no reference left in either README

### Examples

```html
<img src="https://raw.githubusercontent.com/canvascomputing/agentwerk/main/demo.gif" width="800" />
```

```html
<img src="https://raw.githubusercontent.com/canvascomputing/agentwerk/main/tickets.gif" width="600" />
```
