### PR TITLE
Record and query a ticket's failures

### DIFF
--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -386,8 +386,8 @@ The rules the tables never repeat.
 
 | Language | Item | Visibility |
 |----------|------|------------|
-| Rust | `Ticket { task: json, label: string?, schema: Schema?, key: string, status: Status, reporter: string, assignee: string?, created_at: number, started_at: number?, finished_at: number?, failed_at: number?, result: json?, parent: string?, replies: Reply[] }` | pub |
-| Python | `Ticket`: same field names. `replies` is a list of `Reply`, converted on access | |
+| Rust | `Ticket { task: json, label: string?, schema: Schema?, key: string, status: Status, reporter: string, assignee: string?, created_at: number, started_at: number?, finished_at: number?, failed_at: number?, result: json?, errors: Event[], parent: string?, replies: Reply[] }` | pub |
+| Python | `Ticket`: same field names. `replies` is a list of `Reply` and `errors` a list of `Event`, converted on access | |
 | Rust | `Ticket.new(task: json): Ticket` | pub |
 | Python | `Ticket(task)` | |
 | Rust | `Ticket.labeled(label: string, task: json): Ticket` | pub |
@@ -418,9 +418,13 @@ The rules the tables never repeat.
 | Rust | `Replies { key: string, entries: Reply[] }` | crate |
 | Rust | `Replies.append(dir: string, key: string, reply: Reply): void throws io::Error` | crate |
 | Rust | `impl Persist for Replies` | crate |
+| Rust | `TicketErrors { key: string, entries: Event[] }` | crate |
+| Rust | `TicketErrors.append(dir: string, key: string, event: Event): void throws io::Error` | crate |
+| Rust | `impl Persist for TicketErrors` | crate |
 | Rust | `ticket_record_path(dir: string, key: string): string` | super |
 | Rust | `replies_path(dir: string, key: string): string` | private |
 | Rust | `result_path(dir: string, key: string): string` | super |
+| Rust | `errors_path(dir: string, key: string): string` | super |
 | Rust | `impl AsUserMessage for Ticket` | pub |
 | Rust | `Status` | pub |
 | Python | a string: `"todo"`, `"in_progress"`, `"finished"`, `"failed"`. The five `is_*` predicates read better than comparing it | |
@@ -2058,6 +2062,7 @@ Binds `agents/tickets/ticket.rs` and `agents/tickets/query.rs`.
 | Rust | `PyTicket.finished_at(): number?` | python |
 | Rust | `PyTicket.failed_at(): number?` | python |
 | Rust | `PyTicket.replies(): PyReply[]` | python |
+| Rust | `PyTicket.errors(): PyEvent[]` | python |
 | Rust | `PyTicket.__repr__(): string` | python |
 | Rust | `PyTicket.from_ticket(ticket: Ticket): PyTicket` | pub |
 | Rust | `PyTicket.to_ticket(): Ticket` | pub |

--- a/README.md
+++ b/README.md
@@ -319,6 +319,7 @@ tickets.find_results("scan ORDER BY finished DESC");
 | | `agent` | Match the agent that claimed the ticket. |
 | **Outcome** | `status` | Match `Todo`, `InProgress`, `Finished`, or `Failed`. |
 | | `result` | Search the result the agent produced. |
+| | `errors` | Search the failures recorded against the ticket. |
 | **Body** | `task` | Search the work the agent was asked to do. |
 | **Time** | `created` | Sort by when the ticket was submitted. |
 | | `started` | Sort by when an agent claimed the ticket. |
@@ -328,8 +329,8 @@ tickets.find_results("scan ORDER BY finished DESC");
 #### Rules
 
 - `=`, `!=`, `IN`, and `NOT IN` compare exactly, `~` and `!~` ignore case.
-- `IS EMPTY` and `IS NOT EMPTY` read `label`, `agent`, `parent`, `result`, `started`, `finished`, and `failed` only.
-- `~` and `!~` read `task` and `result` only.
+- `IS EMPTY` and `IS NOT EMPTY` read `label`, `agent`, `parent`, `result`, `errors`, `started`, `finished`, and `failed` only.
+- `~` and `!~` read `task`, `result`, and `errors` only.
 - A field holds one value per ticket, so `label = a AND label = b` is rejected and names `IN` as the fix.
 - `ORDER BY` names one field and closes the query. Every field sorts, `key` by its number and `status` along the lifecycle.
 - Without it tickets arrive in creation order, which is also what breaks a tie and what a closure answers in. A ticket missing the field sorts last.
@@ -339,15 +340,29 @@ tickets.find_results("scan ORDER BY finished DESC");
 
 #### Examples
 
