### PR TITLE
docs: point the Agents section at the prompt skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ agent.task("Read CHANGELOG.md and summarize the entries added since the last rel
 agent.start();
 ```
 
+Optionally, install the [`prompt` skill](skills/prompt/SKILL.md), which is optimized for highly efficient agents with a proven structure for effectiveness.
+
 <details>
 <summary>All agent methods</summary>
 

--- a/crates/agentwerk-py/README.md
+++ b/crates/agentwerk-py/README.md
@@ -107,6 +107,8 @@ agent.task("Read CHANGELOG.md and summarize the entries added since the last rel
 agent.start()
 ```
 
+Optionally, install the [`prompt` skill](../../skills/prompt/SKILL.md), which is optimized for highly efficient agents with a proven structure for effectiveness.
+
 <details>
 <summary>All agent methods</summary>
 


### PR DESCRIPTION
### Purpose

- The Agents section shows a `role` string without saying where a good one comes from
- The repo ships a `prompt` skill that no README mentioned
- Readers get the option in the place they first write a prompt

### What changed

- The Agents section links `skills/prompt/SKILL.md` under its example
- `crates/agentwerk-py/README.md` carries the same line, with a path relative to itself

### Example

```markdown
Optionally, install the [`prompt` skill](skills/prompt/SKILL.md), which is optimized for highly efficient agents with a proven structure for effectiveness.
```
