### PR TITLE
docs: simplify agent conventions

### DIFF
--- a/agentdocs/architecture.md
+++ b/agentdocs/architecture.md
@@ -1,230 +1,98 @@
 # Architecture
 
-The invariants that shape how code fits together. Layout says where code lives; this file says why the boundaries are where they are.
+The invariants that govern orchestration, tools, providers, events, and durable state.
 
-## Agent, Werk, Loop
+## Ownership and Concurrency
 
-**A run has three stages: configure the `Agent`, bind it to a `Werk`, drive the Werk with `start` or a `finish_*` wait.**
+**A `Werk` owns shared execution state; each `Agent` processes one claimed task at a time.**
 
-```rust
-let agent = Agent::from_env();
-werk.add_agent(agent);
-werk.finish_all_tasks().await;
-```
+- Configure an `Agent`, bind it through `Werk::add_agent`, then drive the Werk with `start` or a `finish_*` method.
+- Let `Werk::bind_agent` move tasks queued on an agent's private Werk into the shared Werk.
+- Claim each task once and release Werk locks before `ProviderLike::respond` or a tool handler is awaited.
+- Keep one `Werk` as the orchestration boundary; nested Werks are not supported.
 
-- An `Agent` starts with a private Werk behind a shared `WerkRef`. Binding any clone redirects every clone to the shared Werk. `Werk::new` captures its own `Weak<Self>` through `Arc::new_cyclic` for that binding.
-- `add_agent(a)` also drains tasks the agent queued in its private default Werk into the shared one.
-- `start` and the `finish_*` waits spawn one tokio task per registered agent. Each upgrades its `Weak` once and reads the shared store, policy, budget, and ending from the resulting `Arc`.
-- `werk.add_task(value)` creates a task and returns its ID; `werk.add_reply(&id, content)` appends a text reply and the wait-for-input branch drives the next turn on the same replies. That is how multi-turn chat is built on one task.
+## Assignment and Identity
 
-## Shared Werk, Per-Agent Task
+**Use labels for assignment and generated IDs for ownership.**
 
-**Agents read shared state through one `Arc<Werk>`. Locks are held only around Werk state and metric operations, never across `provider.respond().await`.**
+- Match an unlabelled agent only to unlabelled tasks; match a labelled agent only to the same task label.
+- Use a unique label when a task must target one agent; agents sharing a label form a pool.
+- Let `Agent::get_id` assign `<label>-<n>` or `agent-<n>` and store that ID in `Task::assignee` when claimed.
+- Recreate agents in the same label order when resuming a session, because started tasks resume only on the same generated ID.
 
-- The task store, policy, budget, ending, cancel filters, and registered-agent list live on `Werk`.
-- The per-agent loop in `loop/agent.rs` claims one task, drives it through one or more provider and tool turns, and releases locks before each await.
-- Multiple agents share one Werk; a task is claimed exactly once. Nested Werks are not supported: one `Werk` is the unit of orchestration.
+## Queries and Lifecycle
 
-## Assignment Is a Label, Identity Is an Id
+**Use AQL for every string selection over tasks or events.**
 
-**One label per agent, one label per task: the label is the only assignment mechanism, and the id `build` derives from it is the only identity. Neither does the other's job.**
+- Accept `Matcher<Task>` in task selectors; reserve `Query<Event>` for recorded events.
+- Treat a bare `t-<n>` as an ID and another bare word as a label; require `label = t-3` for an ID-shaped label.
+- Use `Query::new` for runtime input so invalid AQL returns `QueryError`; infallible string conversions may panic.
+- Define pending work as unfinished, uncancelled work selected by the query; a task paused for caller input does not keep a `finish_*` wait open.
+- Keep cancellation scoped to the current run: `start()` clears cancellation without changing `Status`.
 
-```rust
-werk.add_task(Task::new("Audit src/db.").label("scan")); // one scope
-werk.add_task(Task::new("Audit src/db."));               // the default scope
-```
+## Completion and Handovers
 
-- `Agent::handles` is equality in both directions: an agent with no label matches only tasks with no label, the default scope. A label no agent serves never matches, since the Werk never resolves one against the registered-agent set. It takes both labels rather than a receiver, because the loop's claim filter holds the label and the Werk keeps that filter.
-- Addressing one agent alone is giving it a label no other agent serves. The task is born `Status::Todo` (`todo`) like any other; nothing is born `in_progress`.
-- `Agent::get_id` assigns `<label>-<n>` the first time anything asks for it, numbering per label from 1; an agent with no label gets `agent-<n>`. It is that late because the label is set after construction, so a label bound afterwards would otherwise rename an agent the Werk already knows. `Agent::clone` reads the id before copying it, since `bind_agent` holds a clone and the two must agree about which tasks are theirs.
-- `claim` writes the claiming agent's id to `Task::assignee`, and the `resumable` check requires the two to match, so agents sharing a label never take over each other's started work. A host that wants resumption builds the same agents, in the same order, after a restart.
-- A session directory written before the label became singular stores `"labels": [..]`, which no longer deserializes. There is no shim: start a fresh session directory.
+**Finish tasks through the completion engine owned by `EventTool` and wrapped by `FinishTool`.**
 
-## A Tool Call Resolves by Exact Name, Then by Folded Key
+- Register `FinishTool` automatically for non-interactive agents; interactive agents pause and the host ends them with `Werk::set_task_finished`.
+- Bind an object `Schema` directly as the finish arguments; keep scalar and unbound results in the legacy `result` envelope.
+- Treat `EventTool`'s `task_finished` event as completion; every other published event remains observational.
+- Create a configured `Agent::handover` child before marking its parent finished so the Werk never appears empty between them.
+- Move `Status` only through task-store transitions; reserve `Status::Failed` for system-driven terminal outcomes.
 
-**Tool resolution matches the name the model sent exactly. Failing that, it folds both sides onto a lookup key (lowercase, hyphens to underscores, one trailing `_tool` removed) and resolves to the tool that key matches. A key two registered tools share resolves to nothing.**
+## Tools and Corrections
 
-- The fold only removes information, so it cannot reach a tool the model did not name. A host's `grep_tool` and the built-in `grep` both stay reachable under their own names, and a third spelling resolves to neither.
-- `get` is the only entry point for dispatch and `partition_tool_calls`.
-- Every registered tool carries a compiled `Schema`. `Tool::schema` is the one place a document compiles, and it panics on one the compiler refuses, so a broken definition fails during configuration rather than a request. Registration rejects a tool without a description or handler.
-- `Schema::validate` is the only thing that rejects a call's arguments. It retypes what the schema names a type for, then checks what that produced, so the model reads back everything still wrong in one report per turn.
-- No tool checks its own arguments. A requirement that holds only for some values of a discriminator is stated with `allOf`/`if`/`then` in the tool's `.schema.json`; a rejection answers as `tool_call_failed` with `kind: schema_failed`.
-- The loop rewrites each call to the registered name before emitting `tool_call_started`, so `Event` and `Stats` never split one tool across spellings. Both repairs reach the host as `tool_call_repaired` events carrying `tool_name`, `call_id`, and either `call_malformed` or `value_mistyped` as their `kind`.
-- A host that needs file-attempt telemetry derives it from the registered name and `input.path` on `tool_call_started`; outcomes can be joined through `call_id`. The core emits no separate file-open event family.
-- A name that resolves to nothing returns `tool_call_failed` with `kind: not_found` and a message naming every registered tool. Without that list each retry spends `max_schema_retries` until the task fails. A call the model wrote as text takes the same path.
+**Validate and dispatch every tool call through the registered `Tool`.**
 
-## Every Directive Is a Catalogue Entry
+- Resolve the model's exact tool name first, then its lowercase hyphen-to-underscore form with one trailing `_tool` removed.
+- Reject an ambiguous folded name instead of choosing one registered tool.
+- Compile input rules through `Tool::schema` and validate arguments through `Schema::validate`; do not repeat schema checks inside each tool.
+- Keep model-facing recovery text in `prompts/directives/*.md`, keyed through `Directive` and rendered by `DirectiveStore`.
+- Emit `tool_call_repaired` when a name or value is corrected and `tool_call_failed` when the model must recover.
 
-**Text agentwerk sends the model to report a failure or correct its behavior is one entry in `prompts/directives/*.md`, named by a `pub const` beside it, and the function an agent takes through `Agent::directives` decides what it renders as. No call site writes one inline.**
+## Events and Hooks
 
-```rust
-Event::new(Event::TOOL_CALL_FAILED)
-    .directive(EDIT_FILE_OLD_STRING_NOT_FOUND)
-    .data(json!({ "kind": "execution_failed", "message": message }))
-```
+**Route every observation through `Werk::emit_event`.**
 
-- `DirectiveStore::render(key, values)` hands that function the key, then binds `{name}` into what comes back, or into the catalogue text when it answers `None`. A store therefore varies a directive by which one it is, and the values reach the model through the template rather than through the function. It takes a `&str`, so the constants rather than the compiler are what keep the 94 call sites honest.
-- The `directives!` macro declares each key once and emits the crate-private constant the render sites write, the `Directive` constant a host matches on, and the `ALL` entry, so the three cannot disagree. A test pairs `ALL` against the `## ` headings, which the macro cannot reach.
-- One function decides every directive, rather than a table of per-key replacements. A host matches the key against the constants `Directive` carries, so a misspelled arm does not compile, and answers `None` to leave a key as it is.
-- `Agent::directives` wraps the function in the crate-private `DirectiveStore`; the loop attaches it to each tool call. Two agents in one process therefore word a failure differently, and no test needs a lock. A host sharing one function across agents passes the same `fn` or a cloned handle.
-- Twenty-one keys render through `built_in` instead, composed where no agent is in reach: the 19 schema violations inside `Node::check`, `knowledge_index_truncated` inside `Knowledge::index`, and `result_schema_required` inside `Task::as_user_message`. Threading a store into any of the three would re-type public API.
-- Binding is one pass, so a value carrying `{` is never read as a placeholder of its own. A `{name}` with no value renders as written, the rule `Agent::template` already states.
-- Two categories stay out: a `SchemaParseError` and the "could not read its arguments" answer both name a mistake in the host's code, and no model reads them. The tags around an offloaded result stay in Rust too, since `cap_aggregate_outputs` reads the opening one back.
-- The retry site binds `attempt`, `max_attempts`, `task`, and `agent` beside `detail`, so a replacement naming `{attempt}` or `{agent}` says how far into the budget a retry is, or which agent it addresses, without an event in reach.
+- Use `Event.name` as the semantic discriminator for built-in and application events.
+- Do not make publication mutate task state; completion through `EventTool` is the explicit exception.
+- Append events to `events.jsonl` before handlers run, excluding `text_chunk_received`, and fold policy statistics from the same records.
+- Keep synchronous handlers cheap; async hook variants are queued and drained by the waiting `finish_*` call.
+- Build `on_result`, `on_failure`, and `on_task` on the ordered `on_event` chain so handlers coexist.
 
-## Finishing Is a Task-Finished Event
+## Providers and Retries
 
-**`EventTool` owns event publication and completion; its `task_finished` event records the result and may create a child task. `FinishTool` is the automatically registered wrapper: a bound object schema is its argument schema, while scalar and unbound calls keep the legacy envelope.**
+**Keep vendor protocols behind `ProviderLike` and centralize HTTP behavior in `Endpoint`.**
 
-`event({ "name": "task_finished", "data": { ... } })` routes `data` through the same completion engine as `finish({ ... })`: it records the result through `Werk::set_result`, then transitions the task to `Status::Finished` (`finished`). Before that dispatch, `FinishTool` wraps a call bound to an object schema as `{ "result": arguments }`; reserved field names inside that result therefore have no control meaning. Scalar and unbound calls use the established envelope, while an unbound non-empty object carrying no reserved argument remains a bare result for compatibility. Every other event name is observational, even when it is a built-in lifecycle name. `Werk::emit_event` remains observational too. The loop still enforces `finish` on every non-interactive agent because `FinishTool` remains the default and `EventTool` is opt-in.
+- Let each concrete provider own an `Endpoint`; do not add another transport abstraction.
+- Keep Anthropic and OpenAI message shapes behind the internal `Protocol` trait; reuse the OpenAI shape for Mistral and LiteLLM.
+- Decode vendor payloads in each provider and assemble `ModelResponse` through the shared `ResponseBuilder`.
+- Apply request retries in the agent request path through `Policy::max_request_retries`, never inside a provider.
 
-- An interactive agent gets no `finish` at all, since ending the task would end the conversation. It pauses on a reply that calls no tool, and the host closes the task with `Werk::set_task_finished`. `bind_agent` is where the tool is registered, because only once the agent joins a Werk is `interactive` final; registration only ever adds, so a host that registers `FinishTool` itself keeps it either way.
-- `Agent::handover(Task)` sets the one child created whenever that agent finishes. Bound object results keep it host-owned. In the legacy envelope, its label is fixed and a nested `handover` may override the task or schema; without a configured handover, nested `label` and `task` are required. String leaves in structured tasks substitute `{parent_id}`, `{parent_result_path}`, and `{parent_result}`, and the child records the current task as its `parent`.
-- The child is inserted BEFORE the parent finishes, so a concurrent `work_left` check can never see an empty Werk between them. `task_finished` and `task_failed` are emitted synchronously from the transition, and a count of in-flight transitions keeps `work_left` true until every handler returns, so an `on_result` follow-up lands first as well.
-- A turn that ends without a `finish` call pushes a corrective directive and retries, the same path a schema failure takes, bounded by `max_schema_retries`; exhaustion emits `policy_violated` for `max_schema_retries` and then `task_failed`. Both paths emit `schema_retried` first, and its `attempt` and `max_attempts` are bound into the directive that follows.
-- `Agent::get_tools(task)` clones the agent's configured tools and binds that task's schema into `FinishTool` and, when registered, `EventTool.data.result`. A bound object schema is exposed directly and wraps the validated arguments only after the call passes. Scalar and unbound finishes use `if`/`then`/`else` for their legacy envelope. A result that misses its schema is rejected before completion, and an exactly encoded object can be decoded at the call root. Their one own check: a handover needs a real result.
-- Configuring `Agent::handover(Task)` makes the chain mandatory. Omitting the nested handover object uses the configured task.
-- `Status` transitions go through task-side helpers; the agent never writes status directly. `Status::Failed` (`failed`) is reserved for system-driven outcomes: exhausted schema retries, exhausted missing-`finish` retries, and breached limits.
+## Persistence
 
