### PR TITLE
Add a hello-world example in Rust and Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ async fn main() {
 
 Example projects built with agentwerk:
 
+- [Hello World](crates/use-cases/src/hello_world/): basic example
 - [Terminal REPL](crates/use-cases/src/terminal_repl/): minimal interactive chat
 - [Divide and Conquer](crates/use-cases/src/divide_and_conquer/): arithmetic problem shared across agents
 - [Deep Research](crates/use-cases/src/deep_research/): deep research pipeline (requires `BRAVE_API_KEY`)

--- a/agentdocs/workflow.md
+++ b/agentdocs/workflow.md
@@ -80,6 +80,7 @@ make use_case name=<name>    # run one
 ```
 
 - Source is in `crates/use-cases/src/`.
+- `hello-world` is the smallest program the crate allows: one agent, one ticket, one printed answer.
 - `terminal-repl` is a per-turn interactive chat that prints output as it arrives.
 - `divide-and-conquer` partitions an arithmetic problem across agents sharing one ticket queue.
 - `deep-research` is a two-phase research pipeline with web search, and requires `BRAVE_API_KEY`.

--- a/crates/agentwerk-py/README.md
+++ b/crates/agentwerk-py/README.md
@@ -80,6 +80,7 @@ asyncio.run(main())
 
 Example projects built with agentwerk:
 
+- [Hello World](https://github.com/canvascomputing/agentwerk/tree/main/crates/use-cases/src/hello_world/): basic example, ported in [examples/hello_world.py](https://github.com/canvascomputing/agentwerk/blob/main/crates/agentwerk-py/examples/hello_world.py)
 - [Terminal REPL](https://github.com/canvascomputing/agentwerk/tree/main/crates/use-cases/src/terminal_repl/): minimal interactive chat
 - [Divide and Conquer](https://github.com/canvascomputing/agentwerk/tree/main/crates/use-cases/src/divide_and_conquer/): arithmetic problem shared across agents, ported in [examples/divide_and_conquer.py](https://github.com/canvascomputing/agentwerk/blob/main/crates/agentwerk-py/examples/divide_and_conquer.py)
 - [Deep Research](https://github.com/canvascomputing/agentwerk/tree/main/crates/use-cases/src/deep_research/): deep research pipeline (requires `BRAVE_API_KEY`)

--- a/crates/agentwerk-py/examples/hello_world.py
+++ b/crates/agentwerk-py/examples/hello_world.py
@@ -1,0 +1,37 @@
+"""The smallest agentwerk program, the Python port of the Rust use case.
+
+Builds an agent from the environment, submits a single task, waits for the
+queue to run dry, and prints the result. No tools, no labels, no schema.
+
+Usage: python hello_world.py [TASK]
+"""
+
+import asyncio
+import sys
+
+from agentwerk import Agent
+
+DEFAULT_TASK = "Say hello to the world in one short sentence."
+
+
+async def main(task):
+    agent = (
+        Agent.from_env()
+        .role("You are a friendly greeter who answers in one short sentence.")
+        .build()
+    )
+
+    agent.task(task)
+
+    work = agent.start()
+    results = await work.finish_all()
+
+    if not results:
+        print("the agent finished no ticket", file=sys.stderr)
+        sys.exit(1)
+    print(results[-1])
+
+
+if __name__ == "__main__":
+    argv = sys.argv[1:]
+    asyncio.run(main(argv[0] if argv else DEFAULT_TASK))

--- a/crates/use-cases/Cargo.toml
+++ b/crates/use-cases/Cargo.toml
@@ -12,6 +12,10 @@ serde_json = "1"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "http2", "charset", "system-proxy"] }
 
 [[bin]]
+name = "hello-world"
+path = "src/hello_world/main.rs"
+
+[[bin]]
 name = "deep-research"
 path = "src/deep_research/main.rs"
 

--- a/crates/use-cases/src/hello_world/main.rs
+++ b/crates/use-cases/src/hello_world/main.rs
@@ -1,0 +1,39 @@
+//! The smallest agentwerk program: one agent, one ticket, one answer.
+//!
+//! Builds an agent from the environment, submits a single task, waits for
+//! the queue to run dry, and prints the result. No tools, no labels, no
+//! schema.
+//!
+//! Usage: hello-world [TASK]
+//!
+//! Example:
+//!   hello-world
+//!   hello-world "Greet the world in Japanese."
+
+use agentwerk::Agent;
+
+const DEFAULT_TASK: &str = "Say hello to the world in one short sentence.";
+
+#[tokio::main]
+async fn main() {
+    let task = std::env::args()
+        .nth(1)
+        .unwrap_or_else(|| DEFAULT_TASK.into());
+
+    let agent = Agent::from_env()
+        .role("You are a friendly greeter who answers in one short sentence.")
+        .build();
+
+    agent.task(task);
+
+    let work = agent.start();
+    let mut results = work.finish_all().await;
+
+    match results.pop() {
+        Some(result) => println!("{}", result.as_str().unwrap_or_default()),
+        None => {
+            eprintln!("the agent finished no ticket");
+            std::process::exit(1);
+        }
+    }
+}


### PR DESCRIPTION
## Add a hello-world example in Rust and Python

### Purpose

- A new caller has no minimal program to copy from
- Every existing use case carries a pipeline, tools, or a schema
- One agent, one task, one printed result is the smallest working shape
- Rust and Python readers get the same starting point

### What changed

- `hello-world` builds an agent from the environment and prints one result
- The example registers no tool, no label, and no schema
- An optional argument replaces the default task
- A run that finishes no ticket prints to stderr and exits `1`
- `examples/hello_world.py` carries the same role, task, and order of operations
- Both README use-case lists and `agentdocs/workflow.md` name it first

### Examples

```bash
make use_case name=hello-world
# Hello, world!
```

```bash
make use_case name=hello-world args="Greet the world in Japanese."
# 世界中の皆さん、こんにちは！
```

```bash
python crates/agentwerk-py/examples/hello_world.py
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
