### PR TITLE
Reword the README subtitle around agents and results

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 </div>
 
 
-<div align="center">agentwerk is a lightweight harness built for small LLMs: it splits work into tickets to keep each context short, runs them in parallel, validates results against a format you define, and reports every step as an event.</div>
+<div align="center">agentwerk is a lightweight harness built for small LLMs: it splits work into tickets to keep context windows short, runs agents in parallel, validates their results and reports every step as an event.</div>
 
 ---
 

--- a/crates/agentwerk-py/README.md
+++ b/crates/agentwerk-py/README.md
@@ -16,7 +16,7 @@
   <a href="#development">Development</a>
 </div>
 
-<div align="center">agentwerk is a lightweight harness built for small LLMs: it splits work into tickets to keep each context short, runs them in parallel, validates results against a format you define, and reports every step as an event.</div>
+<div align="center">agentwerk is a lightweight harness built for small LLMs: it splits work into tickets to keep context windows short, runs agents in parallel, validates their results and reports every step as an event.</div>
 
 ---
 


### PR DESCRIPTION
## Reword the README subtitle around agents and results

### Purpose

- The subtitle ran before the README introduces schemas, so "a format you define" named nothing the reader had yet
- "runs them in parallel" pointed back at tickets; what runs in parallel is agents
- "each context" left open whose context stays short

### What changed

- Both the Rust and the Python README carry the same reworded subtitle
- The sentence names context windows, agents and their results, the terms the rest of the README uses
- No API, code or section text changes

### Examples

```markdown
agentwerk is a lightweight harness built for small LLMs: it splits work into tickets to keep context windows short, runs agents in parallel, validates their results and reports every step as an event.
```