-Schemas and results:
+**Let each persisted type own its path and encoding.**
 
-- `Task::schema(...)` attaches a `Schema` directly to a host-created or handover task. Tasks created through `TaskTool` receive no implicit contract.
-- A handover validates its result against the parent's schema and carries its own schema on the resolved child Task. Invalid results, labels, or inline schemas abort before insertion.
-- A bound object schema always supplies `finish`'s top-level fields, even when it declares `result` or `handover`; those names are result data, not controls. Scalar and unbound calls use the explicit envelope, where `result` and nested `handover` retain their control meaning. The envelope fields also sit inside `event.data` for `task_finished`.
-- A successful finish writes `<dir>/tasks/<id>/result.json` (`Werk::set_dir(d)`, default `./.agentwerk`) and attaches the same value, read back through `Task::get_result()`. The full task state goes to `task.json` on every transition, while the `task_finished` entry in `<dir>/events.jsonl` carries a copy under `data.result`. A finish without a result omits that key, keeping it distinct from a JSON `null` result. These writes are observational: errors are swallowed.
-- Failures are the plural mirror of the single result. `Werk::emit_event` makes events with a failure name visible through `Task::get_errors`, so a task accumulates the failed requests and tool calls it saw. A failure is not a transition: an entry lands whether or not the task goes on to fail, so a `finished` task can carry some. Nothing is written for it: the line is already in `<dir>/events.jsonl`, and `Werk::load` folds the failures back onto each task in the one pass it makes over the log for `Stats`. There is no per-task errors file and no second writer to keep in step.
+- Implement `Persist` for values saved and loaded as a whole; use inherent `append` only for append-only logs such as `Stats` and `Replies`.
+- Route whole-file writes through `write_atomic` and log writes through `append_line`.
+- Store task metadata, replies, results, tool outputs, events, trajectories, and knowledge in separate files under the Werk directory.
+- Keep automatic session writes best-effort so an I/O failure does not replace an in-memory task outcome.
+- Return I/O failures from caller-driven operations such as `Trajectory::save` and `Knowledge::get_pages` mutations.
 
-## Knowledge Is Opt-In and Shareable Across Agents
+## Knowledge
 
-**`Agent::knowledge(&store)` carries durable facts across every task an agent handles, across separate `start` and `finish` calls, and across process restarts. Off by default.**
+**Keep `Knowledge` optional, durable, and shared only by explicit handle.**
 
-- Per-task state is read through `Task::get_replies`, which the loop turns into each request's `Vec<Message>` through its private conversion. `Knowledge` is the separate cross-task layer, surfaced through `KnowledgeTool` and rendered into the system prompt.
-- Two agents bound to the same `Arc<Knowledge>` share one bundle; two agents bound to different stores see independent knowledge.
-- The store is an Open Knowledge Format (OKF) v0.1 bundle in `<dir>/knowledge/` (`BUNDLE_DIR`), which keeps it out of a co-located `Werk`'s files and keeps the recursive page walk inside the bundle.
-- `index.md` is derived and never parsed back: on load the in-memory index is rebuilt by walking the page frontmatter (`rebuild_index_from_pages`), so a bundle dropped into `<dir>/knowledge/` seeds the store.
-- Only the index is injected into the system prompt; the agent reads full pages on demand through `read`. `Agent::run_task` reads the index once, so the prompt stays byte-stable across every turn and the provider's prefix cache survives mid-task writes. Writes become visible at the top of the next task.
-- Knowledge is purely model-driven, and the tool description carries the policy (durable facts only, do NOT save task progress or TODOs). A page's `type` and `tags` are host-side concerns set through the `Page` API, not tool parameters.
-- A character limit caps how much of the index the prompt lists, never what may be written. Past it the index names the absolute path to `index.md` instead, while `list` still returns the whole thing. It defaults to 12 000 and is configurable through `Knowledge::set_index_char_limit(count)`.
+- Store pages as an OKF v0.1 bundle under `<dir>/knowledge/` and rebuild `index.md` from page frontmatter on load.
+- Inject only the index into the prompt; let `KnowledgeTool` read full pages on demand.
+- Read the index once per task so writes become visible on the next task without changing an active prompt prefix.
+- Cap injected index characters through `Knowledge::set_index_char_limit` without limiting stored page content.
 
-## Observer Chain, One Error Path
+## Policy and Run Ending
 
-**`Event` reports state. `ProviderError` reports a failed provider contract. The two channels carry independent information.**
+**Let `run_main_loop` announce one terminal `FinishReason` after agents stop.**
 
