### PR TITLE
docs: restore the observability bullet and name the model size

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,9 @@
 ## Why use agentwerk?
 
 - **Simple interface:** create agents with a few lines of code.
-- **Efficient harness:** low memory footprint, even with many agents at work.
+- **Efficient harness:** optimized for LLMs below 30B parameters with low memory footprint.
 - **Complex interactions:** allow agents to collaborate through queues and shared knowledge.
+- **Deep observability:** inspect every request, tool call, and failure.
 - **Facilitate training:** store trajectories based on granular events for fine-tuning models.
 
 ## Installation

--- a/crates/agentwerk-py/README.md
+++ b/crates/agentwerk-py/README.md
@@ -31,8 +31,9 @@
 ## Why use agentwerk?
 
 - **Simple interface:** create agents with a few lines of code.
-- **Efficient harness:** low memory footprint, even with many agents at work.
+- **Efficient harness:** optimized for LLMs below 30B parameters with low memory footprint.
 - **Complex interactions:** allow agents to collaborate through queues and shared knowledge.
+- **Deep observability:** inspect every request, tool call, and failure.
 - **Facilitate training:** store trajectories based on granular events for fine-tuning models.
 
 ## Installation


### PR DESCRIPTION
## Restore the observability bullet and name the model size

### Purpose

- The previous README pass removed the **Deep observability** bullet
- The **Efficient harness** bullet claimed a memory footprint without naming who the harness is for
- agentwerk targets LLMs below 30B parameters, which the feature list did not say

### What changed

- **Efficient harness** reads "optimized for LLMs below 30B parameters with low memory footprint"
- **Deep observability** is back: "inspect every request, tool call, and failure"
- `README.md` and `crates/agentwerk-py/README.md` carry the same five bullets

### Result

```markdown
- **Simple interface:** create agents with a few lines of code.
- **Efficient harness:** optimized for LLMs below 30B parameters with low memory footprint.
- **Complex interactions:** allow agents to collaborate through queues and shared knowledge.
- **Deep observability:** inspect every request, tool call, and failure.
- **Facilitate training:** store trajectories based on granular events for fine-tuning models.
```
