### PR TITLE
api: hand a hook every result so far, not just the last one

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,7 @@ Agents can share the results of their work in the following ways:
 2. **Read tickets**: the `tickets` tool allows reading any finished ticket's result, by key.
 3. **Read result file**: the `read_file` tool reads a ticket's `result.json` in the session directory.
 4. **Share knowledge**: the `manage_knowledge` tool allows sharing knowledge with other agents.
+5. **Register hooks**: the `create_ticket_on_result` and `create_tickets_on_results` hooks allow creating follow-up tickets when results arrive.
 
 <details>
 <summary>All ways agents pass data</summary>
@@ -389,6 +390,24 @@ The `manage_knowledge` tool allows sharing knowledge with other agents:
   "description": "How the products rank on value.",
   "content": "Three products lead on value: ..."
 }
+```
+
+#### 5. Register hooks
+
+Use hooks to create new tickets when certain results arrived:
+
+```rust
+tickets.create_ticket_on_result(|done, result| {
+    done.has_label("research")
+        .then(|| Ticket::new(result.clone()).label("report"))
+});
+
+tickets.create_tickets_on_results(|results| {
+    match results.iter().filter(|r| r["scanned"] == true).count() == 3 {
+        true => vec![Ticket::new("Write the report.").label("report")],
+        false => Vec::new(),
+    }
+});
 ```
 
 </details>
@@ -609,10 +628,12 @@ tickets.create_ticket_on_failure(|_, failed| {
 |-|--------|-------------|
 | **Observe** | `on_event(handler)` | Read every event as it is emitted. |
 | | `on_result(handler)` | Read every finished ticket together with its result. |
+| | `on_results(handler)` | Read every result the run has produced so far, each time one lands. |
 | | `on_failure(handler)` | Read every failure together with the ticket it happened in. |
 | | `on_ticket(handler)` | Read a ticket as it starts, finishes, or fails. |
 | **Add work** | `create_ticket_on_event(make)` | Enqueue a follow-up ticket from any event. |
 | | `create_ticket_on_result(make)` | Enqueue a follow-up ticket from a finished ticket. |
+| | `create_tickets_on_results(make)` | Enqueue follow-up tickets once a condition across every result holds. |
 | | `create_ticket_on_failure(make)` | Enqueue a retry for a ticket that failed. |
 | **Rewrite** | `edit_replies_on_event(editor)` | Rewrite a ticket's replies before its next request. |
 | | `edit_replies_on_compaction(editor)` | Decide what compaction does with a ticket's replies. |

--- a/crates/agentwerk-py/DIFFS.md
+++ b/crates/agentwerk-py/DIFFS.md
@@ -71,10 +71,12 @@ Seven rules the surface table below never repeats.
 | `TicketQueue::schemas(&store)` | `TicketQueue.schemas(store)` |
 | `TicketQueue::on_event(h)` | `TicketQueue.on_event(callback)` |
 | `TicketQueue::on_result(handler)` | `TicketQueue.on_result(callback)` |
+| `TicketQueue::on_results(handler)` | `TicketQueue.on_results(callback)`: the results arrive as a list. |
 | `TicketQueue::on_failure(handler)` | `TicketQueue.on_failure(callback)` |
 | `TicketQueue::on_ticket(handler)` | `TicketQueue.on_ticket(callback)` |
 | `TicketQueue::create_ticket_on_event(make)` | `TicketQueue.create_ticket_on_event(make)` |
 | `TicketQueue::create_ticket_on_result(make)` | `TicketQueue.create_ticket_on_result(make)` |
+| `TicketQueue::create_tickets_on_results(make)` | `TicketQueue.create_tickets_on_results(make)`: hand back any sequence of tickets. `None` adds nothing, where Rust has only the empty `Vec`. |
 | `TicketQueue::create_ticket_on_failure(make)` | `TicketQueue.create_ticket_on_failure(make)` |
 | `TicketQueue::edit_replies(key, edit)` | `TicketQueue.edit_replies(key, editor)`: the editor returns the new list, or `None` to keep the old one, where Rust mutates in place. An editor that raises, or returns anything but `Reply` objects, raises here. |
 | `TicketQueue::edit_replies_on_event(editor)` | `TicketQueue.edit_replies_on_event(editor)`: same return-instead-of-mutate shape. An editor that raises prints its traceback and changes nothing: it runs on an agent thread with no Python frame to raise into. |

--- a/crates/agentwerk-py/python/agentwerk/__init__.pyi
+++ b/crates/agentwerk-py/python/agentwerk/__init__.pyi
@@ -326,6 +326,9 @@ class TicketQueue:
     def on_result(
         self, callback: Callable[[Ticket, Any], Any]
     ) -> "TicketQueue": ...
+    def on_results(
+        self, callback: Callable[[list[Any]], Any]
+    ) -> "TicketQueue": ...
     def on_failure(
         self, callback: Callable[[Event, Ticket], Any]
     ) -> "TicketQueue": ...
@@ -334,6 +337,9 @@ class TicketQueue:
     ) -> "TicketQueue": ...
     def create_ticket_on_result(
         self, make: Callable[[Ticket, Any], Optional[Ticket]]
+    ) -> "TicketQueue": ...
+    def create_tickets_on_results(
+        self, make: Callable[[list[Any]], Optional[list[Ticket]]]
     ) -> "TicketQueue": ...
     def create_ticket_on_failure(
         self, make: Callable[[Event, Ticket], Optional[Ticket]]

--- a/crates/agentwerk-py/src/ticket_queue.rs
+++ b/crates/agentwerk-py/src/ticket_queue.rs
@@ -230,6 +230,20 @@ impl PyTicketQueue {
         slf
     }
 
+    /// Read every result the run has produced so far, each time one lands. The
+    /// same list `results()` gives after the run, in creation order, delivered
+    /// while it is still going.
+    fn on_results<'py>(slf: PyRef<'py, Self>, callback: Py<PyAny>) -> PyRef<'py, Self> {
+        slf.inner.on_results(move |results: &[Value]| {
+            Python::attach(|py| {
+                if let Err(err) = call_with_results(py, &callback, results) {
+                    err.print(py);
+                }
+            });
+        });
+        slf
+    }
+
     /// Read every failure together with the ticket it happened in: a failed
     /// ticket, tool call, or request, a file that would not open, or compaction
     /// that could not finish. Read `event.kind` to tell them apart.
@@ -264,6 +278,24 @@ impl PyTicketQueue {
                 Python::attach(|py| {
                     let produced = call_with_result(py, &make, ticket, result).ok()?;
                     built_ticket(&produced)
+                })
+            });
+        slf
+    }
+
+    /// Enqueue follow-up tickets once a condition across every result holds.
+    /// Your function is the condition: return an empty list or `None` until
+    /// the results call for the work, which is also what stops a follow-up
+    /// whose own result triggers it again.
+    fn create_tickets_on_results<'py>(slf: PyRef<'py, Self>, make: Py<PyAny>) -> PyRef<'py, Self> {
+        slf.inner
+            .create_tickets_on_results(move |results: &[Value]| {
+                Python::attach(|py| match call_with_results(py, &make, results) {
+                    Ok(produced) => built_tickets(&produced),
+                    Err(err) => {
+                        err.print(py);
+                        Vec::new()
+                    }
                 })
             });
         slf
@@ -600,6 +632,20 @@ fn call_with_ticket<'py>(
     callable.bind(py).call1((to_py_event(event), view))
 }
 
+/// Call a Python function with the parent and its children's results every
+/// `_on_results` hook hands over.
+fn call_with_results<'py>(
+    py: Python<'py>,
+    callable: &Py<PyAny>,
+    results: &[Value],
+) -> PyResult<Bound<'py, PyAny>> {
+    let values = results
+        .iter()
+        .map(|result| value_to_py(py, result))
+        .collect::<PyResult<Vec<_>>>()?;
+    callable.bind(py).call1((values,))
+}
+
 /// Read a ticket back out of what a `create_ticket_*` function returned. `None`,
 /// or anything that is not a `Ticket`, adds nothing.
 fn built_ticket(produced: &Bound<'_, PyAny>) -> Option<Ticket> {
@@ -607,6 +653,19 @@ fn built_ticket(produced: &Bound<'_, PyAny>) -> Option<Ticket> {
         return None;
     }
     Some(produced.extract::<PyRef<PyTicket>>().ok()?.to_ticket())
+}
+
+/// Read every ticket back out of what `create_tickets_on_results` returned.
+/// Anything that is not a sequence, `None` included, and any element that is
+/// not a `Ticket`, adds nothing.
+fn built_tickets(produced: &Bound<'_, PyAny>) -> Vec<Ticket> {
+    let Ok(items) = produced.try_iter() else {
+        return Vec::new();
+    };
+    items
+        .flatten()
+        .filter_map(|item| built_ticket(&item))
+        .collect()
 }
 
 /// Ask a Python condition about a ticket. A conversion or Python error reads as

--- a/crates/agentwerk-py/tests/test_tickets.py
+++ b/crates/agentwerk-py/tests/test_tickets.py
@@ -240,6 +240,35 @@ def test_on_result_receives_the_finished_ticket_and_its_result(queue):
     assert seen == [(key, {"verdict": "clean"})]
 
 
+def test_on_results_hands_over_every_result_so_far(queue):
+    seen = []
+    queue.on_results(lambda results: seen.append(results))
+    first = queue.ticket(aw.Ticket("scan a.py"))
+    second = queue.ticket(aw.Ticket("scan b.py"))
+
+    queue.set_finished(first, "clean")
+    queue.set_finished(second, "malicious")
+
+    assert seen == [["clean"], ["clean", "malicious"]]
+
+
+def test_create_tickets_on_results_waits_until_the_results_call_for_the_work(queue):
+    queue.create_tickets_on_results(
+        lambda results: [aw.Ticket(r, label="review") for r in results]
+        if len(results) == 2
+        else None
+    )
+    first = queue.ticket(aw.Ticket("scan a.py"))
+    second = queue.ticket(aw.Ticket("scan b.py"))
+
+    queue.set_finished(first, "clean")
+    assert queue.find_tickets(lambda t: t.label == "review") == []
+
+    queue.set_finished(second, "malicious")
+    filed = [t.task for t in queue.find_tickets(lambda t: t.label == "review")]
+    assert filed == ["clean", "malicious"]
+
+
 def test_on_failure_receives_the_failed_ticket(queue):
     seen = []
     queue.on_failure(lambda event, ticket: seen.append((event.kind, ticket.key)))

--- a/crates/agentwerk/src/agents/tickets/ticket_queue.rs
+++ b/crates/agentwerk/src/agents/tickets/ticket_queue.rs
@@ -397,6 +397,40 @@ impl TicketQueue {
         })
     }
 
+    /// Read every result the run has produced so far, each time one lands.
+    ///
+    /// Where [`Self::on_result`] hands over the one ticket that just finished,
+    /// this hands over all of them: the same [`Self::results`] a caller reads
+    /// after the run, in creation order, delivered while it is still going.
+    /// That is what lets a handler act on a condition across results rather
+    /// than on any single one, such as every result it was waiting for having
+    /// arrived.
+    ///
+    /// ```no_run
+    /// # use agentwerk::TicketQueue;
+    /// let tickets = TicketQueue::new();
+    /// tickets.on_results(|results| {
+    ///     if results.len() == 3 {
+    ///         println!("every scan landed");
+    ///     }
+    /// });
+    /// ```
+    pub fn on_results<H>(&self, handler: H) -> &Self
+    where
+        H: Fn(&[serde_json::Value]) + Send + Sync + 'static,
+    {
+        let supervisor = self.weak_self.clone();
+        self.on_event(move |event| {
+            if !matches!(event.kind, EventKind::TicketFinished) {
+                return;
+            }
+            let Some(queue) = supervisor.upgrade() else {
+                return;
+            };
+            handler(&queue.results());
+        })
+    }
+
     /// Read every failure together with the ticket it happened in:
     /// `TicketFailed`, `RequestFailed`, `ToolCallFailed`, `FileOpenFailed`,
     /// `KnowledgeFailed`, and `CompactionFailed`.