+Read the results of finished tickets:
+
 ```rust
-tickets.find_result("TICKET-3");                                 // what one ticket produced
-tickets.find_results("report");                                  // every report result
-tickets.find_tickets("status = Failed");                         // every ticket that failed
-tickets.find_tickets("status = Todo AND agent IS EMPTY");        // waiting, never claimed
-tickets.find_results("report AND result ~ risk");                // reports that mention risk
-tickets.find_tickets("parent IS NOT EMPTY ORDER BY created");    // the children of a handover
+tickets.find_result("TICKET-3");                   // one ticket's result
+tickets.find_results("report");                    // every report result
+tickets.find_results("report AND result ~ risk");  // reports that mention risk
+```
+
+Select tickets by status or the failures they recorded:
+
+```rust
+tickets.find_tickets("status = Failed");            // every ticket that failed
+tickets.find_tickets("errors IS NOT EMPTY");        // hit a failure, even if it finished
+tickets.find_tickets("errors ~ tool_call_failed");  // saw a tool call fail
+tickets.find_tickets("status = Todo AND agent IS EMPTY");  // waiting, never claimed
+```
+
+Group terms and order the answer:
+
+```rust
 tickets.find_tickets("(scan OR audit) AND NOT status = Failed");
-tickets.find_ticket("task ~ migration");
+tickets.find_tickets("parent IS NOT EMPTY ORDER BY created");  // handover children, oldest first
+tickets.find_ticket("task ~ migration");                      // the first migration ticket
 ```
 
 Every method that takes a query also takes a closure, for a condition no field carries:
@@ -396,6 +411,7 @@ Ticket members:
 | | `assignee` | Identifier of the agent that claimed the ticket. |
 | **Outcome** | `status` | The ticket lifecycle status. |
 | | `result` | The result the agent produced. |
+| | `errors` | The failures recorded against the ticket, as events. |
 | | `replies` | Messages exchanged with the model. |
 | | `schema` | Optional schema the result must satisfy. |
 | **Timestamps** | `created_at` | Creation time, in milliseconds. |

--- a/README.md
+++ b/README.md
@@ -661,6 +661,7 @@ tickets.start();
 │   └── TICKET-1/
 │       ├── ticket.json                   the ticket without its messages (key, status, label, timestamps)
 │       ├── result.json                   the result the agent produced
+│       ├── errors.jsonl                   every failure recorded against the ticket, one per line
 │       ├── replies.jsonl                 every message exchanged with the model, one per line
 │       └── outputs/<tool_use_id>.txt     full tool outputs spilled out of the messages
 └── knowledge/

--- a/agentdocs/architecture.md
+++ b/agentdocs/architecture.md
@@ -91,6 +91,7 @@ Schemas and results:
 - A handover validates its `result` against the parent's schema and carries none for the child, which takes one from its handover label at claim. A mismatch aborts before the child is inserted, so the operation stays atomic.
 - `handover` and `task` are `finish`'s own arguments; the result is always `result`. A ticket schema declaring a property named `handover` needs no special case, because it sits inside `result`.
 - A successful finish writes `<dir>/tickets/<key>/result.json` (`TicketQueue::dir(d)`, default `./.agentwerk`) and attaches the same value, read back through `Ticket::result()`. The full ticket state goes to `ticket.json` on every transition and the transition itself to `<dir>/events.jsonl`. Both writes are observational: errors are swallowed.
+- Failures are the plural mirror of the single result. `TicketQueue::emit` appends every failure event (`EventKind::is_failure()` bar the `TicketFailed` marker, which `status` and `failed_at` already carry) to `<dir>/tickets/<key>/errors.jsonl` and onto `Ticket::errors`, so a ticket accumulates the failed requests and tool calls it saw. A failure is not a transition: an entry lands whether or not the ticket goes on to fail, so a `Finished` ticket can carry some. `emit` is the only writer and `load` reads the file back, so there is no error-only `error.json` and no second filter to keep in step. The append is observational like the result write.
 
 ## Knowledge Is Opt-In and Shareable Across Agents
 

--- a/crates/agentwerk-py/README.md
+++ b/crates/agentwerk-py/README.md
@@ -332,6 +332,7 @@ tickets.find_results("scan ORDER BY finished DESC")
 | | `agent` | Match the agent that claimed the ticket. |
 | **Outcome** | `status` | Match `todo`, `in_progress`, `finished`, or `failed`. |
 | | `result` | Search the result the agent produced. |
+| | `errors` | Search the failures recorded against the ticket. |
 | **Body** | `task` | Search the work the agent was asked to do. |
 | **Time** | `created` | Sort by when the ticket was submitted. |
 | | `started` | Sort by when an agent claimed the ticket. |
@@ -341,8 +342,8 @@ tickets.find_results("scan ORDER BY finished DESC")
 #### Rules
 
 - `=`, `!=`, `IN`, and `NOT IN` compare exactly, `~` and `!~` ignore case.
-- `IS EMPTY` and `IS NOT EMPTY` read `label`, `agent`, `parent`, `result`, `started`, `finished`, and `failed` only.
-- `~` and `!~` read `task` and `result` only.
+- `IS EMPTY` and `IS NOT EMPTY` read `label`, `agent`, `parent`, `result`, `errors`, `started`, `finished`, and `failed` only.
+- `~` and `!~` read `task`, `result`, and `errors` only.
 - A field holds one value per ticket, so `label = a AND label = b` is rejected and names `IN` as the fix.
 - `ORDER BY` names one field and closes the query. Every field sorts, `key` by its number and `status` along the lifecycle.
 - Without it tickets arrive in creation order, which is also what breaks a tie and what a callable answers in. A ticket missing the field sorts last.