-- Every state transition publishes an `Event`. A failed request fires both `ProviderError` and a matching `Event` (`RequestFailed`, `PolicyViolated`). `Event.name` is the sole semantic discriminator: caller-published built-in names receive the same hooks, statistics, and persistence behavior, but publication does not perform the associated transition.
-- A tool returns one terminal `Event`. `tool_call_finished` carries `output` plus optional `output_path` and `repairs` in its data; `tool_call_failed` carries the stable `kind`, model-visible `message`, and optional top-level `directive`.
-- A model-fixable failure (wrong arguments, schema mismatch, missing file) becomes a failed tool-result content block for the provider. It still fires `tool_call_failed` but does not stop the run.
-- Handlers MUST be cheap and non-blocking; the loop does not await them. The four `_async` twins are the exception, and the loop still never awaits: registering one only queues the event, and whichever `finish` is waiting drains it and awaits each handler on its own task. A handler that never returns therefore stalls the caller rather than an agent, and a `start()`-only host uses the blocking form.
-
-`Werk::on_event(h)` pushes a handler onto an ordered chain. Every installed handler fires on every event, in installation order, and each is handed the Werk and the same `&Event` rather than its own copy. When no handler is installed, `default_logger` runs in its place.
-
-- Every other hook is built on that chain, so a host's logger and a hook coexist.
-- The Werk is the first parameter of every handler. That is what let the `create_task_on_*` and `edit_replies_on_event` hooks go: a handler files its own follow-up work through `werk.add_task(..)`, rewrites what the model reads next through `werk.edit_replies(&event.task_id, ..)`, and selects what it needs through `werk.find_*`, without an `Arc` into the Werk that holds it.
-- `on_result` filters to `task_finished` and unwraps the stored result, `on_failure` filters to failure names, and `on_task` filters to the three lifecycle names. The event name activates these semantic hooks regardless of who published it. Each hook resolves the task only when needed, avoiding a full reply copy for every text chunk.
-- An event that announces a reply is emitted after that reply has landed in the store: `request_finished` after the assistant reply, `tool_call_finished` and `tool_call_failed` after the tool results of their turn. A handler therefore finds the message the event names, and what it rewrites through `werk.edit_replies` reaches the next request.
-- `RunStarted`, `RunFinished { outcome }`, and a host-driven `set_failed` are emitted by the Werk itself and arrive with an empty `agent_id`.
-
-## New Observables Pick a Channel
-
-**Each new signal goes on `Event`, on a typed error, or on both. Pick by what the signal describes.**
-
-- Reached a state: `Event` only.
-- Could not fulfil a contract: typed error in the matching domain.
-- Both at once (terminal request failure, breached limit): define both. Share the payload type when observer-friendly (`PolicyViolation`); keep observer-hostile request detail in `RequestErrorKind`.
-- Model-fixable failure: a `tool_call_failed` event; still recoverable.
-- A public error enum carries `#[non_exhaustive]`, which covers new variants only: adding a field to an existing struct variant still breaks a caller that matches it without `..`, so prefer a new variant to widening an old one.
-
-## Providers Own Their Client
-
-**Each concrete provider owns an `Endpoint`, which owns a `reqwest::Client` directly. There is no transport abstraction beyond it.**
-
-- The `ProviderLike` trait fulfils one contract: `respond`, drive one turn. Callers hold it as a `Provider`, a cloneable handle any implementer converts into.
-- The request and response types are `pub` and documented, because implementing `ProviderLike` is supported and implementors name them.
-- `ModelRequest.tools` carries the `Tool` values themselves rather than a second description of them. `claim` clones the agent's tool list and rebinds any `finish` or `event` tool to the claimed task's schema and configured handover. A provider never calls a tool's handler.
-- Where a request goes, how long it may take, and what a non-2xx answer means are decided in `providers::endpoint`. Vendor code adds its own authentication headers and its own `classify_error`, and never retries: retry is request-level, using `Policy::max_request_retries` and `Policy::request_retry_delay`.
-- Two protocols cover four configurations, and the `Protocol` trait is where that split lives: `AnthropicMessages` and `OpenAiChat` each supply a path, authentication headers, a request shape, a 400-body classifier, and a decoder. `mistral` and `litellm` name `OpenAiChat` against their own `Endpoint`, and every `respond` is one call to `provider::respond::<P>`.
-- A provider decodes its own payloads and names which `ResponseBuilder` call each one is; `providers::stream` decides which block a fragment continues and when a `StreamEvent` fires. The number an endpoint attaches to a fragment routes tool calls only, and never sizes anything.
-- A context window is looked up by model name in `providers::model`, not per vendor.
-
-## The Lifecycle Is Three Verbs Over One Filter
-
-**`start` starts, `finish_tasks(matches)` waits, and `cancel_tasks(matches)` stops. `finish_all_tasks()` and `cancel_all_tasks()` name the whole Werk; `finish_task(matches)` keeps the query but returns one value.**
-
-- `Werk::pending(matches)` is the scheduling definition of "not done yet", and both the main loop and `finish_tasks` ask it. AQL's `pending = true` means `todo` or `in_progress` and not cancelled; the Werk additionally excludes a task paused for a caller reply from a wait.
-- `Werk::cancel_filters` marks current matches through `Task::cancelled` and marks later insertions while the run remains active. Claim and resume both reject that private flag. `start()` clears filters and flags, so unfinished tasks resume without persisting cancellation.
-- A filter runs while the task store lock is held, so it MUST NOT call back into the Werk: the same rule `find_task` and `find_tasks` carry.
-
-## A String That Selects Anything Is AQL
-
-**Every method taking a filter accepts a string, and the string is AQL: a query compiled by `Query::new` over tasks or `Query::<Event>::new` over recorded events. There is no second string meaning, and no method takes a bare label.**
-
-```rust
-werk.find_tasks("scan");                    // label = scan
-werk.find_results("t-3");                // id = t-3
-werk.find_tasks("label IN (scan, report) AND status != failed");
-werk.find_events("tool_call_failed AND created > -1h");
-```
-
-- One grammar, two field sets. The private `QueryField` trait names what a set must answer (`of`, `kind`, `is_optional`, `shorthand`, `label`, `tie_break`, and the `sort_unordered`, `canonical`, and `compare` it may override); `TaskField` and `EventField` implement it, and the tokenizer, `Parser<F>`, `Condition<F>`, `Sort<F>`, and `Compiled<F>` are shared. A third record type would be a third impl, not a second parser.
-- `Query<R>` is a newtype over `Compiled<R::Field>`, which holds the condition tree and the sort key and does everything a parsed query does. `Queryable` maps a record to its field set and stays private, which is what keeps `QueryField` and the tree private; the three declarations that name it carry `#[allow(private_bounds)]`. `R` defaults to `Task`, so a task query is `Query` and an event query is `Query<Event>`, and only `default_status`, `and_status`, and `and_result` sit in a `Query<Task>` block.
-- `Condition<F>` is a tree of `All`, `Any`, `Not`, one term per field, and `Test`, which holds a caller's closure. AQL is the only grammar a selection is written in, and a closure is a leaf of the same tree rather than a second kind of filter, so the Werk holds one thing however the caller wrote it. Nothing outside the module builds a term: the crate reaches the tree through `and`, `default_status`, `and_status`, and `and_result`, all crate-private.
-- A lone bare word is `id = <word>` when it is spelled `t-<digits>` and `label = <word>` otherwise, which is what keeps a label the shortest thing you can write. A label named like an ID needs `label = t-3`.
-- `From<&str>` and `Matcher<R> for &str` are infallible by signature, so a string that does not compile panics, the way `Tool::schema` panics on a document the compiler refuses. `Query::new` returns a `Result` for a string built at run time, and the Python bindings raise `ValueError` rather than panicking across the binding.
-- `Matcher<R>` holds one method, `into_query`. Every call compiles its filter once and reads the query from then on, so a string costs one parse per call rather than one per record. Taking `self` is what makes that possible, and it is why the trait is not object-safe.
-- `ORDER BY` rides on the query rather than on the call, so the one string says both which tasks and in what order, and the `task` tool needs no second argument. A query that is nothing but an `ORDER BY` selects every task.
-- `Compiled::sort` is how the order reaches the Werk, and `QueryField::sort_unordered` is what a query without `ORDER BY` falls back to, so a closure answers in creation order the way it always did. `find_tasks` and `find_results` both pass one `Query` to `matching_tasks`, filter and order together.
-- `cancel`, `finish`, and `pending` read `matches` alone, so an `ORDER BY` handed to them does nothing. Nothing there is ordered.
-- `find_results` and `find_result` share `results_of`, which is `default_status(Finished)` plus `and_result`. `default_status` adds its term only when the tree mentions no status, and `Condition::Test` mentions no field, so a closure always takes the default. `and_result` is why `find_result` answers with the first match carrying a result rather than the first match. `finish` uses `and_status` instead, which adds `status = finished` whatever the filter said.
-- Two equalities on one single-valued field are a parse error rather than a query no task satisfies, and the message names `IN` as the fix. An absent field fails every comparison, so `label != scan` never reaches an unlabelled task and `IS EMPTY` is what does.
-- The `task` tool takes the same syntax as its one `aql` argument, and answers a `QueryError` as `tool_call_failed` through `task_query_invalid`. Nothing on that path panics. The tool reads tasks only: the event set is a host API.
-- A selection an agent's id or label goes into stays a closure. AQL has no way to bind a value, and both derive from a host-supplied label, so `agent = {id}` would let a label carrying `=`, a quote, or a space change the query. `resolve_current_id` and the loop's own claim filter are the two.
-- `EventField::sort_unordered` leaves the log order alone, where `TaskField`'s sorts by creation, because `find_events` reads a file that is already in order and the task store is a map. That is also what lets `find_event` stop at the first match when the query names no order, instead of copying the whole log to sort it.
-- The four time fields take `>`, `>=`, `<`, `<=` against a date, an offset back from now, or milliseconds. An offset resolves in `Query::new`, not in `matches`, so one compiled query answers one set however long it is held.
-
-## The Run Names Its Own Ending
-
-**`run_main_loop` decides when a run is over and announces it once, rather than whichever caller happens to await. A limit breached while the host is busy elsewhere still ends the run.**
-
-- `Werk::run` is one `Arc<Run>` over a `watch` channel of three phases: `Working`, `Draining(reason)` while the agents stop, and `Finished(reason)` once `RunFinished` has been announced. The channel is both the value and the wake, and a run complete without a reason cannot be written.
-- `ending_reason()` names `FinishReason::PolicyViolated(kind)` for a breached limit and `FinishReason::Cancelled` once a cancel leaves nothing claimable. An empty Werk is not an ending: a host that called `start()` may still be filing work, and a paused task revives on the next reply.
-- `FinishReason::Drained` is named by the `finish` that waited for it, and only when no task at all is still open. That is what keeps an interactive chat alive between turns.
-- The main loop joins its agents and emits `RunFinished { outcome }` before `Run::set_finished`, so a caller that starts another run never overlaps the previous one.
-- The tool runtime races every public custom-handler future against the run ending and drops the handler when cancellation wins. Dropping the `Werk` while agents still hold a `Weak` is the public way to abort: the upgrade fails and each task panics out cleanly.
-
-## Every Event Is Logged, Statistics Are Folded From It
-
-**`Werk::emit_event` is the single public and internal publication path. It stamps the time, resolves a known task's label, folds the event into crate-private `Stats`, and appends it to `events.jsonl`, `TextChunkReceived` aside. A host reads the log back through `Werk::find_events`; the crate counts only what a limit check needs.**
-
-- Publication preserves one order: statistics, live streams, persistence, failure attachment, then handlers. The line is written before observers fire, so the log holds what every handler saw. One line per streamed token would outweigh every other line and repeats what `replies.jsonl` already carries, which is why `text_chunk_received` is excluded.
-- `Event::<built_in>(...)` creates a built-in record with its canonical data shape. `Event::new(name)` remains the generic application-event constructor. `.data(value)`, `.task_id(id)`, and `.agent_id(id)` replace those values; task and agent context are optional and independent. Built-in names use lowercase snake case; application names are stored unchanged and matched exactly.
-- New log lines store `name` and `data`; the loader also accepts legacy lines that used `event` with flattened built-in data.
-- The write is best-effort, and a line this build cannot parse is skipped rather than costing every line after it, so a log written by another version still reports.
-- `find_events(condition)` reads the log; a count is `.len()` and any breakdown is a fold. `get_input_tokens()`, `get_output_tokens()`, and `get_duration()` stay off the counters, because the limit check reads the same ones every 50ms.
-- The two sources can disagree, by design: delete the log mid-run and the three totals keep reporting while the finders find nothing.
-- `request_finished` is the one kind whose payload the statistics read: its `usage` adds to the two token totals. Every other kind contributes its count and nothing else.
-- `execution_duration` spans the first `TaskStarted` to the `RunFinished`, or to now while the run is going. `TaskStarted` is emitted from `claim`, so a host claiming a task without running the loop still starts the clock. `Werk::load` restarts it: `max_time` bounds the run resuming the session, not the one that wrote the log.
-- Breakdowns are the host's, not the crate's. Per tool, per model, per file, per agent, or per label is a fold, on the `on_event` chain or over `find_events` afterwards, which is why an `Event` carries `agent_id`, `task_id`, and the task's `label` alongside its name and data.
-- `Stats::record` is the single writer and takes the whole `Event`, so a live Werk and `Stats::load` arrive at the same figures and a run never keeps a second set of counters. The per-task token series (`usage_for_task`) stays crate-internal, because compaction clears it and a caller would read a silently truncated series.
-
-## Persistence Routes Through One Trait
-
-**Every read and write in the crate goes through `Persist` in `persistence`, or through an inherent `append` on the type that owns its log. No domain module hand-rolls file IO; no module knows its file's name except the implementer.**
-
-- `Persist` defines `save(&self, dir) -> io::Result<()>` and `load(dir, &Self::Key) -> io::Result<Self>`. `Task`, `Replies`, `TaskResult`, `Page`, and `Trajectory` implement it, each owning its own path layout under `tasks/<id>/`, `pages/`, or `trajectories/`.
-- A task's result and its replies are both `#[serde(skip)]` on `Task` and spliced back in by `Task::load`, so each fact has one file.
-- A value type the caller stores itself reaches its file through an inherent method that delegates to its own impl, never by publishing the trait: `Trajectory::save(dir)` and `Knowledge::get_pages().save(page)` are the two. Service bootstrap (`Werk::load`, `Knowledge::load`) uses the same `load` verb by convention.
-- The two append-only logs own their filename on the type that reads them back: `Stats::append(dir, &Event)` writes `events.jsonl`, `Replies::append(dir, id, &Reply)` writes `tasks/<id>/replies.jsonl`. Neither earns a trait, since the second takes an ID the first does not.
-- `Replies` also implements `Persist`, whose `save` overwrites the file wholesale so a dropped or redacted reply leaves nothing behind.
-- `t-<N>` IDs are handed out in order. `load()` seeds the next ID from the tasks it just read off disk; a Werk built with `new()` scans for the highest existing ID at the first insert instead.
-- One agent processes one task at a time, so `add_reply` and the rewrite for one ID are sequential within a single loop task. No per-ID lock is needed.
-- `write_atomic` (tmp plus rename) and `append_line` (`O_APPEND` plus newline) are the only places that touch the filesystem. They are `pub(crate)`, and by convention nothing outside a `Persist` impl or an `append` reaches for them. One documented exception: `Werk::write_tool_output` writes single-shot flat files that fit neither trait.
-- Vocabulary is fixed: `save`, `load`, `append`. Bootstrap verbs other than `load` (such as `open`) are not used, and `checkpoint`, `snapshot`, `counter`, and `persist` do not appear in identifiers or test names.
-
-## Policy Is Per-Werk, Checked at Turn Boundaries
-
-**A run stops cleanly when any limit on `Policy` is breached. The check emits `Event::POLICY_VIOLATED` and exits the per-agent task.**
-
-- The loop calls `policy_violated` at each iteration; a non-`None` return stops the agent from claiming more work.
-- Token budgets read from the Werk's live `Stats`; `max_time` reads from `Policy` and from `Stats::execution_duration()`. `get_finish_reason` reports the matching `FinishReason::PolicyViolated(violation)` once the run has ended.
-- `Werk::set_policy` replaces the whole value, so a host builds one from `Policy::default()`, and `get_policy` reads back what it stored, including the clamped `compaction_threshold`.
-- The schema-retry budget is applied per-task inside the result-writing path, not at the top of the loop.
-- `compaction_threshold` rides on `Policy` for the same per-Werk snapshot every limit gets, but it is a trigger rather than a limit: `policy_violated` ignores it, and reaching it costs a compaction, not the run.
+- Check `Policy` limits at turn boundaries and emit `policy_violated` before ending the run.
+- Keep schema retries per task; treat `compaction_threshold` as a trigger, not a terminal limit.
+- Use `FinishReason::Drained` only when no open task remains, so an interactive task can continue across replies.
+- Emit `run_finished` before allowing another run to begin on the same Werk.

--- a/agentdocs/layout.md
+++ b/agentdocs/layout.md
@@ -1,99 +1,70 @@
 # Layout
 
-Where code lives and the rules that govern placement.
+Where code, tests, bindings, examples, and repository guidance live.
 
-## Crates
+## Workspace
 
-**Four crates: one library, one internal search engine, one binding layer, and one example set.**
+**Keep each crate responsible for one layer.**
 
-```
-crates/
-├── agentwerk/      the library
-├── agentwerk-codegrep/ unpublished code-shape search engine
-├── agentwerk-py/   the Python bindings
-└── use-cases/      runnable example binaries
-```
+- `crates/agentwerk/` contains the public Rust library.
+- `crates/agentwerk-codegrep/` contains the unpublished structural matcher used by `GrepTool`.
+- `crates/agentwerk-py/` contains the PyO3 bindings and the pure-Python package surface.
+- `crates/use-cases/` contains runnable examples and depends on the libraries, never the reverse.
+- Keep `agentwerk-py` outside `default-members` because its extension links against Python.
 
-- `use-cases` depends on the library, never the other way round, and nothing in it is re-exported.
+## Library Root
 
-## The `agentwerk-py` Crate
+**Place code under the domain that owns its behavior.**
 
-**One file per bound concept, mirroring the library. Naming rules live in [style.md](style.md).**
+- `src/lib.rs` declares modules and re-exports the small root API.
+- `src/event.rs` owns `Event`; `src/persistence.rs` owns shared file primitives and stays crate-private.
+- `src/agents/` owns agent configuration, tasks, orchestration, policy, queries, statistics, retries, compaction, and knowledge.
+- `src/providers/`, `src/tools/`, and `src/schemas/` own LLM providers, agent actions, and result validation.
+- `src/prompts/` owns prompt assembly, `Text`, and the directive catalogue.
 
-- `src/lib.rs` is the `#[pymodule]` and registers every class and function. `agent.rs`, `task.rs`, `werk.rs`, `reply.rs`, `trajectory.rs`, `knowledge.rs`, `schema.rs`, `event.rs`, `providers.rs`, and `tools.rs` each bind the library module of the same name.
-- `src/query.rs` binds `Query`, which covers both field sets: Python carries no type parameter, so the class compiles its string over tasks and over events at once and each call reads the compilation it needs.
-- `src/convert.rs` holds the only JSON boundary: `py_to_value` and `value_to_py` over `pythonize`, plus `py_to_text` for a prompt argument and `runtime_error`.
-- The compiled extension is `_agentwerk`. `python/agentwerk/__init__.py` re-exports it and holds the `@tool` decorator, the one piece of pure-Python logic. `__init__.pyi` declares the surface and MUST match the module, which `tests/test_parity.py` enforces.
-- The root `INVENTORY.md` lists every declaration of both crates, Rust rows next to Python rows. A binding missing from it, or a divergence its cells do not state, is a bug in one of the two.
-- The crate is a workspace member but not a default member: `cargo build` and `cargo test` skip it because it links against a Python interpreter. Its commands live in [workflow.md](workflow.md).
+## Agents and Tasks
 
-## Top-Level Files
+**Separate orchestration state from one agent's current operation.**
 
-**Each top-level source file is one concern the caller observes directly.**
+- `agents/agent.rs` configures `Agent`; `agents/tasks/werk.rs` exposes `Werk`.
+- `agents/tasks/` owns `Task`, `Reply`, storage transitions, trajectories, and task errors.
+- `agents/loop/` splits execution into the main scheduler, per-agent work, provider requests, compaction, and tool calls.
+- `agents/query.rs` owns AQL; `policy.rs`, `stats.rs`, and `retry.rs` own limits, statistics, and retry timing.
+- `agents/knowledge.rs` owns `Knowledge`, pages, and the OKF bundle under `<dir>/knowledge/`.
 
-- `lib.rs` holds public re-exports only. `Query` is part of the documented root contract. Extension types live in `tools::` and `default_logger` in `event::`.
-- `event.rs` defines the generic `Event` record, its built-in name constants, and `default_logger`. Runtime discriminants live with the policy, Werk, loop, or tool behavior they control; event-only payload vocabulary stays as strings. Internal and caller-published events use the same record, and the name is their semantic discriminator.
-- `persistence.rs` holds the `Persist` trait and the shared `write_atomic`, `append_line`, and `output_path` helpers. It is `pub(crate)` and not re-exported.
-- The root `INVENTORY.md` lists every declaration of both crates, one section per source file, public rows before internal ones. It changes in the same commit that adds, renames, removes, or re-types an item.
-- The `agents/`, `prompts/`, `providers/`, `schemas/`, and `tools/` modules each own their domain. `agents/` and `tools/` re-export their headline types, so `use agentwerk::agents::{Agent, Werk}` works without descending into leaf files.
+## Providers
 
-## The `agents/` Module
+**Keep vendor formats at the edge and shared transport in the center.**
 
