### PR TITLE
docs: name where a vulnerability report goes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
   <a href="#quick-start">Quick Start</a> •
   <a href="#api">API</a> •
   <a href="#use-cases">Use Cases</a> •
+  <a href="#security">Security</a> •
   <a href="#development">Development</a>
 </div>
 
@@ -823,6 +824,10 @@ Example projects built with agentwerk:
 make use_case                # list available names
 make use_case name=<name>    # run one
 ```
+
+## Security
+
+Report a vulnerability to security@canvascomputing.org, not in a public issue. See [SECURITY.md](SECURITY.md).
 
 ## Development
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,11 @@
+# Security
+
+## Reporting a Vulnerability
+
+Report a vulnerability to security@canvascomputing.org. Do not open a public issue for it.
+
+Include the version, the component it affects, and the steps that reproduce it.
+
+## Supported Versions
+
+Fixes land in a new release. Earlier versions get no backport.

--- a/agentdocs/style.md
+++ b/agentdocs/style.md
@@ -413,7 +413,7 @@ Also:
 
 **Terse, example-driven, scannable.**
 
-- Fixed section order: Why use agentwerk?, Installation, Quick Start, Agent Swarms, Demo, the API sections, Use Cases, Development.
+- Fixed section order: Why use agentwerk?, Installation, Quick Start, Agent Swarms, Demo, the API sections, Use Cases, Security, Development.
 - The opening section is one bullet per reason to reach for the crate: `**Reason:** one short sentence`. A reason with nothing behind it is marketing and is cut. It runs before the reader has met a single agentwerk concept, so it carries no identifier, no type or function name, and none of the domain vocabulary the API sections introduce. "Task" and "agent" are the only nouns assumed.
 - API sections run in the order a new reader needs them: Agents, Tickets, Tools, Events, Knowledge. Sessions is a subsection of Tickets.
 - Prompting has no section of its own. `role`, `task`, and the template bindings configure an agent, so they live in Agents next to `name` and `tool`.

--- a/crates/agentwerk-py/README.md
+++ b/crates/agentwerk-py/README.md
@@ -14,6 +14,7 @@
   <a href="#quick-start">Quick Start</a> •
   <a href="#api">API</a> •
   <a href="#use-cases">Use Cases</a> •
+  <a href="#security">Security</a> •
   <a href="#development">Development</a>
 </div>
 
@@ -838,6 +839,10 @@ Example projects built with agentwerk:
 ```bash
 python examples/divide_and_conquer.py 200 4 2
 ```
+
+## Security
+
+Report a vulnerability to security@canvascomputing.org, not in a public issue. See [SECURITY.md](https://github.com/canvascomputing/agentwerk/blob/main/SECURITY.md).
 
 ## Development
 


### PR DESCRIPTION
## Add SECURITY.md and a README security section

### Purpose

- A reporter had no private address for a security finding
- A public issue discloses a finding before a fix exists
- The version policy of a pre-1.0 crate was unstated

### What changed

- `SECURITY.md` names security@canvascomputing.org as the reporting address
- A report carries the version, the component, and the steps to reproduce it
- Fixes land in a new release, and earlier versions get no backport
- Both READMEs gain a `Security` section between Use Cases and Development
- `agentdocs/style.md` records `Security` in the fixed README section order

### Examples

```markdown
## Security

Report a vulnerability to security@canvascomputing.org, not in a public issue. See [SECURITY.md](SECURITY.md).
```