@@ -352,15 +353,29 @@ tickets.find_results("scan ORDER BY finished DESC")
 
 #### Examples
 
+Read the results of finished tickets:
+
 ```python
-tickets.find_result("TICKET-3")                                 # what one ticket produced
-tickets.find_results("report")                                  # every report result
-tickets.find_tickets("status = Failed")                         # every ticket that failed
-tickets.find_tickets("status = Todo AND agent IS EMPTY")        # waiting, never claimed
-tickets.find_results("report AND result ~ risk")                # reports that mention risk
-tickets.find_tickets("parent IS NOT EMPTY ORDER BY created")    # the children of a handover
+tickets.find_result("TICKET-3")                   # one ticket's result
+tickets.find_results("report")                    # every report result
+tickets.find_results("report AND result ~ risk")  # reports that mention risk
+```
+
+Select tickets by status or the failures they recorded:
+
+```python
+tickets.find_tickets("status = Failed")            # every ticket that failed
+tickets.find_tickets("errors IS NOT EMPTY")        # hit a failure, even if it finished
+tickets.find_tickets("errors ~ tool_call_failed")  # saw a tool call fail
+tickets.find_tickets("status = Todo AND agent IS EMPTY")  # waiting, never claimed
+```
+
+Group terms and order the answer:
+
+```python
 tickets.find_tickets("(scan OR audit) AND NOT status = Failed")
-tickets.find_ticket("task ~ migration")
+tickets.find_tickets("parent IS NOT EMPTY ORDER BY created")  # handover children, oldest first
+tickets.find_ticket("task ~ migration")                      # the first migration ticket
 ```
 
 Every method that takes a query also takes a callable, for a condition no field carries:
@@ -409,6 +424,7 @@ Ticket members:
 | | `assignee` | Identifier of the agent that claimed the ticket. |
 | **Outcome** | `status` | The ticket lifecycle status. |
 | | `result` | The result the agent produced. |
+| | `errors` | The failures recorded against the ticket, as events. |
 | | `replies` | Messages exchanged with the model. |
 | | `schema` | Optional schema the result must satisfy. |
 | **Timestamps** | `created_at` | Creation time, in milliseconds. |
@@ -672,6 +688,7 @@ tickets.start()
 │   └── TICKET-1/
 │       ├── ticket.json                   the ticket without its messages (key, status, label, timestamps)
 │       ├── result.json                   the result the agent produced
+│       ├── errors.jsonl                   every failure recorded against the ticket, one per line
 │       ├── replies.jsonl                 every message exchanged with the model, one per line
 │       └── outputs/<tool_use_id>.txt     full tool outputs spilled out of the messages
 └── knowledge/

--- a/crates/agentwerk-py/python/agentwerk/__init__.pyi
+++ b/crates/agentwerk-py/python/agentwerk/__init__.pyi
@@ -159,6 +159,7 @@ class Ticket:
     finished_at: Optional[int]
     failed_at: Optional[int]
     replies: list[Reply]