-**Holds the agent, the Werk, and the multi-agent loop.**
+- `providers/provider.rs` defines `ProviderLike`, `Provider`, and the internal `Protocol` boundary.
+- `anthropic.rs`, `openai.rs`, `mistral.rs`, and `litellm.rs` adapt vendor authentication and payloads.
+- `endpoint.rs` owns HTTP execution; `stream.rs` and `frames.rs` rebuild model responses.
+- `types.rs`, `error.rs`, `model.rs`, and `environment.rs` own shared values, failures, model settings, and environment selection.
 
-- `agent.rs`: `Agent`, its configuration methods, and task-dispatch helpers.
-- `compaction.rs`: the summarizer that compaction runs, and the threshold and chunking arithmetic behind it.
-- `policy.rs`: the public `Policy`, what a run may spend, how it retries, and when it compacts.
-- `knowledge.rs`: `Knowledge`, the cross-task store, an OKF v0.1 bundle in `<dir>/knowledge/`. Pages are curated through the `get_pages()` handle (`save`, `load`, `remove`, `get_all`) plus `clear`; failures are typed as `KnowledgeError`.
-- `stats.rs`: the crate-private `Stats`, the counters a limit check reads and the one reader over `events.jsonl`.
-- `query.rs`: AQL. The tokenizer, the parser, the private `Queryable`, `QueryField`, and `Compiled<F>`, and the two field sets: `TaskField` behind `Query<Task>`, `EventField` behind `Query<Event>`. `Matcher<R>` and `QueryError` live here too.
+## Tools and Prompts
 
-`tasks/` holds the task value types and the orchestrator:
+**Keep each built-in tool beside its model-facing contract.**
 
-- `mod.rs` re-exports them and hosts the free helpers `policy_violated`, `now_millis`, `numeric_id`.
-- `task.rs`: `Task`, `Status`, the `Replies` log helper, and the `tasks/<id>/...` path helpers. `reply.rs`: `Author`, `Reply`, `ReplyContent`, and their conversions to and from `providers::Message` and `ContentBlock`. `error.rs`: `TaskError`.
-- `werk.rs`: constructors, configuration, task creation, agent binding, run lifecycle, results, and queries. `store.rs`: the store mutations (`insert`, `claim`, `set_task_finished`, `edit_replies`, transition recording).
-- `trajectory.rs`: `Trajectory`, a task's replies captured as a training example, its `trajectories/<id>.json` write, and the `.html` rendering written beside it.
+- `tools/tool.rs` owns the public `Tool` builder and internal execution context.
+- A built-in tool keeps its Rust implementation, `<name>.tool.md`, and `<name>.schema.json` together.
+- `tools/command/` and `tools/task/` use submodules because parsing and completion have separate concerns.
+- `prompts/directives.rs` indexes the entries under `prompts/directives/*.md`; `builder.rs`, `section.rs`, and `text.rs` assemble prompt text.
 
-`loop/` holds the multi-agent loop, split by operation:
+## Python Bindings
 
-- `main.rs`: `run_main_loop`, which spawns one tokio task per registered agent, decides when the run is over, joins them, and emits `RunFinished`.
-- `agent.rs`: `Agent::run` and its one explicit task loop. Task-specific tools, prompts, policy, and failure counts remain local to that loop.
-- `compact.rs`, `request.rs`, `tool_call.rs`: private `Agent` methods for compaction, the provider round-trip with retry and backoff, and `call_tools` with output offloading and the tool-failure budget.
+**Mirror Rust concepts without duplicating Rust behavior.**
 
-## The `providers/` Module
+- `crates/agentwerk-py/src/` has one binding module per exposed domain, including `policy.rs` and `directives.rs`.
+- `src/convert.rs` owns Python and JSON conversion helpers; `src/lib.rs` registers the extension surface.
+- `python/agentwerk/__init__.py` re-exports `_agentwerk` and owns the pure-Python `@tool` decorator.
+- `python/agentwerk/__init__.pyi` declares the Python surface and is checked by `tests/test_parity.py`.
 
-**Holds every concrete LLM provider plus the shared request and response types.**
+## Tests and Repository Docs
 
-- `provider.rs` defines the behavior: `ProviderLike`, the `Provider` handle over it, the crate-internal `Protocol` trait, and the generic `respond` every provider answers through.
-- `types.rs` defines every value the two sides exchange, in the order a turn happens: `ModelRequest`, `ReasoningEffort`, `Message`, `AsUserMessage`, `ContentBlock`, `ModelResponse`, `TokenUsage`, `ResponseStatus`, `ToolDeclineKind`, `StreamEvent`.
-- `anthropic.rs`, `openai.rs`, `mistral.rs`, and `litellm.rs` are concrete providers, each a newtype over one `Endpoint` whose `respond` names a `Protocol`. `mistral.rs` and `litellm.rs` name `OpenAiChat` too, so the OpenAI request shape is written once.
-- `endpoint.rs` holds `Endpoint`, the one HTTP call every provider makes. `environment.rs` reads the variables behind `Provider::from_env()` and `Model::from_env()`. `model.rs` holds `Model` and the one table of context window sizes.
-- `error.rs` holds `ProviderError`, `ProviderResult`, `RequestErrorKind`, and the bank of upstream wordings a proxy wraps.
-- `stream.rs` takes an HTTP response and gives back a `ModelResponse`: `read_reply`, the SSE reader, and `ResponseBuilder`, the one place a `StreamEvent` is emitted from. `frames.rs` recovers the calls a model wrote as prose rather than emitting through the tool channel.
+**Put verification next to its layer and keep inventories separate from conventions.**
 
-## The `tools/` Module
-
-**`tool.rs` holds tool construction and execution; every other file is one built-in tool or a helper.**
-
-- `tool.rs` defines the public `Tool` builder and the private execution functions over `Vec<Tool>`.
-- `read_file.rs`, `write_file.rs`, `edit_file.rs`, `glob.rs`, `grep.rs`, and `list_directory.rs` are filesystem tools; `code.rs` backs `grep`'s `syntax: "code"` shape matching, delegating to the `codegrep` engine. `fetch.rs` is the web fetch tool.
-- `command/tool.rs` is the command tool, restricted through `new()` and widened through `allow()`; it runs one program per call and never a shell. `command/parse.rs` splits a line into one command and classifies its arguments, which is how the tool refuses anything that is not one command.
-- `event.rs` owns `EventTool` and the completion engine; `task/finish.rs` wraps its `task_finished` branch, while `task/tool.rs` holds `TaskTool`. `knowledge.rs` is the model-facing wrapper around `Knowledge`. `util.rs` is a shared helper.
-- Each built-in tool pairs with a `<tool>.tool.md` definition (the prose shown to the model) and a `<tool>.schema.json` (the input schema). Both reach the tool through `include_str!` in its `From<XTool> for Tool` conversion, which is also where the name and concurrency are stated.
-
-## The `prompts/` and `schemas/` Modules
-
-**Composable prompt assembly and JSON-Schema validation.**
-
-- `prompts/builder.rs` and `prompts/section.rs` hold `PromptBuilder` and `Section`, which assemble role and knowledge blocks.
-- `prompts/directives.rs` holds `Directive`, the key namespace, the crate-private `DirectiveStore` carrying the function an agent decides its text with, and one `directives!` block declaring every key as a constant and an `ALL` entry. The text lives in `prompts/directives/*.md`, one file per area, each entry under a `## key` heading; a test pairs every key with its heading. It reaches the caller as the root re-export `agentwerk::Directive`.
-- `prompts/text.rs` holds `Text`, the text a role, a description, or a task is set from, reading a file where the caller names a path. It reaches the caller as the root re-export `agentwerk::Text`.
-- `schemas/mod.rs` holds `Schema`, `SchemaParseError`, and `SchemaViolation`.
-
-## Tests
-
-**Integration tests live in their own directory; everything else is inline.**
-
-- `crates/agentwerk/tests/integration/` holds real-provider tests, bundled by `tests/integration.rs`, with shared helpers in `common.rs`.
-- Every module also carries its own `#[cfg(test)] mod tests` for mock-free unit coverage.
+- Keep Rust unit tests inline under `#[cfg(test)]`; keep live-provider tests under `crates/agentwerk/tests/integration/`.
+- Keep Python tests under `crates/agentwerk-py/tests/` and use the `live` marker for provider-dependent cases.
+- Keep use-case-specific tests inside their binary modules so the binary test pass reaches them.
+- Use `INVENTORY.md` for declaration-level API tracking; use `agentdocs/` only for decisions the code does not state.
+- Keep reusable agent skills under `skills/`, hook configuration under `hooks/`, and repository checks under `tools/`.

--- a/agentdocs/project.md
+++ b/agentdocs/project.md
@@ -1,58 +1,46 @@
 # Project
 
-agentwerk is a Rust crate for building LLM agents. An agent reads input, calls an LLM provider, optionally invokes tools, and returns an output.
+agentwerk is a Rust library for composing LLM agents, tools, tasks, and shared execution state.
 
-## Library, Not Framework
+## Library Boundary
 
-**The crate provides building blocks. The caller composes them.**
+**Provide building blocks that a caller composes inside its own application.**
 
-- No runtime to boot, and no traits the caller must implement to get started.
-- No required structure for the consuming application.
-- Every feature is optional.
+- Keep startup, process structure, logging, and UI in the consuming application.
+- Let callers begin with `Agent::from_env()` without implementing framework traits.
+- Add an abstraction only when it removes more caller complexity than it introduces.
 
 ## Minimal Surface
 
-**Each abstraction must remove more complexity than it adds.**
+**Make every public concept earn its maintenance cost.**
 
-- Dependencies are limited to tokio, serde, serde_json, reqwest, and futures-util.
-- No transport abstractions and no plugin registries: providers own a `reqwest::Client` directly.
-- Indirection without a concrete benefit is not added.
+- Prefer extending `Agent`, `Werk`, `Task`, `Tool`, `Event`, or `Knowledge` over adding a parallel concept.
+- Keep features optional unless correctness requires them.
+- Reject registries, adapters, and aliases that only rename existing behavior.
+- Put exhaustive API detail in rustdoc and `README.md`, not in convention files.
 
-## Parallel by Default
+## Parallel Composition
 
-**Many agents share one `Werk` and pick up tasks concurrently.**
+**Use one `Werk` to coordinate agents over shared tasks.**
 
-```rust
-werk.add_agent(Agent::from_env().label("scan"));
-werk.add_task(Task::new("Audit src/db.").label("scan"));
-```
+- Assign tasks through one optional label on `Agent` and `Task`.
+- Claim each task once while allowing agents with the same label to work concurrently.
+- Attach a `Schema` when a task result needs a machine-checked shape.
+- Keep agent configuration local: no global agent or tool registration.
 
-- Each agent runs on its own tokio task; the shared Werk claims a task exactly once.
-- An agent serves one label and a task carries one, so a label only one agent serves pins the task to that agent.
-- Agents are cloned and modified, then bound to a `Werk`. No global registration, no implicit state.
-- A task carries a `Schema`; the loop validates the agent's result against it.
+## Provider Independence
 
-## Provider-Agnostic
+**Keep orchestration independent of the selected LLM provider.**
 
-**The same agent code runs against any supported LLM provider.**
+- Support Anthropic, OpenAI, Mistral, and LiteLLM through `ProviderLike` and `Provider`.
+- Keep tasks, tools, schemas, events, and policies unchanged when provider configuration changes.
+- Isolate vendor request and response formats under `providers/`.
 
-- Anthropic, OpenAI, Mistral, and LiteLLM are supported, and share one retry policy.
-- Switching providers changes only the `.model(...)` call.
-- `Provider::from_env()` and `Model::from_env()` select a provider and model from environment variables.
+## Observable State
 
-## Observe, Do Not Prescribe
+**Expose behavior through tasks, results, events, and optional durable state.**
 
-**The loop emits events. The caller decides what to do with them.**
-
-- No built-in UI, no required logging.
-- The event handler receives `Event { name, data, ... }` at every lifecycle boundary.
-- The handler may log, forward, store, or discard each event.
-
-## Correctness Over Convenience
-
-**Zero warnings, typed errors, no silent fallbacks.**
-
-- The build MUST pass with `RUSTFLAGS="-D warnings"`: any warning fails it.
-- Schema validation retries on mismatch, then fails explicitly.
-- IMPORTANT: no blanket `From<io::Error>` or `From<serde_json::Error>`. Every conversion is an explicit mapping into a typed variant.
-- Misconfigured builders panic at build time.
+- Publish lifecycle and failure information as `Event` records without requiring a logger.
+- Persist sessions under the directory configured by `Werk::set_dir`.
+- Share durable facts through `Knowledge` only when the caller opts in.
+- Report invalid configuration and exhausted retries explicitly; do not silently fall back.

--- a/agentdocs/style.md
+++ b/agentdocs/style.md
@@ -1,503 +1,101 @@
 # Style
 
-Naming, comment, and prose rules, plus README structure. Skim the section matching what is being written.
+Naming, API, comment, binding, and README conventions for this workspace.
 
-## Crate Root
+## Public API
 
-**A type earns a `pub use` at `lib.rs` only when it names a concept in the one-sentence description of the crate, or when root-level signatures hand it to the caller.**
+**Keep the root API small and domain types in their modules.**
 
-`Agent`, `Werk`, `Task`, `Query`, `Policy`, `PolicyViolation`, `Knowledge`, `Directive`, `Text`, `Trajectory`, `Reply`, `Event`, `Status`, `FinishReason`, `Schema`
+- Re-export only headline concepts and types required by root-level signatures from `lib.rs`.
+- Keep concrete providers under `providers::`, tools under `tools::`, and domain errors beside their domain.
+- Keep implementation types `pub(crate)` unless callers implementing a public trait must name them.
+- Follow [workflow.md](workflow.md) for inventory and verification steps after API changes.
 
