### PR TITLE
Fix unclaimable-ticket examples and rewrite the README lead

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <h1 align="center">agentwerk</h1>
 
 <div align="center">
-  <strong>A minimal Rust & Python library for running many agents in parallel.</strong>
+  <strong>A minimal Rust & Python library for solving hard problems with many agents.</strong>
 </div>
 
 <div align="center">
@@ -17,7 +17,7 @@
 </div>
 
 
-<div align="center">agentwerk is designed to tackle complex problems with fleets of agents through the simplest interface possible. It provides a ticket queue which distributes tasks across agents running in parallel, validates results, retries on failure, and reports every step as an event.</div>
+<div align="center">agentwerk is a lightweight harness built for small LLMs: it splits work into tickets to keep each context short, runs them in parallel, validates results against a format you define, and reports every step as an event.</div>
 
 ---
 
@@ -32,9 +32,8 @@
 ## Why use agentwerk?
 
 - **Simple interface:** create agents with a few lines of code.
-- **Efficient harness:** optimized for LLMs below 30B parameters with low memory footprint.
+- **Efficient harness:** low memory footprint, even with many agents at work.
 - **Complex interactions:** allow agents to collaborate through queues and shared knowledge.
-- **Deep observability:** inspect every request, tool call, and failure.
 - **Facilitate training:** store trajectories based on granular events for fine-tuning models.
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -31,11 +31,11 @@
 
 ## Why use agentwerk?
 
-- **Minimal interface:** create agents with a few lines of code.
-- **Complex workflows:** allow agents to interact through shared knowledge and tickets.
-- **Deep observability:** inspect every request, message and failure.
-- **Ease of integration:** apply agents as simple as HTTP calls.
-- **Facilitate training:** collect trajectories for fine-tuning models.
+- **Simple interface:** create agents with a few lines of code.
+- **Efficient harness:** optimized for LLMs below 30B parameters with low memory footprint.
+- **Complex interactions:** allow agents to collaborate through queues and shared knowledge.
+- **Deep observability:** inspect every request, tool call, and failure.
+- **Facilitate training:** store trajectories based on granular events for fine-tuning models.
 
 ## Installation
 
@@ -110,13 +110,11 @@ An `Agent` is the core entity of agentwerk. It has access to tools for solving t
 use agentwerk::tools::ReadFileTool;
 
 let agent = Agent::from_env()
-    .label("math")
     .role("You are an arithmetic agent. Compute step by step and show your work.")
     .tool(ReadFileTool)
     .build();
 
-tickets.agent(agent);
-tickets.task("Compute (47 * 92) / 8, then round to the nearest integer.");
+agent.task("Compute (47 * 92) / 8, then round to the nearest integer.");
 ```
 
 <details>
@@ -545,8 +543,12 @@ See [`EventKind`](https://docs.rs/agentwerk/latest/agentwerk/event/enum.EventKin
 Hooks allow you to react to events:
 
 ```rust