@@ -828,6 +862,43 @@ impl TicketQueue {
             };
             if let Some(queue) = supervisor.upgrade() {
                 queue.ticket(ticket);
+            }
+        })
+    }
+
+    /// Enqueue follow-up tickets once a condition across every result holds.
+    ///
+    /// The many-to-many counterpart to [`Self::create_ticket_on_result`], on
+    /// the terms [`Self::on_results`] sets: every result so far in, as many
+    /// follow-ups as you hand back out. Your function is the condition, so
+    /// hand back an empty `Vec` until the results call for the work, which is
+    /// how it waits for the ones it needs. That also guards against a
+    /// follow-up whose own result triggers it again, or execution never ends.
+    ///
+    /// ```no_run
+    /// # use agentwerk::{Ticket, TicketQueue};
+    /// let tickets = TicketQueue::new();
+    /// tickets.create_tickets_on_results(|results| {
+    ///     match results.iter().filter(|r| r["scanned"] == true).count() == 3 {
+    ///         true => vec![Ticket::new("Write the report.").label("report")],
+    ///         false => Vec::new(),
+    ///     }
+    /// });
+    /// ```
+    pub fn create_tickets_on_results<M>(&self, make: M) -> &Self
+    where
+        M: Fn(&[serde_json::Value]) -> Vec<Ticket> + Send + Sync + 'static,
+    {
+        let supervisor = self.weak_self.clone();
+        self.on_results(move |results| {
+            let follow_ups = make(results);
+            if follow_ups.is_empty() {
+                return;
+            }
+            if let Some(queue) = supervisor.upgrade() {
+                for ticket in follow_ups {
+                    queue.ticket(ticket);
+                }
             }
         })
     }