-- Discriminants callers match on earn a root slot: `Status`, `FinishReason`, `PolicyViolation`.
-- Builder parameters, selectors, and run outputs earn one when callers name them: `Schema`, `Query`, `Policy`, `Directive`, `Text`, `Reply`, `Trajectory`.
-- Errors and conversion traits do not. They live in their domain module.
-- Free functions at the root are forbidden: convert to an associated function or move to the domain module.
-- Name collisions at the root are forbidden.
+## Type and Variant Names
 
-## Where Non-Root Types Live
+**Choose names that describe the domain without redundant prefixes.**
 
-**Types live next to the abstraction, owner, or protocol they belong to.**
+- Name concrete LLM providers for the vendor: `Anthropic`, `OpenAi`, `Mistral`, `LiteLlm`.
+- Give the public handle the bare noun and its extension trait the `Like` suffix: `Provider` and `ProviderLike`.
+- Name failure variants as concrete states: `AuthenticationFailed`, `ContextWindowExceeded`, `PolicyViolated`.
+- Use a tuple variant for one self-explanatory payload and a struct variant when field names carry meaning.
+- When a fieldless discriminant needs a stable external spelling, expose `get_name()` and reuse it for `Display` and serde.
 
-- Concrete implementations live with their abstraction: `Anthropic` under `providers::`, `CommandTool` under `tools::`.
-- Companion types and handles live with their owner: `Task`, `Status`, `TaskError`, `Reply`, and `ReplyContent` under `agents::tasks`.
-- Domain errors live with their domain: `ProviderError` under `providers::`, `TaskError` under `agents::tasks`.
-- Request and response types live with the protocol: `ModelRequest`, `Message`, `TokenUsage` under `providers::`.
-- Free functions live in their module, never at the crate root: the env readers in `providers::environment`, helpers in `tools::util`.
+## Fields
 
-## Name Disambiguation
+**Use one vocabulary for common payloads and units.**
 
-**Names are disambiguated through content, not through redundant prefixes.**
+- Name human-readable failure text `message`, wrapped errors `source`, and stable categories `kind`.
+- Use `Duration` in public Rust APIs; use a float named `seconds` in Python bindings.
+- Suffix directory paths with `_dir`, file paths with `_file`, and ambiguous paths with `_path`.
+- Name scalar counts with a plural noun such as `turns` or `input_tokens`; reserve `_counts` for grouped maps.
+- Return `Option` when an empty population has no value, but return zero for an empty sum.
 
-- Specific compound names stand alone: `Werk`, `PolicyViolation`.
-- A concrete LLM provider is named for its vendor alone. Acronyms follow Rust API guidelines, so `OpenAi`, not `OpenAI`.
-- Two structs may not share a bare name within one module; both stay qualified.
-- When a trait and the concrete type callers hold want the same name, the bare noun goes to the type and the trait takes a `Like` suffix: `Provider` / `ProviderLike`.
+## Methods
 
-## Failure Variants
+**Let the receiver and operation determine the method name.**
 
-**Failure variants use passive-voice past-participle: `<Subject><Verb-ed>`.**
+- Use bare nouns for builders: `model`, `tool`, `label`, `concurrent`; do not add `with_`.
+- Use `get_` for public readers, `set_` for mutation, and `is_` or `has_` for boolean questions.
+- Use `new` for the primary constructor and a semantic name such as `load`, `from_env`, `success`, or `error` for another path.
+- Use `save` and `load` for whole values, and `append` for append-only logs.
+- Keep free functions for module entry points, foreign-type construction, shared algorithms, or ambient state; otherwise use a method.
 
-```rust
-RequestFailed, TodoItemNotFound, ContextWindowExceeded, PolicyViolated   // accepted
-InvalidRequest, UnexpectedStatus, MissingKey, RequestError               // rejected
-```
+## Werk Operations
 
-- Rejected: adjective-first forms such as `InvalidX`, `UnexpectedX`, or `MissingX`.
-- Rejected: noun-suffix forms such as `XError`; the `Error` suffix is reserved for the top-level `Error` and its domain sub-enums.
-- State-transition events use the same form: `AgentStarted`, `RequestRetried`, `ContextCompacted`.
-- Whether a failure is terminal is documented on the variant, not encoded in the name.
+**Name orchestration methods by action and selection scope.**
 
-## Variant Shape
+- Use `finish_task(matches)`, `finish_tasks(matches)`, and `finish_all_tasks()` for waiting and results.
+- Use `cancel_tasks(matches)` and `cancel_all_tasks()` for cancellation; do not add label-specific variants.
+- Use `find_*` for AQL or closure selection and `get_*` for direct access such as `get_task(id)`.
+- Name observers `on_<trigger>` and async twins `on_<trigger>_async`; name immediate mutation `edit_<noun>`.
+- Publish built-in and application events only through `Werk::emit_event`.
 
-**Tuple for one payload. Struct for multiple fields or a meaningful field name.**
+## Rust Documentation
 
-- Tuple form: `Provider(ProviderError)`, `TodoItemNotFound(String)`, `IoFailed(io::Error)`.
-- Struct form: `RequestRetried { attempt, max_attempts }`, and also when a single field name carries meaning the type alone does not.
-- Two-arm result enums use one word per variant: `Success` and `Error`, with no `is_*` predicates.
+**Document public purpose and non-obvious contracts, not implementation narration.**
 
-## Discriminant Members
+- Begin each module with `//!` stating what it contributes.
+- Begin `///` comments with a noun phrase for a type or an imperative verb for a method.
+- Keep rustdoc examples small and runnable; let strict rustdoc checks catch broken links and doctest drift.
+- Describe caller-visible behavior in public docs; keep locks, `Arc`, private helpers, and file algorithms in `architecture.md` when they form an invariant.
+- Keep a type's member documentation consistently complete; do not document only arbitrary members.
 
-**A fieldless discriminant exposes `name()`, and `Display` prints what `name()` returns.**
+## Line Comments
 
-```rust
-event.get_data()["kind"]                 // "execution_failed"
-```
+**Keep comments only when the code cannot state the reason.**
 
-- `name()` returns the stable snake_case spelling, which is also what serde reads and writes.
-- No `as_str`, no `label`, and no second spelling of the same string.
-- Built-in event names are associated constants on `Event`, with the same spelling in Rust and Python.
-
-## Payload Fields
-
-**One vocabulary is used across every error type.**
-
-- Human-readable strings MUST be named `message: String`, never `error`.
-- Wrapped underlying errors MUST be named `source`, as in `FooFailed { source: io::Error }`.
-- Typed metadata uses descriptive names: `status`, `retryable`, `retry_delay`, `tool_name`, `retries`, `after_ms`, `action`, `slug`.
-- A stable machine-readable category is `kind`; a human-readable explanation is `message`.
-- An initiating condition is `trigger`, a successful termination value is `outcome`, and a breached policy is `policy`.
-- IMPORTANT: do not overload one payload key across these meanings; generic event readers depend on the distinction.
-
-## RAII Guard Fields
-
-**Fields held only for their `Drop` behavior use a plain name and `#[allow(dead_code)]`.**
-
-- Name the field for its purpose: `guard`, `lock`, `permit`. The `_guard` form is not used.
-- `rustc`'s `dead_code` lint flags such fields because neither `Clone` nor drop glue count as reads.
-- `#[expect(dead_code)]` is preferred on Rust 1.81+: it self-removes if the field later does get read.
-
-## Time-Typed Fields
-
-**Public API fields MUST use `std::time::Duration`. The type is the unit.**
-
-- No `_ms`, `_MS`, or `_seconds` suffix on public Rust API names; the Python binding takes a float `seconds` instead.
-- Internal helpers and on-the-wire JSON may use raw integers where the protocol requires it: `timeout_ms` is acceptable inside a tool input schema.
-
-## Path Identifiers
-
-**A directory path uses `_dir`. A file path uses `_file`. The bare suffix `_path` is used only when the value can be either.**
-
-- Directories: `results_dir`, `knowledge_dir`, `task_dir`, `working_dir`. Matches `std::fs::read_dir` and `std::env::current_dir`.
-- Files: `page_file`. The value is always a concrete file on disk.
-- `_path` is for genuinely ambiguous cases: input that could name either, or a value passed through as opaque.
-- IMPORTANT: `folder` is never used; it has no std analog. Doc comments and environment labels may still say "working directory" in English prose.
-
-## Count Identifiers
-
-**A field or method that returns a count uses a bare plural noun. No `_count` suffix.**
-
-`requests`, `tool_calls`, `turns`, `input_tokens`, `output_tokens`
-
-- Event payloads follow suit: `usage` on `request_finished` carries token counts, not a `token_count`. Accessor methods mirror the field form.
-- The `_count` suffix is reserved for the rare case where the plural would clash with a sibling collection field on the same type.
-- The ban is on scalars: a map keyed by subject is `<subject>_counts()` for a bare count and `<subject>_stats()` for a struct.
-- Bare `<subject>s()` stays reserved for a collection of the subject itself, which is why `find_events(condition)` hands back the events themselves.
-
-## Optional Returns
-
-**A value undefined over an empty population returns `Option`. A sum returns its zero.**
-
-- `Option`: an average, a rate, and `get_duration()`, which has no answer until execution starts.
-- Not `Option`: `get_input_tokens()`, `event_count(event)`. Zero is the honest answer for a sum over nothing.
-- A sum is named `total`: the bare noun reads as one subject's value, not the population's. When a sum and its mean travel together they are two fields of one struct, not accessors prefixed `total_` and `avg_`.
-
-## Persistence Verbs
-
-**Two traits cover every read and write in the crate. The trait dictates the verb; the implementer's type name binds the file location.**
-
-- `Persist` (in `persistence`): `save(&self, dir)` and `load(dir, &Self::Key)`. Service bootstrap (`Werk::load`, `Knowledge::load`) uses the same `load` verb by convention.
-- `append(dir, ..)` is the inherent verb on a type that owns an append-only log: `Stats` and `Replies`. Each encodes its own filename, so the wrong file cannot be reached through the wrong type.
-- No `open` for bootstrap, no `write_X_to_dir`, no `to_json` or `from_json`, and no `checkpoint`, `snapshot`, `persist`, or `counter` in names.
-- Function names do not embed the type names of their arguments: `Stats::append(dir, &event)`, not `append_event`.
-
-## Builders
-
-**Builder methods are bare nouns. No `with_` prefix.**
-
-`.model()`, `.tool()`, `.label()`, `.concurrent()`
-
-- The `with_` prefix is reserved for a bare name that would be ambiguous even with an inherent and trait split; no current builder needs it.
-- A value the caller owns before execution consumes itself: `Agent` and `Tool` take `mut self` and return `Self`. Both configure themselves rather than through a second type; missing agent configuration is caught when it joins a Werk, and missing tool configuration when it is registered.
-- A type handed out as `Arc` configures through `&self` and returns `&Self`: `Werk` and `Knowledge`. A third shape, `self: Arc<Self> -> Arc<Self>`, is not used.
-
-## Constructors
-
-**`new()` for the primary path. Named constructors carry semantics.**
-
-- Named constructors: `load()`, `success()`, `error()`, `from_id()`, `from_env()`.
-
-## Getters and Setters
-
-**Every public reader uses `get_`; mutable accessors use `set_`; builders remain bare nouns.**
-
-- Example: `set_extension()`, `get_extension()`. Builder methods remain unprefixed.
-- A public method returning `bool` is `is_<state>` or `has_<thing>`. A bare past participle such as `label_cancelled` reads as a field, not a question.
-- `get_<name>` is the only reader spelling: `Werk::get_dir`, `Model::get_context_window`, `Agent::get_provider`, `Tool::get_name`, and `Agent::get_id`. A lookup by ID keeps `get_` for the same rule, which is why `get_task(id)` stands apart from `find_task(matches)`.
-
-## Lifecycle
-
-**Werk action names state their target: `finish_task(matches)`, `finish_tasks(matches)`, `finish_all_tasks()`, `cancel_tasks(matches)`, and `cancel_all_tasks()`. A filter is a `Matcher<Task>`, so the same call names one task or one pool.**
-
-```rust
-werk.start();
-werk.finish_tasks("label = scan").await;                   // one pool
-werk.finish_all_tasks().await;                             // the whole run
-werk.finish_task("ORDER BY created DESC").await;           // one result
-werk.cancel_tasks("label = scan");                        // one pool
-werk.cancel_all_tasks();                                   // the whole run
-```
-
-- A verb takes a filter when it can mean part of the Werk, and none when it cannot: `run` starts everything or nothing.
-- IMPORTANT: the filter says WHICH tasks, never WHAT to wait for. `finish_tasks("status = finished")` returns at once because the filter selects tasks and "no work left" is the fixed wait condition.
-- The whole-run case has exactly one spelling: `finish_all_tasks()` and `cancel_all_tasks()`.
-- `finish_task(matches)` follows the same wait and query order as `finish_tasks(matches)`, then returns the first available result.
-- Do not grow back label-, status-, or predicate-specific Werk methods; fixed selections are AQL.
-
-## Hooks
-
-**A hook's name says when it runs. Every hook observes: `on_<trigger>`, and `on_<trigger>_async` for the same trigger in a handler `finish` awaits.**
-
-```rust
-on_event(handler)                    // observe
-on_result_async(handler)             // observe, in a handler `finish` awaits
-edit_replies(id, editor)             // act once, now
-```
-
-- `on_<trigger>(handler)` observes: the handler sees every `<trigger>` and returns nothing.
-- `on_<trigger>_async(handler)` is the same trigger in a handler whichever `finish` is waiting awaits. Every observer has one, and only observers do.
-- A bare `<action>(..)` acts once, now: `cancel`, `edit_replies`.
-- IMPORTANT: the trigger fixes the handler's parameters. `_on_event` hands over `&Event`, `_on_result` a `&Task` and its validated `&Value`, `_on_failure` the `&Event` and the `&Task` it happened in. Observing returns `()`.
-- IMPORTANT: an observer takes the Werk first, `&Arc<Werk>` before the trigger's own parameters, owned in the `_async` twin. That is what a hook acts through, and why neither a `create_task_on_*` nor an `edit_replies_on_*` family exists: `werk.add_task(..)` inside `on_result`, and `werk.edit_replies(&event.task_id, ..)` inside `on_event`, are the whole of them.
-- A hook reacts to something agentwerk produces. Anything the caller already holds needs no hook: to stop a pool on a verdict, `finish` for it and `cancel`.
-- `on_task` sits outside the trigger grid, keying on a task rather than naming a trigger.
-- No hook registers something agentwerk calls in place of its own work. Compaction summarizes and says so through the four `Compaction*` events, and what agentwerk writes to correct the model is set once by `Agent::directives`, which takes one function over every directive.
-
-## Event Publication
-
-**Publishing is always `werk.emit_event(event)`, from both host code and crate internals.**
-
-- Keep `event` in the verb. Bare `emit` is ambiguous beside provider streams and is not an event-publication API.
-- Construct built-in events with their schema-aware `Event::<name>(...)` constructor. Construct application events with `Event::new(name)`, then add `.data(value)`. Add `.task_id(id)` or `.agent_id(id)` when context applies. Do not use a struct literal: the Werk owns the timestamp and derived task label.
-- Order Event members by relevance: `name`, `data`, `task_id`, `agent_id`, `label`, `created_at`; builders follow the constructor and readers follow in that same order.
-- Contextual helpers, when they remove repeated agent or task plumbing, are also named `emit_event` and delegate immediately to `Werk::emit_event`.
-- Do not add parallel names such as `emit`, `emit_custom`, or `publish_event`; every built-in and caller-defined event takes the same pipeline.
-- `Event.name` is the sole semantic discriminator. Named constructors produce the same generic record as `Event::new(name).data(value)`; branch defensively on its name and JSON data, and do not introduce a parallel typed event model or provenance marker.
-
-## Editors
-
-**An editor is `edit_<noun>`. Its last parameter is the `&mut` value it rewrites; anything before it is read-only context.**
-
-- `edit_replies(id, FnOnce(&mut Vec<Reply>))`: the ID is the read-only context, the replies are the value.
-- The value arrives holding what agentwerk would otherwise have used, so an editor that writes nothing keeps the default. No editor returns `Option<T>`: there is nothing left to signal.
-- IMPORTANT: an editor acts once, on the value as it stands. Nothing is registered, so a second caller reads what the first left rather than replacing it.
+- Explain ordering, crash safety, protocol quirks, workarounds, or non-obvious constraints.
+- Use a plain section label only to divide a long function.
+- Delete comments that restate the next line, narrate setup, or preserve task history.
+- Do not leave `TODO`, `FIXME`, commented-out code, or decorative banners.
 
 ## Python Bindings
 