-tickets.create_ticket_on_failure(|_, ticket| {
-    Some(Ticket::new(ticket.task.clone()).label("retry"))
+tickets.create_ticket_on_failure(|_, failed| {
+    failed.parent.is_none().then(|| {
+        Ticket::new(failed.task.clone())
+            .labels(failed.labels.clone())
+            .parent(&failed.key)
+    })
 });
 ```
 

--- a/crates/agentwerk-py/README.md
+++ b/crates/agentwerk-py/README.md
@@ -5,7 +5,7 @@
 <h1 align="center">agentwerk (Python)</h1>
 
 <div align="center">
-  <strong>A minimal Rust & Python library for running many agents in parallel.</strong>
+  <strong>A minimal Rust & Python library for solving hard problems with many agents.</strong>
 </div>
 
 <div align="center">
@@ -16,7 +16,7 @@
   <a href="#development">Development</a>
 </div>
 
-<div align="center">agentwerk is designed to tackle complex problems with fleets of agents through the simplest interface possible. It provides a ticket queue which distributes tasks across agents running in parallel, validates results, retries on failure, and reports every step as an event.</div>
+<div align="center">agentwerk is a lightweight harness built for small LLMs: it splits work into tickets to keep each context short, runs them in parallel, validates results against a format you define, and reports every step as an event.</div>
 
 ---
 
@@ -31,9 +31,8 @@
 ## Why use agentwerk?
 
 - **Simple interface:** create agents with a few lines of code.
-- **Efficient harness:** optimized for LLMs below 30B parameters with low memory footprint.
+- **Efficient harness:** low memory footprint, even with many agents at work.
 - **Complex interactions:** allow agents to collaborate through queues and shared knowledge.
-- **Deep observability:** inspect every request, tool call, and failure.
 - **Facilitate training:** store trajectories based on granular events for fine-tuning models.
 
 ## Installation

--- a/crates/agentwerk-py/README.md
+++ b/crates/agentwerk-py/README.md
@@ -30,11 +30,11 @@
 
 ## Why use agentwerk?
 
-- **Minimal interface:** create agents with a few lines of code.
-- **Complex workflows:** allow agents to interact through shared knowledge and tickets.
-- **Deep observability:** inspect every request, message and failure.
-- **Ease of integration:** apply agents as simple as HTTP calls.
-- **Facilitate training:** collect trajectories for fine-tuning models.
+- **Simple interface:** create agents with a few lines of code.
+- **Efficient harness:** optimized for LLMs below 30B parameters with low memory footprint.
+- **Complex interactions:** allow agents to collaborate through queues and shared knowledge.
+- **Deep observability:** inspect every request, tool call, and failure.
+- **Facilitate training:** store trajectories based on granular events for fine-tuning models.
 
 ## Installation
 
@@ -115,14 +115,12 @@ from agentwerk import Agent, ReadFileTool
 
 agent = (
     Agent.from_env()
-    .label("math")
     .role("You are an arithmetic agent. Compute step by step and show your work.")
     .tool(ReadFileTool())
     .build()
 )
 
-tickets.agent(agent)
-tickets.task("Compute (47 * 92) / 8, then round to the nearest integer.")
+agent.task("Compute (47 * 92) / 8, then round to the nearest integer.")
 ```
 
 <details>
@@ -558,10 +556,13 @@ See [`EventKind`](https://docs.rs/agentwerk/latest/agentwerk/event/enum.EventKin
 Hooks allow you to react to events:
 
 ```python
+def retry_once(event, failed):
+    if failed.parent is not None:
+        return None
+    return Ticket(failed.task, labels=failed.labels, parent=failed.key)
 
-tickets.create_ticket_on_failure(
-    lambda event, ticket: Ticket(ticket.task, labels=["retry"])
-)
+
+tickets.create_ticket_on_failure(retry_once)
 ```
 
 <details>


### PR DESCRIPTION
## Fix unclaimable-ticket examples and rewrite the README lead

### Purpose

- The Agents example gave the agent a label but filed an unlabeled ticket
- A labeled agent claims only tickets carrying that label, so nothing claimed it
- `finish_all` never returns for a ticket no agent can claim
- The title, subtitle, and bullets each repeated the same three claims
- The subtitle named schemas and events before either section introduces them

### What changed

- The Agents example drops `label` and submits the task through `agent.task`
- `create_ticket_on_failure` re-files a retry under the failed ticket's own labels
- The retry reads `parent` as its guard, so a task is retried once
- The subtitle states the machinery in one sentence, naming no schema
- The bullets drop the two claims the subtitle now carries
- Both the Rust and the Python README carry the same lead and bullets

### Examples

```rust
tickets.create_ticket_on_failure(|_, failed| {
    failed.parent.is_none().then(|| {
        Ticket::new(failed.task.clone())
            .labels(failed.labels.clone())
            .parent(&failed.key)
    })
});
```

```python
def retry_once(event, failed):
    if failed.parent is not None:
        return None
    return Ticket(failed.task, labels=failed.labels, parent=failed.key)


tickets.create_ticket_on_failure(retry_once)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