@@ -1908,6 +1979,86 @@ mod tests {
         queue.create_ticket_on_result(|_, _| Some(Ticket::new("follow-up").label("next")));
         queue.emit("KEY", "agent", EventKind::TurnStarted);
         assert!(queue.tickets().is_empty());
+    }
+
+    /// File `count` tickets labelled `scan`, all `Todo`.
+    fn scans(queue: &TicketQueue, count: usize) -> Vec<String> {
+        (0..count)
+            .map(|i| queue.ticket(Ticket::new(format!("scan {i}")).label("scan")))
+            .collect()
+    }
+
+    #[test]
+    fn on_results_hands_over_every_result_so_far_each_time_one_lands() {
+        let (queue, _tmp) = test_queue();
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let record = Arc::clone(&seen);
+        queue.on_results(move |results| record.lock().unwrap().push(results.to_vec()));
+        let scans = scans(&queue, 2);
+
+        queue.set_finished(&scans[0], 1).unwrap();
+        queue.set_finished(&scans[1], 4).unwrap();
+
+        assert_eq!(
+            *seen.lock().unwrap(),
+            vec![
+                vec![serde_json::json!(1)],
+                vec![serde_json::json!(1), serde_json::json!(4)],
+            ]
+        );
+    }
+
+    #[test]
+    fn on_results_stays_quiet_for_a_ticket_that_failed() {
+        let (queue, _tmp) = test_queue();
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let record = Arc::clone(&seen);
+        queue.on_results(move |results| record.lock().unwrap().push(results.to_vec()));
+        let scans = scans(&queue, 1);
+
+        queue.set_failed(&scans[0]).unwrap();
+
+        // A failed ticket produces no result, so nothing changed to report.
+        assert!(seen.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn create_tickets_on_results_waits_until_the_results_call_for_the_work() {
+        let (queue, _tmp) = test_queue();
+        queue.create_tickets_on_results(|results| match results.len() == 2 {
+            true => vec![Ticket::new("write the report").label("report")],
+            false => Vec::new(),
+        });
+        let scans = scans(&queue, 2);
+
+        queue.set_finished(&scans[0], "clean").unwrap();
+        assert!(queue.find_tickets(|t| t.has_label("report")).is_empty());
+
+        queue.set_finished(&scans[1], "clean").unwrap();
+        assert_eq!(queue.find_tickets(|t| t.has_label("report")).len(), 1);
+    }
+
+    #[test]
+    fn create_tickets_on_results_files_one_follow_up_per_result() {
+        let (queue, _tmp) = test_queue();
+        queue.create_tickets_on_results(|results| match results.len() == 2 {
+            true => results
+                .iter()
+                .map(|r| Ticket::new(r.clone()).label("review"))
+                .collect(),
+            false => Vec::new(),
+        });
+        let scans = scans(&queue, 2);
+
+        queue.set_finished(&scans[0], 1).unwrap();
+        queue.set_finished(&scans[1], 4).unwrap();
+
+        let filed: Vec<serde_json::Value> = queue
+            .find_tickets(|t| t.has_label("review"))
+            .into_iter()
+            .map(|t| t.task)
+            .collect();
+        assert_eq!(filed, vec![serde_json::json!(1), serde_json::json!(4)]);
     }
 
     #[test]


### PR DESCRIPTION
## Why

`on_result` fires once per ticket, so a driver waiting on several results has to keep its own bookkeeping to work out when they have all arrived. Customer drivers hand-rolled exactly that: a set of scheduled labels, a fired-once flag, a subset comparison, and a guard against the empty set.

## What

```rust
tickets.on_results(|results| { /* every result so far, creation order */ });

tickets.create_tickets_on_results(|results| {
    match results.iter().filter(|r| r["scanned"] == true).count() == 3 {
        true => vec![Ticket::new("Write the report.").label("report")],
        false => Vec::new(),
    }
});
```

`on_results` fires on each `TicketFinished` and hands over exactly what `TicketQueue::results()` returns after the run, delivered while it is still going. `create_tickets_on_results` files whatever comes back.

The condition lives in the caller's function rather than in an argument. Handing back an empty `Vec` until the results call for the work is how it waits, and is also what stops a follow-up whose own result would trigger it again.

Both are mirrored in the Python bindings, where `None` also adds nothing.

## Notes

- Additive only: no existing signature changes.
- `on_results` is four lines over the existing `results()`; `create_tickets_on_results` sits on it the way `create_ticket_on_result` sits on `on_result`.
- README hooks table, a new "Register hooks" entry under Handover, and `DIFFS.md` are updated.

## Verification

- `make` clean under `-D warnings`
- `make test`: 912 lib, 49 doc, 51 + 4 use-case tests
- `make python_test`: 128 tests, including `test_parity.py` against the updated `.pyi`