-**Every public Rust item has a Python counterpart of the same name. The transforms below are permitted; nothing else.**
+**Mirror every supported Rust item with the same public name unless Python requires a documented transform.**
 
-- Rust configuration types collapse into the class they configure. Python `Tool` is the opaque handle for a complete built-in or decorated tool.
-- `Duration` becomes a float named `seconds`, with the unit repeated in the docstring: `Policy::request_retry_delay` binds as a float in seconds. Every other parameter keeps its Rust name.
-- A fieldless enum becomes its snake_case `Display` string. That `Display` impl is the single source, so the binding never formats a variant with `{:?}`.
-- `Status`, `Author`, `ReasoningEffort`, `PolicyViolation`, `ResponseStatus`, `RequestErrorKind`, and `ToolDeclineKind` expose that source through `get_name()`; serde and Python output use the same spelling.
-- The task tool is `TaskTool` and model name `task`; the fetch tool is `FetchTool` and model name `fetch`. Singular names extend to modules, schemas, prompts, and argument types.
-- Public API requires `///` documentation and the crate keeps `missing_docs` enabled. Crate-private implementation detail stays private instead of being documented into an accidental contract.
-- An enum whose variants carry fields becomes a class with a `kind` string, a `data` dict, and one static constructor per variant. `ReplyContent` does this; `Event` is instead a generic record whose Python API mirrors Rust.
-- A builder method whose name collides with a reader on the same Python class becomes a constructor keyword argument, because a Python class cannot carry both. `Task` needs this for `label`, `schema`, and `parent`.
-- A `&mut` editor becomes a callable that returns the replacement, or `None` to keep the current value, since Python cannot take a Rust `&mut`.
-- A conversion type a setter takes collapses into the Python types it converts from: `Text` is a `str` for the text itself and an `os.PathLike` for the file holding it.
-- Readers keep their Rust `get_*` names in Python: `Agent::get_id()` is `agent.get_id()` and `Task::get_id()` is `task.get_id()`.
-- IMPORTANT: no `with_` prefix in either language, and no transform beyond this list.
+- Keep binding modules aligned with their Rust domains and centralize conversion in `convert.rs`.
+- Collapse Rust configuration types into the Python class they configure when Python cannot expose both builder and reader forms.
+- Represent fieldless Rust enums by their snake_case name and data-carrying enums by a `kind` plus `data` object.
+- Convert `&mut` editors into callables returning a replacement or `None` to keep the current value.
+- Update `_agentwerk`, `__init__.py`, `__init__.pyi`, and parity tests together when the surface changes.
 
-## Free Functions
+## Prose
 
-**A free function is used only for one of five reasons. Otherwise the function lives on a type.**
+**Write direct, concrete sentences at the reader's abstraction level.**
 
-Permitted:
+- Put the action or constraint first and keep one idea per sentence.
+- Use second person for caller guidance and imperative voice for agent-facing text.
+- Avoid marketing adjectives, borrowed metaphors, hedging, and unexplained internal jargon.
+- Use a colon or a new sentence instead of an em dash.
+- Preserve negations, exceptions, units, identifiers, and ordering constraints when shortening prose.
 
-- **Ambient state** has no receiver: timestamp helpers and similar utilities in `tools::util`.
-- **Foreign-type constructors** cannot use an inherent `impl`: `build_client()` returns a `reqwest::Client`.
-- **Module entry points** drive multiple types: `run_main_loop()` in `agents::r#loop`.
-- **Higher-order utilities** take a function and wrap it: `with_file_lock(path, || ...)`.
-- **Shared algorithm helpers** are called by two or more sibling types in the same module.
+## README
 
-Forbidden:
+**Keep both READMEs example-first and synchronized by concept.**
 
