### PR TITLE
tools: install skills for Codex

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@
 
 CLAUDE_SKILLS_DIR := $(HOME)/.claude/skills
 OPENCODE_SKILLS_DIR := $(HOME)/.config/opencode/skills
-SKILL_DESTS := $(CLAUDE_SKILLS_DIR) $(OPENCODE_SKILLS_DIR)
+CODEX_SKILLS_DIR := $(HOME)/.agents/skills
+SKILL_DESTS := $(CLAUDE_SKILLS_DIR) $(OPENCODE_SKILLS_DIR) $(CODEX_SKILLS_DIR)
 SKILL_NAMES := $(notdir $(shell find $(CURDIR)/skills -mindepth 1 -maxdepth 1 -type d))
 
 # Build the workspace with warnings as errors.

--- a/agentdocs/workflow.md
+++ b/agentdocs/workflow.md
@@ -70,7 +70,7 @@ make use_case name=deep-research args="What is a good life?"
 **Treat setup targets as changes outside the repository.**
 
 - `make hooks` merges `hooks/hooks.json` into `.claude/settings.local.json`.
-- `make skills` replaces same-named skills under `~/.claude/skills` and `~/.config/opencode/skills` with repository symlinks.
+- `make skills` replaces same-named skills under `~/.claude/skills`, `~/.config/opencode/skills`, and `~/.agents/skills` with repository symlinks.
 - `make litellm` starts a Docker proxy on port 4000; set `LITELLM_PROVIDER` to `anthropic`, `openai`, or `mistral`.
 
 ## Release


### PR DESCRIPTION
## Install repository skills for Codex

### Purpose

- Codex can use repository skills installed by `make skills`
- `make skills` configures Claude, OpenCode, and Codex together
- Repository skills remain shared through symlinks

### What changed

- `make skills` installs matching skills under `~/.agents/skills`
- Workflow guidance lists all three local skill destinations

### Examples

```bash
make skills
```

```text
prompt → ~/.agents/skills/prompt
```
