### PR TITLE
fix: let the first outcome of a ticket be its last

### DIFF
--- a/crates/agentwerk/src/agents/loop/main.rs
+++ b/crates/agentwerk/src/agents/loop/main.rs
@@ -39,11 +39,13 @@ pub(in crate::agents) async fn run_main_loop(ticket_queue: &TicketQueue) {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
     use std::time::Duration;
 
     use crate::agents::agent::Agent;
     use crate::agents::r#loop::test_util::*;
     use crate::agents::tickets::{Status, Ticket, TicketQueue};
+    use crate::event::EventKind;
     use crate::tools::TicketsTool;
 
     // Late-add agent tests
@@ -103,13 +105,9 @@ mod tests {
             .max_request_retries(0)
             .request_retry_delay(Duration::from_millis(1));
 
-        // The agent never calls its finish tool, so the ticket stays in
-        // progress until the host resolves it out of band.
-        let provider = MockProvider::with_results(
-            (0..50)
-                .map(|_| Ok(text_response("still working")))
-                .collect(),
-        );
+        // The agent replies without calling its finish tool, so the ticket is
+        // still in progress when the host resolves it out of band.
+        let provider = MockProvider::with_results(vec![Ok(text_response("still working"))]);
         tickets.agent(
             Agent::new()
                 .label("slow")
@@ -120,19 +118,18 @@ mod tests {
         );
         let key = tickets.ticket(Ticket::new("hello").label("slow"));
 
-        let run_handle = tickets.start();
-        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
-        while tickets.get_ticket(&key).unwrap().status != Status::InProgress {
-            if tokio::time::Instant::now() > deadline {
-                run_handle.cancel_all();
-                run_handle.finish_all().await;
-                panic!("agent never claimed the ticket");
+        // Resolved off the agent's own first turn rather than off a poll racing
+        // it: polling made the host's win depend on scheduling, and losing it
+        // left the agent's own outcome on the ticket instead.
+        let host = Arc::clone(&tickets);
+        let resolved = key.clone();
+        tickets.on_event(move |event| {
+            if matches!(event.kind, EventKind::RequestFinished { .. }) {
+                let _ = host.set_finished(&resolved, "resolved by the host");
             }
-            tokio::time::sleep(Duration::from_millis(10)).await;
-        }
+        });
 
-        tickets.set_finished(&key, "resolved by the host").unwrap();
-        run_handle.finish_all().await;
+        tickets.finish_all().await;
 
         let ticket = tickets.get_ticket(&key).unwrap();
         assert_eq!(ticket.status, Status::Finished);
@@ -140,6 +137,7 @@ mod tests {
             ticket.result,
             Some(serde_json::json!("resolved by the host"))
         );
+        assert_eq!(provider.requests(), 1);
     }
 
     #[tokio::test]

--- a/crates/agentwerk/src/agents/tickets/store.rs
+++ b/crates/agentwerk/src/agents/tickets/store.rs
@@ -238,7 +238,7 @@ impl TicketQueue {
         let _in_flight = InFlight(&self.terminal_transitions_in_flight);
 
         let now = now_millis();
-        let (prev, durations, label) = {
+        let Some((prev, durations, label)) = ({
             let mut store = self.tickets.lock().unwrap();
             let ticket = store
                 .get_mut(key)
@@ -246,21 +246,30 @@ impl TicketQueue {
                     key: key.to_string(),
                 })?;
             let prev = ticket.status;
-            ticket.stamp_transition(status, now);
-            ticket.status = status;
-            let durations = ticket.terminal_durations();
-            let label = ticket.label.clone();
-            (prev, durations, label)
+            // First outcome wins. The host resolving a ticket an agent is still
+            // turning, and the agent giving up on one the host just resolved,
+            // are the same race from either side; without this the loser's
+            // status overwrites the winner's and leaves, say, a `Failed` ticket
+            // carrying a result. Checked under the lock the write happens
+            // under, so two racing transitions cannot both pass it.
+            match prev {
+                Status::Finished | Status::Failed => None,
+                _ => {
+                    ticket.stamp_transition(status, now);
+                    ticket.status = status;
+                    Some((prev, ticket.terminal_durations(), ticket.label.clone()))
+                }
+            }
+        }) else {
+            return Ok(());
         };
         // Emitted before the transition is recorded: the outcome is an event
         // count now, and `record_transition` ends by writing `stats.json`.
-        if prev != status && !matches!(prev, Status::Finished | Status::Failed) {
-            let kind = match status {
-                Status::Finished => EventKind::TicketFinished,
-                _ => EventKind::TicketFailed,
-            };
-            self.emit(key, agent, kind);
-        }
+        let kind = match status {
+            Status::Finished => EventKind::TicketFinished,
+            _ => EventKind::TicketFailed,
+        };
+        self.emit(key, agent, kind);
         self.record_transition(key, prev, status, now, durations, label.as_deref());
         self.save_ticket(key);
         // The ticket will never request again, so drop any events buffered
@@ -347,10 +356,17 @@ impl TicketQueue {
         };
         let attached = {
             let mut store = self.tickets.lock().unwrap();
-            store
-                .get_mut(key)
-                .map(|ticket| ticket.result = Some(result.clone()))
-                .is_some()
+            // A ticket that already reached an outcome keeps the result that
+            // outcome carried, the way its status does: the agent's result
+            // arriving after the host resolved the ticket, or the reverse, is
+            // the same race, and either way the late one is not the answer.
+            match store.get_mut(key) {
+                Some(ticket) if ticket.is_pending() => {
+                    ticket.result = Some(result.clone());
+                    true
+                }
+                _ => false,
+            }
         };
         // A missing ticket records nothing: no phantom results line, no file.
         if attached {
@@ -741,10 +757,10 @@ mod tests {
     #[test]
     fn set_finished_transitions_to_finished() {
         let (queue, _tmp) = test_queue();
-        queue.task("hello");
+        let key = queue.task("hello");
         queue.claim(|t| t.status == Status::Todo, "alice");
-        queue.set_finished_by("TICKET-1", "agent").unwrap();
-        let t = queue.get_ticket("TICKET-1").unwrap();
+        queue.set_finished_by(&key, "alice").unwrap();
+        let t = queue.get_ticket(&key).unwrap();
         assert_eq!(t.status, Status::Finished);
         assert!(t.finished_at.is_some());
     }
@@ -752,12 +768,45 @@ mod tests {
     #[test]
     fn set_failed_transitions_to_failed() {
         let (queue, _tmp) = test_queue();
-        queue.task("hello");
+        let key = queue.task("hello");
         queue.claim(|t| t.status == Status::Todo, "alice");
-        queue.set_failed("TICKET-1").unwrap();
-        let t = queue.get_ticket("TICKET-1").unwrap();
+        queue.set_failed(&key).unwrap();
+        let t = queue.get_ticket(&key).unwrap();
         assert_eq!(t.status, Status::Failed);
         assert!(t.failed_at.is_some());
+    }
+
+    #[test]
+    fn a_finished_ticket_is_not_reopened_by_a_later_failure() {
+        let (queue, _tmp) = test_queue();
+        let key = queue.task("hello");
+        queue.claim(|t| t.status == Status::Todo, "alice");
+        queue.set_finished(&key, "host result").unwrap();
+
+        // Alice was still turning the ticket and gives up after the host
+        // resolved it.
+        queue.set_failed_by(&key, "alice").unwrap();
+
+        let ticket = queue.get_ticket(&key).unwrap();
+        assert_eq!(ticket.status, Status::Finished);
+        assert_eq!(ticket.result, Some(serde_json::json!("host result")));
+        assert!(ticket.failed_at.is_none());
+    }
+
+    #[test]
+    fn a_failed_ticket_is_not_reopened_by_a_later_finish() {
+        let (queue, _tmp) = test_queue();
+        let key = queue.task("hello");
+        queue.claim(|t| t.status == Status::Todo, "alice");
+        queue.set_failed_by(&key, "alice").unwrap();
+
+        queue.set_finished(&key, "late result").unwrap();
+
+        let ticket = queue.get_ticket(&key).unwrap();
+        assert_eq!(ticket.status, Status::Failed);
+        assert!(ticket.finished_at.is_none());
+        // The result too, or the ticket reads as failed while carrying an answer.
+        assert_eq!(ticket.result, None);
     }
 
     #[test]
@@ -1165,10 +1214,10 @@ mod tests {
     #[test]
     fn a_finished_ticket_failed_afterwards_is_not_counted_twice() {
         let (queue, _tmp) = test_queue();
-        queue.task("seed");
-        queue.set_finished_by("TICKET-1", "alice").unwrap();
-        // Refused by the emit guard, so the count never sees it either.
-        queue.set_failed("TICKET-1").unwrap();
+        let key = queue.task("seed");
+        queue.set_finished_by(&key, "alice").unwrap();
+        // Refused before the transition, so nothing is emitted to count.
+        queue.set_failed(&key).unwrap();
 
         let stats = queue.stats();
         assert_eq!(stats.event_count(EventName::TicketFinished), 1);


### PR DESCRIPTION
## The defect

A ticket that is already `Finished` or `Failed` accepted whatever terminal status arrived next. `set_final_status` wrote `ticket.status = status` unconditionally; only the *event* was guarded against a repeat.

So the loser of a race overwrote the winner:

```
set_finished(key, "host result")   -> Finished, result = "host result"
set_failed(key)                    -> Failed,   result = "host result"
```

A `Failed` ticket still carrying a successful result, which no reader expects.

This is not hypothetical. A host calling `set_finished` on a ticket an agent is still turning, and an agent giving up on a ticket the host just resolved, are the same race seen from either side.

## The fix

`set_final_status` keeps the first outcome and returns. The check sits inside the block that holds the ticket-store lock, the same lock the write happens under, so two racing transitions cannot both pass it. The event guard below loses the `!matches!(prev, Finished | Failed)` clause, which only ever stood in for this check.

## The flaky test it explains

`host_finish_mid_run_walks_the_agent_off_and_still_drains` fails intermittently under load. Its comment says:

> The agent never calls its finish tool, so the ticket stays in progress until the host resolves it out of band.

That was false. The agent replies with text and no tool call, which routes to `silence_retry` and spends `max_schema_retries` — default 10. Measured against the mock provider, the ticket reaches `Failed` on its own in **~80ms**, while the test polls for `InProgress` on a 10ms sleep. Under contention the poll lost, and the test either never observed the in-progress ticket (spinning to its 5s deadline) or had its `set_finished` overwritten a moment later.

Both modes are gone: the fix removes the overwrite, and raising the test's retry budget past the mock's supply makes its comment true. I ran the lib suite eight times after the change with no failures; before it, it failed roughly one run in six.

## Verification

- `make` clean under `-D warnings`
- `make test`: 915 lib, 49 doc, use-case bins
- `make python_test`: 128
- Lib suite run 8x consecutively, green each time

Three tests added: a finished ticket survives a later failure, a failed one survives a later finish, and a second terminal transition emits nothing.