-- A free function that delegates to a single method on one type. Inline it as a method.
-- A free constructor for a local type that already has an inherent `impl`.
-- A free helper called from exactly one private method. Make it a private method or a nested `fn`.
-- An associated function that takes no `self` and does not return `Self` or `Result<Self>`. Move it to the module.
-
-Naming is `snake_case`. Tool structs keep the `{Name}Tool` suffix. The name the model calls is a separate namespace and takes no suffix: `read_file`, `grep`, `task`. It is written once, in the tool's `From<XTool> for Tool` conversion, and never at a call site: a host registers `ReadFileTool`, not the string.
-
-## Doc Comments (`///`)
-
-**State the purpose in one sentence, with the same verb the item's README row uses.**
-
-```rust
-/// Set the LLM provider.            // builder: imperative configuration verb
-/// Get the elapsed duration.        // accessor: Get
-/// Begin processing tasks.        // action: imperative effect
-/// A task finished successfully.  // event: past-tense state sentence
-```
-
-- Noun phrase for types and fields; verb for functions. No "This function…" or "Returns…".
-- The full set of verbs is under [README Table Shape](#readme-table-shape). A method and its README row say the same thing in the same words.
-- Additional paragraphs are added only for a constraint, invariant, or non-obvious semantic the caller can act on.
-- Trivial getters, `Default::default`, `From` impls, and self-explanatory variants are left undocumented.
-- Within one type, coverage is all-or-none: every member has a real doc comment, or none does.
-
-## Module Docs (`//!`)
-
-**Every file begins with a `//!` that states what the file contributes to the crate.**
-
-- One sentence; two only when the second adds context the first cannot carry.
-- State the problem the file solves, not the types it defines. Do not list the contents of the file.
-- The `//!` stays even when the filename is already descriptive.
-
-## Hiding Internal Types
-
-**A type a public trait or extension point hands to callers is documented; a genuinely internal type is `pub(crate)`.**
-
-- The request and response types under `providers::` are documented: implementing `ProviderLike` is supported, and implementors name them.
-- Tool execution state is the other case: callers reach it through `Agent::tool(..)` and never name the private context or collection.
-- `#[doc(hidden)]` is reserved for items a macro or trait forces `pub` that are useless even to implementors; there are currently none.
-
-## Line Comments (`//`)
-
-**Four reasons are allowed. Everything else is deleted.**
-
-Allowed:
-
-- Order-dependency or crash-safety, such as `Write mark BEFORE task file: crash-safe.`
-- API quirk or workaround, such as `serde_json::Map is sorted alphabetically, so we format manually.`
-- Non-obvious constraint, such as `Newest first so 'gpt-4' does not shadow 'gpt-4.1'.`
-- Plain section label in a long function, on its own line above the block it introduces.
-
-Not allowed:
-
-- Restating what the code does on the same line.
-- Task, PR, issue, or changelog references, and commented-out code.
-- Stub or aspirational markers; use `unimplemented!(...)` or return `Ok(())`.
-- IMPORTANT: no `TODO`, `FIXME`, or `NOTE`. Fix it or file an issue.
-- Decorative banners of any kind: `// ── Title`, `// ==== Title ====`, `// ----- Title -----`.
-
-## Tests
-
-**Test names carry intent. Setup is not narrated.**
-
-- A comment is justified only to pin an architectural invariant the test guards.
-- A module-level `//!` describing the test file's scope is acceptable.
-
-## Comment Examples
-
-**The failure mode in each case is restating what the reader can already see.**
-
-```rust
-// GOOD: states what the file contributes
-//! Runs many agents in parallel, each in its own tokio task, over one shared task store.
-// BAD: lists contents
-//! Agent loop.
-//! - `run_main_loop`: entry point.
-
-// GOOD: purpose and invariant
-/// A task. Caller-settable fields: `task`, `label`, `schema`, `parent`. System-managed fields are set at insertion time.
-// BAD: restates the name
-/// The task field.
-
-// GOOD: flags an order constraint
-// Write mark BEFORE task file: crash-safe.
-// BAD: restates the code, then decorates it
-// Increment the counter.
-// ── Parse the reply, append the assistant message
-```
-
-## Sentence Shape
-
-**One idea per sentence. A section lead is one sentence, and so is a table cell.**
-
-```markdown
-GOOD: A `Schema` constrains the result an agent produces for a task.
-BAD:  A `Schema` is a JSON Schema document that gets attached to a task and,
-      when the result comes back, is used to validate it; failures retry.
-```
-
-- Budgets: 10 to 25 words for a lead, 4 to 15 for a table cell. The cell figure is a hard cap.
-- Present tense, declarative, no hedging. No semicolons stapling two facts together.
-- A second short sentence is allowed only when it carries information the first cannot.
-- A description that needs more than two sentences moves to prose under the table.
-
-## Voice and Address
-
-**Second person for the reader. Imperative for the agent. No marketing language.**
-
-- "you" and "your" address the reader; "we" is never used.
-- In agent-facing text the agent is the actor and the tool exposes the action: `Fetch a URL and read its body.`
-- "Give the agent access to filesystem tools", not "empower the application".
-- Avoid adjectives that carry no information ("powerful", "seamless", "sensible").
-
-## Component Descriptions
-
-**Introduce a type as `` `Type` `` plus one clause saying what it is for.**
-
-```markdown
-An `Agent` is the core entity of agentwerk.
-A `Schema` constrains the result an agent produces for a task.
-`Knowledge` allows agents to share insights or learnings.
-```
-
-- A second sentence is added only for a constraint: "A violation triggers a retry until `max_schema_retries` is exhausted."
-- The type's `///` and its README lead use the same shape, so the two read alike.
-- Name the type's job, not its implementation: not "the shared Werk holding an `Arc<Mutex<..>>`", but "the core data structure of agentwerk for coordinating complex interactions".
-
-## Abstraction Level
-
-**In caller-facing text, describe what the caller gets, not how it works inside.**
-
-- The reader may be new to agent concepts: write for them.
-- Internal type names, private field names, and enum variant names do not belong in the README. The reference lives in the API docs.
-- Internal mechanics do not appear in caller-facing rustdoc either: no `Weak<Self>` or `Arc<Self>`, no "stamps", no `record_*`, no lock ordering, no drain counts. They live in `agentdocs/architecture.md`.
-- Accepted: `// run the task once and return the result`, "Transient provider error triggered a retry". Rejected: `// drive the loop`, `// one-shot`, "(carries typed `kind: RequestErrorKind`)".
-- Jargon and internal terms are cut even when they are shorter.
-
-## Punctuation
-
-**No em dashes anywhere. A colon or a second sentence replaces one.**
-
-- Applies to the README, rustdoc, agentdocs, and agent-facing prompt files alike.
-- Numbers are spelled out with a space: "33 000 tokens", never "33K".
-- No emoji, and no decorative banners.
-- Prose is not hard-wrapped in Markdown files. Wrapping reflows a whole paragraph when one word changes.
-
-## Terminology
-
-**Word-level rules for caller-facing prose: rustdoc, README, and agentdocs (except where called out).**
-
-Replaced:
-
-- "worker" as a role noun becomes "agent"; "routed" and "routing" become "assigned" and "assignment".
-- "transcript" becomes "replies" or "messages". The field is `replies`, so name it.
-- "caps" as a noun becomes "limits"; imperative cells say "Limit X", not "Cap X".
-- "counters" becomes "statistics"; "wall-clock" becomes "elapsed duration", "max time", or "time cap".
-- "settle" and "settled" become "finish", "mark done", or "done"; "upsert" becomes "creates or replaces".
-- "smoke test" becomes "high-signal set", "starting point", or "core checks"; "drift" becomes the specific verb, "safety margin", or "stays anchored".
-- "park" and other vehicle metaphors become what actually happens: "stays `in_progress`", "is not re-claimed".
-- "stamp", "trip", "walk off", and "mint" are internal metaphors for writing a timestamp, breaching a limit, releasing a task, and creating one. Use the plain verb.
-- Rust async primitive nouns ("future", "closure", "predicate", "callback") become "another task that finishes", "a condition you supply", "your function". The Rust identifiers stay as identifiers.
-- Abstract pronouns and fractions ("one half", "the other", "either side") leave the reader guessing. Name the subject: not "detect one half from the environment and override the other", but "read only the provider from the environment, or only the model".
-
-Banned:
-
-- "user" is not a domain concept. It names one thing only, the `Message::User` role in the exchange with the model.
-- "finisher", in agent-facing prompts (role files, `*.tool.md`, directives) as much as in caller-facing prose. Name the tool, `finish` (rustdoc names the type `FinishTool`).
-- "snapshot": say what the value is. "live" as an adjective for statistics: say *when* the value is available in plain English.
-- "wire-protocol" and "wire-shaped": describe the types by what they carry.
-- "ships", "ships with", "sensible defaults", "tuning", "various options": state one concrete fact, or list the identifiers and point at docs.rs. Do not dump every default value into prose either.
-- "stream" and "streaming": say "print as it arrives", "forward", or "show live", or name the SSE layer when describing the implementation.
-- "drives the provider/tool loop" is slang. An agent calls the LLM provider and runs the tools it requests.
-- "the loop" and "the agent loop": say "agentwerk", "the agent", or name the subject. The phrase is fine in `agentdocs/architecture.md` and `agentdocs/layout.md`.
-- "header" and "task header" for the on-disk file holding a `Task` without its `replies`: say "the task" or "the task without its messages". The internal helper `task_header_path` and `architecture.md` may keep the term.
-
-Also:
-
-- Bare "provider" is spelled "LLM provider". Identifier names stay unqualified.
-- "execution" is the word for a run, in prose and in identifiers: `Werk::get_duration()`. `run` survives only in built-in names such as `Event::RUN_STARTED` and `Event::RUN_FINISHED`.
-- The Knowledge store is described as durable memory the agent shares across tasks and other agents; the sharing is the headline, not a footnote.
-
-## README Structure
-
-**Terse, example-driven, scannable.**
-
-- Fixed section order: Why use agentwerk?, Installation, Quick Start, Agent Swarms, Demo, the API sections, Use Cases, Security, Development.
-- The opening section is one bullet per reason to reach for the crate: `**Reason:** one short sentence`. A reason with nothing behind it is marketing and is cut. It runs before the reader has met a single agentwerk concept, so it carries no identifier, no type or function name, and none of the domain vocabulary the API sections introduce. "Task" and "agent" are the only nouns assumed.
-- API sections run in the order a new reader needs them: Agents, Tasks, Tools, Events, Knowledge. Sessions is a subsection of Tasks.
-- Prompting has no section of its own. `role`, `task`, and the template bindings configure an agent, so they live in Agents next to `name` and `tool`.
-- Every section leads with one minimal example, then at most three sentences. Facts live in one place; other sections cross-link rather than repeat.
-
-## README Folds
-
-**Above the fold is what a reader needs. The exhaustive reference goes inside a `<details>` block at the end of the section.**
-
-- Nothing is deleted, only folded. A method that exists is documented somewhere, or the fold is not doing its job.
-- Folds are the last thing in a section. Every `<summary>` reads `All <what the fold holds>`: `All event names`, `All hooks`, `All session files`. One section holds one fold; a second catalogue earns its own `h3` with its own lead example.
-- IMPORTANT: a blank line after `</summary>` and before `</details>`. `details` opens a raw-HTML block, so without the blank line every table inside renders as literal pipe characters on GitHub, crates.io, and PyPI alike.
-- Snippet budgets: eight lines for a section lead, five for a subsection lead. Quick Start gets sixteen.
-- Agent Swarms is the one exception and runs long, because it is the only place a whole system is shown at once: a pool working in parallel, a second pool the first hands tasks to, and one knowledge store between them.
-
-## README Mechanics
-
-**Formatting choices that are not about either language.**
-
-- One `h1` per file, the title. Every section is `h2`, every subsection `h3`. No wrapper heading above a group of sections.
-- `h2` is Title Case, `h3` is Sentence case.
-- A method placeholder is spelled as what the caller passes, never a single letter: `add_reply(id, content)`, `cancel_tasks(matches)`. In a bullet list the bare method name carries no parentheses at all.
-- Centered blocks use `<div align="center">`. `align` is not allowed on `<p>` by the crates.io sanitizer, so `<p align="center">` renders left-aligned there.
-
-## README Tables
-
-**No table above a fold. Every enumeration inside a fold is a table.**
-
-- Above the fold there is prose and one example, so a table there is a sign the section is doing reference work it should have folded.
-- Inside a fold the content is the reference, and a two-column grid is what a reader scans. Bullets there only hide the second column.
-- A catalogue with categories takes a third column on the left holding the bold group label: the built-in tools, the event names, the execution methods, and the hooks.
-- Prose still belongs in a fold when it is a caveat rather than an entry, as does a snippet showing how one of the entries is called.
-
-## README Table Shape
-
-**Each table picks one cell shape and holds it. Mixing shapes inside one table is a defect.**
-
-- Builder rows lead with an imperative configuration verb: `Set the LLM provider.`
-- Action rows lead with the imperative effect: `Begin processing tasks.`
-- Accessor rows lead with `Get`: `Get every finished task's result.`
-- Tool rows lead with the imperative action the agent takes: `Fetch a URL and read its body.`
-- Event rows are past-tense state sentences: `A task finished successfully.`
-- Every row is a description, not a constraint fragment. A cell that does not lead with a verb is a defect.
-- A tool does not act; the agent does. The table intro carries that framing once so individual rows stay terse.
-- The prose verb "Return" stays for instructions to the caller, as in "Return a `tool_call_failed` event for a failure the model should work around".
-
-## README Table Order
-
-**Rows are grouped by subject, and one axis order is repeated in every group.**
-
-- Groups do not interleave. The result rows run before the task rows in Results; the observers run before the cancels in Hooks.
-- One axis order is chosen and held across every group. Hooks is the model: `event`, `result`, `failure`.
-- Werk tables follow caller workflow: configure, submit/interact, observe, run, cancel, inspect tasks, inspect results/events, then inspect run metadata. Setters stay beside getters, synchronous hooks beside async twins, and singular selectors before plural selectors.
-- One table holds one receiver. A method on another type goes in the fold's trailing prose.
-- The Execution fold holds everything that acts once over a run. The hooks fold holds only what registers a handler the Werk calls back into on every matching event.
-
-## README Examples
-
-**Show the smallest snippet that demonstrates the feature.**
-
-- Example models are `claude-haiku-4-5-20251001` or `claude-sonnet-4-20250514`.
-- Update triggers: a new builder method, a new tool, a new event name, a new environment variable, or a changed default.
-- A chain of more than two calls breaks one call per line, even where it would fit the formatter's width.
-- A code change edits only the doc sentences it made wrong. Surrounding prose is not rewritten unprompted.
-
-## Rust and Python READMEs
-
-**The Python README mirrors the Rust one section for section, carrying the same examples.**
-
-- The heading lists of the two files match. A section in one is a section in the other.
-- A snippet is a translation of its twin: same variable names, same string literals, same order of operations.
-- A difference that is real belongs in the root `INVENTORY.md`, and the README shows it in the same place in both files.
-- Only the Installation cross-links and the Development section differ in substance.
+- Lead each API section with the smallest useful example and move exhaustive lists into one trailing `<details>` block.
+- Use tables for catalogues inside folds and short prose above them.
+- Describe public behavior, not private types or control flow.
+- Mirror root examples in `crates/agentwerk-py/README.md` with the same names, values, and operation order.
+- Update examples, methods, events, tools, and environment variables in the same change as the public API.

--- a/agentdocs/testing.md
+++ b/agentdocs/testing.md
@@ -1,69 +1,49 @@
 # Testing
 
-How tests are organized and written. Commands used to run them live in [workflow.md](workflow.md).
+How Rust, Python, documentation, and live-provider tests demonstrate behavior.
 
-## Layers
+## Offline Layers
 
-**Two layers: integration and inline.**
+**Put each deterministic test at the narrowest public boundary that proves the contract.**
 
-- `tests/integration/` uses a real LLM provider; bundled by `tests/integration.rs`, with shared helpers in `tests/integration/common.rs`.
-- Inline `#[cfg(test)] mod tests` lives next to the code it covers and runs without a network.
+- Keep Rust unit tests in inline `#[cfg(test)] mod tests` blocks beside the implementation.
+- Keep rustdoc examples runnable as part of the offline suite.
+- Keep binary-specific tests inside `crates/use-cases/src/` so the `--bins` pass reaches them.
+- Keep offline Python behavior under `crates/agentwerk-py/tests/` without the `live` marker.
 
-## Purpose
+## Live Providers
 
-**One test, one observable behavior.**
+**Separate provider-dependent behavior from the offline suite.**
 
-- A test exists because a single contract would otherwise go undemonstrated.
-- A failure points to one cause: no grab-bag assertions across unrelated concerns.
-- A sibling covering the same branch with trivial input changes is merged or removed.
-- Behavior is tested at the layer where it lives: unit, integration, or inline.
+- Put Rust live tests under `crates/agentwerk/tests/integration/` and register them through `tests/integration.rs`.
+- Put shared live helpers in `tests/integration/common.rs`.
+- Mark provider-dependent Python tests with `@pytest.mark.live`.
+- Require explicit provider environment variables; do not silently skip a requested live suite.
 
-## Naming
+## Test Shape
 
-**The name states the behavior, not the method called.**
+**Make one test demonstrate one observable behavior.**
 
-```rust
-add_reply_appends_one_line_to_replies_jsonl        // accepted
-an_explicit_task_schema_overrides_the_label_default
-test_add_reply                                     // rejected
-test_schema_works
-```
+- Name the behavior and expected outcome, such as `add_reply_appends_one_line_to_replies_jsonl`.
+- Exercise the public entry point when the contract is public; use private access only for a private algorithm.
+- Assert state through readers such as `Task::get_status`, `Task::get_result`, or `Werk::find_events`.
+- Cover rejected transitions and verify the original state remains unchanged.
+- Merge sibling cases when one parameterized or table-driven test expresses the same rule more clearly.
 
-- The body verifies what the name claims, with no surprise assertions.
-- The name is the first line of the documentation the test provides.
+## Boundaries
 
-## API Focus
+**Use real in-process state and isolate only external trust boundaries.**
 
-**Tests exercise the public surface the way callers hold it.**
+- Prefer temporary directories, real stores, and real serialization over mocks of agentwerk internals.
+- Fake network responses, elapsed time, or provider output only at the boundary that owns them.
+- Keep the action under test visible; move repeated setup into `test_util` helpers.
+- Comment only when a test protects an architectural invariant that its name cannot express.
 
-- Call the public entry point; do not poke at private fields, patched internals, or field assignments.
-- Mock at trust boundaries (network, clock, disk), never at the subject under test.
-- Assert observable outcomes, not call logs or the order internal methods ran in.
-- The arrange, act, and assert shape mirrors how a real caller would use the API.
+## Surface Parity
 
-## State Transitions
+**Treat tests as executable API documentation.**
 
-**Actions and the resulting state MUST be visible through the public API.**
-
-- Build the starting state by calling real actions, not by field assignment that bypasses invariants.
-- Read the resulting state back through a public query, not by peeking at private fields.
-- Assert both the starting and the final state so the transition is shown, not implied.
-- Cover illegal transitions and verify state is unchanged after a rejection.
-- One transition per test, so a failure locates the exact broken action.
-
-## Clarity
-
-**Setup is hidden. Intent is highlighted.**
-
-- Push scaffolding into factories, builders, and fixtures so the body reads as a short story.
-- Name literals that carry meaning: `EXPIRED_COUPON`, not `42`.
-- Keep the act step a single visible line; do not bury it in setup.
-- Comments are justified only to pin an architectural invariant the test guards.
-
-## Coverage Shape
-
-**Every public operation has a test that demonstrates intended usage.**
-
-- Error cases, edge conditions, and boundaries sit at the same interface level as the happy path.
-- A missing behavior is added before a duplicate case is kept for symmetry.
-- IMPORTANT: a public method with no test is a documentation gap, not just a coverage gap.
+- Add a happy path, failure path, and meaningful boundary for each public operation.
+- Update Rust doctests when public examples change.
+- Update `crates/agentwerk-py/tests/test_parity.py` when Rust or Python exports change.
+- Follow [workflow.md](workflow.md) for the exact commands and live-test prerequisites.

--- a/agentdocs/this.md
+++ b/agentdocs/this.md
@@ -2,116 +2,83 @@
 
 How every file under `agentdocs/` is written. This file is itself an example of the format.
 
-## File Shape
+## File shape
 
 **One topic per file. Start with a title and a one-sentence description.**
 
-```markdown
-# Style
-
-Naming and comment rules, plus README structure. Skim the section matching what is being written.
-```
-
 - `# Title`: one word or short phrase, no trailing punctuation.
-- Sections use plain headings: `## Title Cased Heading`. No numbers, so adding a section forces no renumbering.
-- Each section is self-contained, so a reader can skip straight to it.
+- One sentence under the title states what the file covers.
+- Sections use plain `##` headings without numbers.
+- Make each section self-contained so a reader can skip to it directly.
 
-## Section Shape
+## Section shape
 
-**Bold rule first. One example second. Bullets last.**
+**Put the rule first and supporting bullets second.**
 
-```markdown
-## Builders
-
-**Builder methods are bare nouns. No `with_` prefix.**
-
-`.name()`, `.model()`, `.tool()`, `.label()`, `.concurrent()`
-
-- The `with_` prefix is reserved for a bare name that would be ambiguous.
-```
-
-- The first line after the heading is a bold one-liner stating the rule as an instruction.
-- An example follows whenever the rule is about code or about the shape of text. Use the smallest form that shows the rule: a fence, a line of identifiers, or a good and bad pair.
-- A section whose own text already demonstrates the rule needs no separate example.
-- Bullets carry what the rule and the example do not. A closing sentence is added only when it carries information the bullets cannot.
+- Start each section with a bold one-line instruction.
+- Add three to five bullets that unpack only what the rule does not say.
+- Add an example only when it makes the rule materially clearer.
+- Add a closing sentence only when it carries new information.
 
 ## Bullets
 
-**Three to five bullets per section. One line each. Imperative voice.**
+**Use imperative, one-line bullets.**
 
-- Start with a capital letter; end with a period.
-- Lead with the verb or with the thing being forbidden.
-- Two short sentences per bullet are acceptable; longer bullets are not.
-- Nested bullets are used only under a parent line ending in a colon.
+- Start with a capital letter and end with a period.
+- Lead with the action or the thing forbidden.
+- Keep each bullet to one idea; use two short sentences only when needed.
+- Nest bullets only under a parent line ending in a colon.
 
 ## Enumerations
 
-**Use bullets, not tables.**
+**Use bullets instead of tables.**
 
-```markdown
-- `Persist`: `save(&self, dir)` and `load(dir, &Self::Key)`.
-- `Append`: `append(dir, &Self::Record)`.
-```
-
-- Tables produce wide rows that are hard to compare.
-- For `name: description` pairs, write `` `Name`: description. ``
-- Group related bullets under a one-line header ending in a colon.
-- Tables belong in the README, where a `<details>` fold gives them a place to sit. These files have no folds.
-
-## Punctuation
-
-**Colons, not em dashes.**
-
-- Use `:` where an em dash would otherwise appear.
-- Use commas or parentheses for short parenthetical asides.
-- `>` blockquotes are reserved for callouts at the top of a file.
+- Write name and description pairs as `` `Name`: description. ``
+- Group related bullets under a short framing line when needed.
+- Keep commands and small examples in code fences.
+- Reserve tables for public reference documents such as `README.md`.
 
 ## Voice
 
-**Direct and neutral. No marketing language. No unnecessary jargon.**
+**Write direct, neutral instructions without decoration.**
 
-```markdown
-GOOD: `Stats` records every event and exposes read accessors.
-BAD:  `Stats` seamlessly wires a powerful metrics plane into the kernel.
-```
-
-- State the rule; justify only when the rule is not obvious on its own.
+- State the rule and justify only what a reader would question.
 - Prefer present tense and second person over passive voice.
-- Avoid adjectives that do not carry information ("powerful", "clean", "seamless").
-- Avoid borrowed metaphors ("kernel", "plane", "seam", "pipeline") unless they are the precise technical term.
+- Remove marketing language, hedging, and unnecessary jargon.
+- Reserve blockquotes for important callouts at the top of a file.
 
 ## Emphasis
 
-**Use MUST for non-negotiable rules. Use IMPORTANT for easy-to-miss gotchas.**
+**Use MUST for correctness and IMPORTANT for easy-to-miss consequences.**
 
-- MUST: correctness-critical rules where a violation breaks compilation, the shape exchanged with LLM providers, or an architectural invariant.
-- IMPORTANT: prefixes a bullet that a reader skimming would miss and regret later.
-- Most rules need neither: the bold one-liner is already the rule.
-- SHOULD, MAY, and CAN are not used: RFC-2119 without the full spec is noise.
+- Use MUST when violating a rule breaks compilation, a public contract, or an architectural invariant.
+- Prefix an easy-to-miss operational consequence with IMPORTANT.
+- Let the bold lead carry ordinary emphasis.
+- Avoid RFC-style SHOULD, MAY, and CAN outside a formal specification.
 
-## Code Grounding
+## Code grounding
 
-**Rules name identifiers that exist in the crate. No invented vocabulary.**
+**Name real project identifiers and keep each statement true to the code.**
 
-- A type, function, field, or method named in a rule MUST be greppable in `crates/agentwerk/src/`.
-- Verbs describe what the code does, not how it feels: avoid "wires", "magic", "ergonomic", "seamless".
-- A rule that cannot point at code is opinion, not architecture: drop it or move it to the consuming application.
-- When a name changes in code, the docs change in the same commit.
+- Verify named types, functions, fields, methods, and paths under `crates/`.
+- Describe what code does with concrete verbs.
+- Drop opinions that cannot point to code or a documented repository decision.
+- Update a rule in the same change as the code that invalidates it.
 
-## Cross-Linking
+## Cross-linking
 
-**Each fact lives in one file. Other files link to it.**
+**Give each fact one home and link to it elsewhere.**
 
-- Commands belong in `workflow.md`; other files link there rather than restating them.
-- File and module placement belongs in `layout.md`; `architecture.md` describes invariants and assumes placement is known.
-- Naming and comment rules belong in `style.md`; `testing.md` covers test-specific naming and links out for the rest.
-- A duplicated fact is a future inconsistency: when two files would say the same thing, one of them links instead.
+- Put commands in `workflow.md`.
+- Put file placement in `layout.md` and cross-module invariants in `architecture.md`.
+- Put naming and comment rules in `style.md` and test-specific rules in `testing.md`.
+- Replace duplicated facts with a link to their authoritative file.
 
 ## Length
 
-**If agentdocs are getting too long, consolidate them. Information loss is acceptable.**
+**Optimize for retrieval, not completeness.**
 
-- Drop sections that restate what a careful reader of the code would already see.
-- Merge two short, overlapping sections before splitting one long section.
-- A rule that has not earned its line is cut, not rewritten shorter.
-- Skim cost matters more than completeness: a forgotten file teaches nothing.
+- Drop facts a careful reader can recover immediately from code or `INVENTORY.md`.
+- Keep constraints, exceptions, negations, and surprising behavior.
+- Merge overlapping sections before adding another file.
+- Cut a rule that has not earned its skim cost.

--- a/agentdocs/workflow.md
+++ b/agentdocs/workflow.md
@@ -1,80 +1,89 @@
 # Workflow
 
-Commands used to build, test, release, and run example agents.
+Commands for building, testing, documenting, running, and releasing the workspace.
 
 ## Build
 
-**Every build MUST run with `-D warnings`. Any warning fails it.**
+**Use the Make targets so warnings and documentation checks stay consistent.**
 
 ```bash
-make        # compile the crate
-make fmt    # format the code
-make clean  # remove build artifacts
+make                 # format and build with warnings denied
+make fmt             # format Rust code
+make doc             # build strict rustdoc for agentwerk
+make check_names     # reject removed names and missing inventory files
+make clean           # remove build artifacts
+make update          # update dependencies
 ```
 
-## Test
+- Run `make` after Rust changes.
+- Run `make doc` after public API or rustdoc changes.
+- Update `INVENTORY.md` with every added, removed, renamed, or retyped declaration.
 
-**Test layout and writing rules live in [testing.md](testing.md).**
+## Rust Tests
 
-- `make test` runs three passes: `--lib` (every crate's inline `#[cfg(test)] mod tests`), `--doc` (the examples in `///` comments), and `-p use-cases --bins` (the tests inside the use-case binaries).
-- `--lib` alone reaches neither of the last two.
-- `make test_integration` runs the live-provider tests bundled by `tests/integration.rs`.
+**Run the offline suite before any live-provider suite.**
+
+```bash
+make test
+make test_integration
+make test_integration name=command_usage
+```
+
+- `make test` runs workspace library tests, rustdoc examples, and the `use-cases` binary tests.
+- `make test_integration` runs `crates/agentwerk/tests/integration.rs` against the configured LLM provider.
+- Set `name=<test name>` to filter the Rust integration binary.
+- Export provider variables in the shell before live tests; the target does not load a `.env` file.
 
 ## Python Bindings
 
-**`make python` runs `maturin develop` in `crates/agentwerk-py/`, building the extension into the active virtualenv.**
-
-- Create the virtualenv first with `python3 -m venv .venv` at the repo root and activate it. maturin fails without one, and the test targets resolve `python3` off the PATH, so an unactivated virtualenv imports the system interpreter instead.
-- `make python_test` runs the offline pytest suite: no network, no LLM provider.
-- `make python_test_integration` runs the tests marked `live`, which call a real LLM provider.
-- Both test targets depend on `make python`, so an edit to the binding crate is picked up automatically.
-
-## Integration Environment
-
-**Integration tests read LLM provider configuration from the environment. Export it in your shell before running them; no target reads a file.**
+**Build and test the extension inside an activated virtual environment.**
 
 ```bash
-export OPENAI_API_KEY=sk-local
-export OPENAI_BASE_URL=http://localhost:8095
-make test_integration
+python3 -m venv .venv
+source .venv/bin/activate
+make python
+make python_test
+make python_test_integration
 ```
 
-- `OPENAI_BASE_URL` points at a local OpenAI-compatible proxy on port 8095.
-- A target that finds no provider fails at the first request rather than skipping, so an unset variable is loud.
-- Keeping a `.env` and sourcing it yourself still works, since the targets inherit whatever the shell exports.
-
-## Release
-
-**`make bump` runs tests, bumps the patch version, commits, and tags.**
-
-- `make bump part=minor` and `make bump part=major` bump the other two parts.
-- Push the new tag with `git push --tags`.
-
-## Hooks
-
-**`make hooks` installs Claude Code hooks into `.claude/settings.local.json`.**
-
-- Source files live in `hooks/` (tracked); `make hooks` copies them into `.claude/hooks/` (ignored) and merges the configuration.
-- `check-conventions.sh` injects `agentdocs/style.md` and `agentdocs/architecture.md` as context after each Rust file edit.
-
-## Skills
-
-**`make skills` symlinks every directory under `skills/` into `~/.claude/skills` and `~/.config/opencode/skills`.**
-
-- `skills/prompt` writes and rewrites the crate's agent-facing text: role files, `*.tool.md` definitions, directives.
-- IMPORTANT: the destinations are shared across every project. A skill of the same name already installed there is replaced, so `make skills` changes what `/prompt` means everywhere, not just here.
+- `make python` runs `maturin develop` in `crates/agentwerk-py/`.
+- `make python_test` runs tests not marked `live`.
+- `make python_test_integration` runs only tests marked `live` against the configured provider.
+- Keep the virtual environment active because both maturin and pytest use `python3` from `PATH`.
 
 ## Use Cases
 
-**Example agents live in `crates/use-cases/src/` and run through `make use_case`.**
+**Run examples through `make use_case`.**
 
 ```bash
-make use_case                # list available names
-make use_case name=<name>    # run one
+make use_case
+make use_case name=terminal-repl
+make use_case name=deep-research args="What is a good life?"
 ```
 
-- `hello-world` is the smallest program the crate allows: one agent, one task, one printed answer.
-- `terminal-repl` is a per-turn interactive chat that prints output as it arrives.
-- `divide-and-conquer` partitions an arithmetic problem across agents sharing one Werk.
-- `deep-research` is a two-phase research pipeline with web search, and requires `BRAVE_API_KEY`.
-- `malware-scanner` identifies indicators of compromise in a software package.
+- Use the empty target to list names from `crates/use-cases/Cargo.toml`.
+- Pass program arguments through `args=`, not after `--`.
+- Set `BRAVE_API_KEY` before running `deep-research`.
+
+## Local Tooling
+
+**Treat setup targets as changes outside the repository.**
+
+- `make hooks` merges `hooks/hooks.json` into `.claude/settings.local.json`.
+- `make skills` replaces same-named skills under `~/.claude/skills` and `~/.config/opencode/skills` with repository symlinks.
+- `make litellm` starts a Docker proxy on port 4000; set `LITELLM_PROVIDER` to `anthropic`, `openai`, or `mistral`.
+
+## Release
+
+**Use `make bump` only when a versioned release is intended.**
+
+```bash
+make bump
+make bump part=minor
+make bump part=major
+git push && git push --tags
+```
+
+- The target runs tests, updates both crate versions, commits, and creates a `v<version>` tag.
+- Omit `part` for a patch release; use only `patch`, `minor`, or `major`.
+- GitHub Actions publishes after the tag is pushed.


### PR DESCRIPTION
## Simplify and correct agent conventions

### Purpose

- `agentdocs/` had grown to 13,832 words, obscuring actionable rules
- Existing guidance no longer matched repository structure and setup targets
- Code-grounded sections reduce skim cost for maintainers and agents

### What changed

- Seven guides now separate boundaries, commands, placement, architecture, style, and tests

### Examples

```bash
make check_names
make test
```

```bash
make doc
```