+    errors: list[Event]
 
     def __init__(
         self,

--- a/crates/agentwerk-py/src/lib.rs
+++ b/crates/agentwerk-py/src/lib.rs
@@ -4,11 +4,11 @@
 use pyo3::prelude::*;
 
 mod agent;
-mod policy;
 mod convert;
 mod directives;
 mod event;
 mod knowledge;
+mod policy;
 mod providers;
 mod reply;
 mod schema;

--- a/crates/agentwerk-py/src/ticket.rs
+++ b/crates/agentwerk-py/src/ticket.rs
@@ -208,6 +208,18 @@ impl PyTicket {
         crate::reply::replies_to_py(&self.inner.replies)
     }
 
+    /// The failures recorded against the ticket, as events, in the order they
+    /// happened. A failed tool call or request does not fail the ticket, so a
+    /// finished ticket can carry some.
+    #[getter]
+    fn errors(&self) -> Vec<crate::event::PyEvent> {
+        self.inner
+            .errors
+            .iter()
+            .map(crate::event::to_py_event)
+            .collect()
+    }
+
     fn __repr__(&self) -> String {
         format!(
             "Ticket(key={:?}, status={:?})",

--- a/crates/agentwerk-py/src/ticket_queue.rs
+++ b/crates/agentwerk-py/src/ticket_queue.rs
@@ -11,9 +11,9 @@ use pyo3::prelude::*;
 use serde_json::Value;
 
 use crate::agent::PyAgent;
-use crate::policy::PyPolicy;
 use crate::convert::{py_to_value, runtime_error, value_to_py};
 use crate::event::{to_py_event, PyEvent};
+use crate::policy::PyPolicy;
 use crate::reply::{py_to_replies, replies_to_py};
 use crate::schema::PySchemaStore;
 use crate::ticket::{to_ticket, try_extract_query, PyTicket};

--- a/crates/agentwerk-py/tests/test_tickets.py
+++ b/crates/agentwerk-py/tests/test_tickets.py
@@ -181,6 +181,16 @@ def test_set_failed_resolves_a_ticket_from_outside_the_run(queue):
     assert queue.get_ticket(key).status == "failed"
 
 
+def test_errors_is_a_list_and_excludes_the_terminal_failure(queue):
+    key = queue.ticket(aw.Ticket("scan the corpus"))
+
+    queue.set_failed(key)
+
+    # A host fail is the terminal marker, not a recorded cause: the errors
+    # list holds the failure events (failed requests, tool calls) the run saw.
+    assert queue.get_ticket(key).errors == []
+
+
 def test_set_finished_resolves_a_ticket_with_its_result(queue):
     key = queue.ticket(aw.Ticket("scan the corpus"))
 

--- a/crates/agentwerk/src/agents/agent.rs
+++ b/crates/agentwerk/src/agents/agent.rs
@@ -9,8 +9,8 @@ use crate::prompts::{context_values, render_context, PromptBuilder, Text};
 use crate::providers::{Model, Provider};
 use crate::tools::{FinishTool, KnowledgeTool, Tool, ToolRegistry};
 
-use super::policy::Policy;
 use super::knowledge::Knowledge;
+use super::policy::Policy;
 use super::stats::Stats;
 use super::tickets::{Ticket, TicketQueue};
 use crate::prompts::directives::DirectiveStore;

--- a/crates/agentwerk/src/agents/loop/agent.rs
+++ b/crates/agentwerk/src/agents/loop/agent.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use crate::agents::agent::Agent;
 use crate::agents::policy::Policy;
 use crate::agents::tickets::{policy_violated, Reply, Run, Status, Ticket, TicketQueue};
-use crate::event::{CompactReason, PolicyViolation, Event, EventKind};
+use crate::event::{CompactReason, Event, EventKind, PolicyViolation};
 use crate::prompts::directives::{NO_TOOL_CALLED, REPLY_REJECTED};
 use crate::providers::{AsUserMessage, Message, Model, RequestErrorKind};
 use crate::tools::{FinishTool, ToolRegistry};
@@ -957,7 +957,7 @@ mod tests {
 
     #[tokio::test]
     async fn loop_fails_ticket_when_silence_exceeds_schema_retry_budget() {
-        use crate::event::{PolicyViolation, EventKind};
+        use crate::event::{EventKind, PolicyViolation};
 
         let results_dir = crate::test_util::TempDir::new().unwrap();
         let provider = MockProvider::with_results(vec![Ok(text_response("hi"))]);

--- a/crates/agentwerk/src/agents/loop/tool_call.rs
+++ b/crates/agentwerk/src/agents/loop/tool_call.rs
@@ -4,7 +4,7 @@
 use std::sync::Arc;
 
 use crate::agents::tickets::Reply;
-use crate::event::{PolicyViolation, EventKind, RepairKind, ToolFailureKind};
+use crate::event::{EventKind, PolicyViolation, RepairKind, ToolFailureKind};
 use crate::providers::ContentBlock;
 use crate::tools::{ToolCall, ToolContext, ToolResult};
 
@@ -161,7 +161,7 @@ mod tests {
     use crate::agents::policy::Policy;
     use crate::agents::r#loop::test_util::*;
     use crate::agents::tickets::{Status, Ticket, TicketQueue};
-    use crate::event::{PolicyViolation, EventKind, RepairKind};
+    use crate::event::{EventKind, PolicyViolation, RepairKind};
     use crate::schemas::Schema;
 
     #[tokio::test]

--- a/crates/agentwerk/src/agents/mod.rs
+++ b/crates/agentwerk/src/agents/mod.rs
@@ -2,14 +2,14 @@
 
 pub mod agent;
 pub(crate) mod compaction;
-pub mod policy;
 pub mod knowledge;
 pub mod r#loop;
+pub mod policy;
 pub(crate) mod retry;
 pub(crate) mod stats;
 pub mod tickets;
 
 pub use agent::{Agent, AgentBuilder};
-pub use policy::Policy;
 pub use knowledge::Knowledge;
+pub use policy::Policy;
 pub use tickets::{Query, QueryError, Reply, Status, Ticket, TicketError, TicketQueue, Trajectory};

--- a/crates/agentwerk/src/agents/tickets/mod.rs
+++ b/crates/agentwerk/src/agents/tickets/mod.rs
@@ -2,7 +2,7 @@
 
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use crate::event::{PolicyViolation, EventName};
+use crate::event::{EventName, PolicyViolation};
 
 use super::policy::Policy;
 use super::stats::Stats;
@@ -25,7 +25,7 @@ pub use ticket::{Status, Ticket};
 pub use ticket_queue::TicketQueue;
 pub use trajectory::Trajectory;
 
-pub(crate) use ticket::{Replies, TicketResult};
+pub(crate) use ticket::{Replies, TicketErrors, TicketResult};
 pub(crate) use ticket_queue::Run;
 
 /// Whether the run-wide policy have been exceeded by the current

--- a/crates/agentwerk/src/agents/tickets/query.rs
+++ b/crates/agentwerk/src/agents/tickets/query.rs
@@ -191,6 +191,7 @@ enum Field {
     Parent,
     Task,
     Result,
+    Errors,
     Created,
     Started,
     Finished,
@@ -198,7 +199,7 @@ enum Field {
 }
 
 /// Every field name AQL knows, in the order the error message lists them.
-const FIELDS: [(&str, Field); 11] = [
+const FIELDS: [(&str, Field); 12] = [
     ("key", Field::Key),
     ("label", Field::Label),
     ("status", Field::Status),
@@ -206,6 +207,7 @@ const FIELDS: [(&str, Field); 11] = [
     ("parent", Field::Parent),
     ("task", Field::Task),
     ("result", Field::Result),
+    ("errors", Field::Errors),
     ("created", Field::Created),
     ("started", Field::Started),
     ("finished", Field::Finished),
@@ -249,6 +251,10 @@ impl Field {
             Field::Parent => ticket.parent.as_deref().map(Cow::Borrowed),
             Field::Task => Some(as_text(&ticket.task)),
             Field::Result => ticket.result.as_ref().map(as_text),
+            // The serialized events, so `~` reaches both the kind
+            // (`"event":"tool_call_failed"`) and the message.
+            Field::Errors => (!ticket.errors.is_empty())
+                .then(|| Cow::Owned(serde_json::to_string(&ticket.errors).unwrap_or_default())),
             Field::Created => Some(Cow::Owned(ticket.created_at.to_string())),
             Field::Started => ticket.started_at.map(millis_text),
             Field::Finished => ticket.finished_at.map(millis_text),
@@ -265,6 +271,7 @@ impl Field {
                 | Field::Agent
                 | Field::Parent
                 | Field::Result
+                | Field::Errors
                 | Field::Started
                 | Field::Finished
                 | Field::Failed
@@ -273,7 +280,7 @@ impl Field {
 
     fn kind(self) -> Kind {
         match self {
-            Field::Task | Field::Result => Kind::Text,
+            Field::Task | Field::Result | Field::Errors => Kind::Text,
             Field::Created | Field::Started | Field::Finished | Field::Failed => Kind::Time,
             _ => Kind::Value,
         }
@@ -855,6 +862,7 @@ mod tests {
         fn status(self, status: Status) -> Ticket;
         fn task(self, task: serde_json::Value) -> Ticket;
         fn finished(self, result: serde_json::Value) -> Ticket;
+        fn errored(self, kind: crate::event::EventKind) -> Ticket;
         fn created_at(self, millis: u64) -> Ticket;
         fn finished_at(self, millis: u64) -> Ticket;
     }
@@ -862,6 +870,13 @@ mod tests {
     impl Fixture for Ticket {
         fn agent(mut self, agent: &str) -> Ticket {
             self.assignee = Some(agent.to_string());
+            self
+        }
+
+        fn errored(mut self, kind: crate::event::EventKind) -> Ticket {
+            let key = self.key.clone();
+            self.errors
+                .push(crate::event::Event::new("agent", key, None, kind));
             self
         }
 
@@ -1077,6 +1092,76 @@ mod tests {
         let q = parse("result ~ zip");
         assert!(q.matches(&ticket("TICKET-1").finished(json!({"finding": "zip slip"}))));
         assert!(!q.matches(&ticket("TICKET-2").finished(json!({"finding": "clean"}))));
+    }
+
+    fn tool_failed(message: &str) -> crate::event::EventKind {
+        crate::event::EventKind::ToolCallFailed {
+            tool_name: "grep".into(),
+            call_id: "c1".into(),
+            reason: crate::event::ToolFailureKind::ExecutionFailed,
+            message: message.into(),
+        }
+    }
+
+    #[test]
+    fn errors_is_empty_matches_a_ticket_without_failures() {
+        let q = parse("errors IS EMPTY");
+        assert!(q.matches(&ticket("TICKET-1")));
+        assert!(!q.matches(&ticket("TICKET-2").errored(tool_failed("boom"))));
+    }
+
+    #[test]
+    fn errors_is_not_empty_matches_a_ticket_that_failed() {
+        let q = parse("errors IS NOT EMPTY");
+        assert!(q.matches(&ticket("TICKET-1").errored(tool_failed("boom"))));
+        assert!(!q.matches(&ticket("TICKET-2")));
+    }
+
+    #[test]
+    fn contains_matches_a_failure_by_kind() {
+        let request_failed = crate::event::EventKind::RequestFailed {
+            model: "mock".into(),
+            reason: crate::providers::RequestErrorKind::ConnectionFailed,
+            message: "boom".into(),
+        };
+        let q = parse("errors ~ tool_call_failed");
+        assert!(q.matches(&ticket("TICKET-1").errored(tool_failed("boom"))));
+        // A different kind is excluded: the search selects by kind, not presence.
+        assert!(!q.matches(&ticket("TICKET-2").errored(request_failed)));
+    }
+
+    #[test]
+    fn contains_matches_a_failure_message() {
+        let q = parse("errors ~ timeout");
+        assert!(q.matches(&ticket("TICKET-1").errored(tool_failed("connection timeout"))));
+        assert!(!q.matches(&ticket("TICKET-2").errored(tool_failed("no such file"))));
+    }
+
+    #[test]
+    fn omits_excludes_a_matching_failure() {
+        let q = parse("errors !~ timeout");
+        assert!(q.matches(&ticket("TICKET-1").errored(tool_failed("no such file"))));
+        assert!(!q.matches(&ticket("TICKET-2").errored(tool_failed("connection timeout"))));
+    }
+
+    #[test]
+    fn omits_does_not_match_a_ticket_without_failures() {
+        // An optional field the ticket does not carry fails every comparison,
+        // so `!~` excludes a clean ticket rather than including it.
+        let q = parse("errors !~ timeout");
+        assert!(!q.matches(&ticket("TICKET-1")));
+        assert!(q.matches(&ticket("TICKET-2").errored(tool_failed("no such file"))));
+    }
+
+    #[test]
+    fn contains_searches_every_recorded_failure() {
+        // A ticket accumulates many failures; the search reads the whole log,
+        // so a needle in the second failure still matches.
+        let q = parse("errors ~ timeout");
+        let ticket = ticket("TICKET-1")
+            .errored(tool_failed("no such file"))
+            .errored(tool_failed("connection timeout"));
+        assert!(q.matches(&ticket));
     }
 
     #[test]

--- a/crates/agentwerk/src/agents/tickets/ticket.rs
+++ b/crates/agentwerk/src/agents/tickets/ticket.rs
@@ -6,6 +6,7 @@ use std::path::{Path, PathBuf};
 
 use serde::Serialize;
 
+use crate::event::Event;
 use crate::persistence::Persist;
 use crate::prompts::Text;
 use crate::providers::{AsUserMessage, Message};
@@ -67,6 +68,12 @@ pub struct Ticket {
     /// of the ticket record.
     #[serde(skip)]
     pub result: Option<serde_json::Value>,
+    /// Failures recorded against the ticket, appended as they happen. A tool
+    /// call or request that failed does not fail the ticket, so this can carry
+    /// entries on a ticket that finished. Stored in its own file, so it is not
+    /// part of the ticket record.
+    #[serde(skip)]
+    pub errors: Vec<Event>,
     /// The parent ticket if a handover was performed.
     pub parent: Option<String>,
     /// Messages exchanged with the model.
@@ -94,6 +101,7 @@ impl Ticket {
             finished_at: None,
             failed_at: None,
             result: None,
+            errors: Vec::new(),
             parent: None,
             replies: Vec::new(),
         }
@@ -258,6 +266,7 @@ impl crate::persistence::Persist for Ticket {
         let mut ticket: Ticket = serde_json::from_slice(&bytes).map_err(io::Error::other)?;
         ticket.replies = Replies::load(dir, key)?.entries;
         ticket.result = TicketResult::load(dir, key)?.value;
+        ticket.errors = TicketErrors::load(dir, key)?.entries;
         Ok(ticket)
     }
 }
@@ -349,6 +358,56 @@ impl Persist for Replies {
     }
 }
 
+/// A ticket's failures on disk, one JSON [`Event`] per line in
+/// `tickets/<key>/errors.jsonl`.
+///
+/// The failure parallel of [`Replies`]: [`TicketErrors::append`] adds one line
+/// as each failure is emitted, and [`Persist::load`] reads them back.
+pub(crate) struct TicketErrors {
+    pub(crate) key: String,
+    pub(crate) entries: Vec<Event>,
+}
+
+impl TicketErrors {
+    /// Add one failure event as a single line, without reading the file.
+    pub(crate) fn append(dir: &Path, key: &str, event: &Event) -> io::Result<()> {
+        let line = serde_json::to_string(event).map_err(io::Error::other)?;
+        crate::persistence::append_line(&errors_path(dir, key), &line)
+    }
+}
+
+impl Persist for TicketErrors {
+    type Key = String;
+
+    /// Rewrite `errors.jsonl` whole. Unused by the append path, present for the
+    /// same [`Persist`] shape [`Replies`] carries.
+    fn save(&self, dir: &Path) -> io::Result<()> {
+        let mut body = String::new();
+        for event in &self.entries {
+            body.push_str(&serde_json::to_string(event).map_err(io::Error::other)?);
+            body.push('\n');
+        }
+        crate::persistence::write_atomic(&errors_path(dir, &self.key), body.as_bytes())
+    }
+
+    fn load(dir: &Path, key: &String) -> io::Result<Self> {
+        let path = errors_path(dir, key);
+        let entries = if path.exists() {
+            std::fs::read_to_string(&path)?
+                .lines()
+                .filter(|l| !l.is_empty())
+                .map(|l| serde_json::from_str::<Event>(l).map_err(io::Error::other))
+                .collect::<io::Result<Vec<_>>>()?
+        } else {
+            Vec::new()
+        };
+        Ok(TicketErrors {
+            key: key.clone(),
+            entries,
+        })
+    }
+}
+
 /// Where `key`'s ticket is stored: `tickets/<key>/ticket.json`.
 pub(super) fn ticket_record_path(dir: &Path, key: &str) -> PathBuf {
     dir.join("tickets").join(key).join("ticket.json")
@@ -362,6 +421,11 @@ fn replies_path(dir: &Path, key: &str) -> PathBuf {
 /// Where `key`'s result is stored: `tickets/<key>/result.json`.
 pub(super) fn result_path(dir: &Path, key: &str) -> PathBuf {
     dir.join("tickets").join(key).join("result.json")
+}
+
+/// Where `key`'s failures are stored: `tickets/<key>/errors.jsonl`.
+pub(super) fn errors_path(dir: &Path, key: &str) -> PathBuf {
+    dir.join("tickets").join(key).join("errors.jsonl")
 }
 
 impl AsUserMessage for Ticket {

--- a/crates/agentwerk/src/agents/tickets/ticket_queue.rs
+++ b/crates/agentwerk/src/agents/tickets/ticket_queue.rs
@@ -22,7 +22,7 @@ use super::super::r#loop::run_main_loop;
 use super::super::stats::Stats;
 use super::query::TicketMatcher;
 use super::ticket::{Status, Ticket};
-use super::{policy_violated, numeric_id, Reply};
+use super::{numeric_id, policy_violated, Reply, TicketErrors};
 
 /// The queue arrives first so a handler selects tickets and files follow-up work
 /// without capturing an `Arc` into the queue that holds it.
@@ -719,6 +719,25 @@ impl TicketQueue {
         if !matches!(event.kind, EventKind::TextChunkReceived { .. }) {
             let _guard = self.events_lock.lock().unwrap();
             let _ = Stats::append(&self.get_dir(), &event);
+        }
+        // Record a failure against its ticket, the way a result is recorded
+        // against it. `TicketFailed` is left out: it is the outcome, already
+        // carried by the ticket's status and `failed_at`, not a cause. Pushed
+        // before the handlers run, so one receiving the ticket sees it.
+        if event.kind.is_failure() && !matches!(event.kind, EventKind::TicketFailed) {
+            let recorded = {
+                let mut store = self.tickets.lock().unwrap();
+                store
+                    .get_mut(key)
+                    .map(|t| t.errors.push(event.clone()))
+                    .is_some()
+            };
+            if recorded {
+                // Best-effort, like the other ticket writes: it is already in
+                // memory and in `events.jsonl`, so a failed append is
+                // observational.
+                let _ = TicketErrors::append(&self.get_dir(), key, &event);
+            }
         }
         let handlers: Vec<Arc<EventHandler>> = self.event_handlers.lock().unwrap().clone();
         if handlers.is_empty() {
@@ -1916,6 +1935,102 @@ mod tests {
                 ("ticket_failed", key.clone()),
             ]
         );
+    }
+
+    #[test]
+    fn failures_accumulate_on_the_ticket_in_order() {
+        let (queue, dir) = test_queue();
+        let key = queue.ticket("work");
+
+        queue.emit(
+            &key,
+            "agent",
+            EventKind::ToolCallFailed {
+                tool_name: "grep".into(),
+                call_id: "c1".into(),
+                reason: ToolFailureKind::ExecutionFailed,
+                message: "no such directory".into(),
+            },
+        );
+        queue.emit(
+            &key,
+            "agent",
+            EventKind::RequestFailed {
+                model: "mock".into(),
+                reason: crate::providers::RequestErrorKind::ConnectionFailed,
+                message: "dns lookup failed".into(),
+            },
+        );
+
+        let ticket = queue.get_ticket(&key).unwrap();
+        let names: Vec<&str> = ticket.errors.iter().map(|e| e.kind.name()).collect();
+        assert_eq!(names, ["tool_call_failed", "request_failed"]);
+
+        // One JSON line per failure, each a full event.
+        let body =
+            std::fs::read_to_string(dir.path().join("tickets").join(&key).join("errors.jsonl"))
+                .unwrap();
+        let lines: Vec<&str> = body.lines().collect();
+        assert_eq!(lines.len(), 2);
+        for line in lines {
+            let _: crate::event::Event = serde_json::from_str(line).unwrap();
+        }
+    }
+
+    #[test]
+    fn a_recoverable_failure_stays_on_a_finished_ticket() {
+        let (queue, _tmp) = test_queue();
+        let key = queue.ticket("work");
+
+        // A failed tool call the model recovered from: the ticket finishes.
+        queue.emit(
+            &key,
+            "agent",
+            EventKind::ToolCallFailed {
+                tool_name: "grep".into(),
+                call_id: "c1".into(),
+                reason: ToolFailureKind::ExecutionFailed,
+                message: "boom".into(),
+            },
+        );
+        queue.set_finished(&key, "done").unwrap();
+
+        let ticket = queue.get_ticket(&key).unwrap();
+        assert_eq!(ticket.status, Status::Finished);
+        assert_eq!(ticket.errors.len(), 1);
+        assert_eq!(ticket.errors[0].kind.name(), "tool_call_failed");
+    }
+
+    #[test]
+    fn the_terminal_ticket_failed_is_not_recorded_as_an_error() {
+        let (queue, _tmp) = test_queue();
+        let key = queue.ticket("work");
+        queue.set_failed(&key).unwrap();
+        assert!(queue.get_ticket(&key).unwrap().errors.is_empty());
+    }
+
+    #[test]
+    fn failures_round_trip_through_load() {
+        let dir = crate::test_util::TempDir::new().unwrap();
+        let original = TicketQueue::new();
+        original.dir(dir.path().to_path_buf());
+        let key = original.ticket("work");
+        original.emit(
+            &key,
+            "agent",
+            EventKind::ToolCallFailed {
+                tool_name: "grep".into(),
+                call_id: "c1".into(),
+                reason: ToolFailureKind::ExecutionFailed,
+                message: "boom".into(),
+            },
+        );
+        drop(original);
+
+        let resumed = TicketQueue::load(dir.path()).unwrap();
+        let ticket = resumed.get_ticket(&key).unwrap();
+        assert_eq!(ticket.errors.len(), 1);
+        assert_eq!(ticket.errors[0].kind.name(), "tool_call_failed");
     }
 
     #[test]

--- a/crates/agentwerk/src/lib.rs
+++ b/crates/agentwerk/src/lib.rs
@@ -94,8 +94,8 @@ pub use agents::Ticket;
 pub use agents::TicketQueue;
 
 // Tuning, telemetry, durable state
-pub use agents::Policy;
 pub use agents::Knowledge;
+pub use agents::Policy;
 pub use agents::Trajectory;
 
 // Validation

--- a/crates/agentwerk/tests/integration/compaction.rs
+++ b/crates/agentwerk/tests/integration/compaction.rs
@@ -9,7 +9,7 @@ use super::common;
 
 use agentwerk::agents::tickets::Author;
 use agentwerk::event::EventKind;
-use agentwerk::{Agent, Policy, Event, Ticket, TicketQueue};
+use agentwerk::{Agent, Event, Policy, Ticket, TicketQueue};
 
 // Pins a known context window: the trigger stays quiet on a model whose window
 // it cannot look up, and the model here comes from the environment. The first

--- a/crates/agentwerk/tests/integration/seeker_finds_planted.rs
+++ b/crates/agentwerk/tests/integration/seeker_finds_planted.rs
@@ -18,7 +18,7 @@ use super::common;
 use agentwerk::agents::knowledge::Page;
 use agentwerk::event::{default_logger, Event, EventKind};
 use agentwerk::tools::GrepTool;
-use agentwerk::{Agent, Policy, Knowledge, Ticket, TicketQueue};
+use agentwerk::{Agent, Knowledge, Policy, Ticket, TicketQueue};
 
 const SEEKER_AGENT: &str = include_str!("../../../use-cases/src/malware_scanner/agents/seeker.md");
 

--- a/crates/agentwerk/tests/integration/tickets_all_actions.rs
+++ b/crates/agentwerk/tests/integration/tickets_all_actions.rs
@@ -13,7 +13,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use super::common;
 
 use agentwerk::tools::TicketsTool;
-use agentwerk::{Agent, Policy, EventKind, Query, Ticket, TicketQueue};
+use agentwerk::{Agent, EventKind, Policy, Query, Ticket, TicketQueue};
 
 const ACTIONS: [&str; 5] = ["ticket", "result", "list", "create", "edit"];
 

--- a/crates/use-cases/src/malware_scanner/main.rs
+++ b/crates/use-cases/src/malware_scanner/main.rs
@@ -23,7 +23,7 @@ use std::sync::Arc;
 use agentwerk::agents::Trajectory;
 use agentwerk::providers::{Model, Provider};
 use agentwerk::tools::{GlobTool, GrepTool, ListDirectoryTool, ReadFileTool};
-use agentwerk::{Agent, Policy, FinishReason, Knowledge, SchemaStore, Ticket, TicketQueue};
+use agentwerk::{Agent, FinishReason, Knowledge, Policy, SchemaStore, Ticket, TicketQueue};
 use serde_json::{json, Value};
 
 use cli::{CliArgs, ModelTable};

--- a/crates/use-cases/src/terminal_repl/main.rs
+++ b/crates/use-cases/src/terminal_repl/main.rs
@@ -34,7 +34,7 @@ use agentwerk::providers::Model;
 use agentwerk::tools::{
     GlobTool, GrepTool, ListDirectoryTool, ReadFileTool, TicketsTool, WriteFileTool,
 };
-use agentwerk::{Agent, Policy, Knowledge, Ticket, TicketQueue};
+use agentwerk::{Agent, Knowledge, Policy, Ticket, TicketQueue};
 
 const ROLE: &str = include_str!("prompts/repl.role.md");
 const BIBLE_PASSAGE: &str = include_str!("prompts/bible.txt");


### PR DESCRIPTION
### Purpose

  - A ticket's failures lived only in `events.jsonl`, unreadable per ticket
  - One result cannot capture the many failures a ticket hits
  - Retried requests and recovered tool calls now stay on the ticket
  - AQL gains a way to select tickets by their recorded failures

  ### What changed

  - `Ticket.errors` carries each failure as an `Event`, in order
  - `TicketQueue.emit` appends failures to `tickets/<key>/errors.jsonl`
  - Every `is_failure` event is recorded except the terminal `TicketFailed`
  - A recorded failure is not a transition; `set_failed(key)` is unchanged
  - AQL adds an `errors` field taking `~`, `!~`, `IS EMPTY`, `IS NOT EMPTY`
  - Python `Ticket.errors` returns the same events

  ### Examples

  ```rust
  tickets.find_tickets("errors IS NOT EMPTY");        // hit a failure, even if it finished
  tickets.find_tickets("errors ~ tool_call_failed");  // saw a tool call fail
  ```

  ```py
  for event in ticket.errors:
      print(event.kind)
  ```

  ```rust
  let failures = ticket.errors;  // every failure recorded against the ticket
  ```