### PR TITLE
Strengthen prompt contract guidance

### DIFF
--- a/skills/prompt/SKILL.md
+++ b/skills/prompt/SKILL.md
@@ -1,138 +1,230 @@
 ---
 name: prompt
-description: Write or rewrite agentwerk role files, tool definitions, and directives at maximum task-relevant compression. Keeps observable actions, tool names, placeholders, output fields, and task-facing consequences; removes filler, implementation details, hidden state, and behavior-seeding examples.
+description: Write or rewrite roles, tasks, handoffs, schemas, tool descriptions, directives, and shared prompt fragments. Use when agent-facing text lacks orientation or disagrees with its runtime contract.
 ---
 
 # Prompt
 
-You write agentwerk's agent-facing text: role files, `*.tool.md` definitions, directives. Each one contains only what the model needs to act and return a valid result. Every sentence must change an action, tool choice, decision, output, or recovery.
+Write only what an agent needs to act and return a valid result. Edit a supplied path or write inline.
 
-Use the same compressed style in every mode.
+## Contract Audit
 
-## Modes
+Before editing:
 
-- Write: input is a task or agent description. Output goes to the path named, or inline when none is named.
-- Rewrite: input is an existing prompt file. Output replaces it in place.
+1. Read the prompt and its call site.
+2. Inspect rendered tasks, handoffs, placeholders, and values.
+3. Compare named tools with granted tools.
+4. Read input and output schemas.
+5. Trace requested fields to sources and inspect the consumer.
+6. Find contradictions across prompts, examples, payloads, schemas, and conditions.
 
-Both modes apply the same rules.
+DO NOT rewrite from the prompt file alone. Clear prose can still describe a false contract.
+
+Resolve contradictions before compression. Update every affected prompt surface and test.
+
+## Room Test
+
+Read the opening alone. Assume the agent has no conversation history.
+
+Open every autonomous role with exactly these bullets:
+
+- **Identity:** Start with `You are` and name the specialist.
+- **Place:** Name its codebase, library, service, or environment.
+- **Tools:** Name where its input and evidence live.
+- **Job:** State one owned action or decision.
+- **Stop:** State completion, including empty or negative results.
+
+Rules:
+
+- Keep each bullet to 16 words after its label.
+- Use one sentence and one instruction per bullet.
+- NEVER begin with `The task`, `You run`, or `You audit`.
+- Give every reference an antecedent.
+- Say who supplied or decided each verdict, finding, or result.
+- Remove internal terms the agent does not read, call, or return.
+- Define each necessary technical term at first use.
+- Name an audience ONLY when it changes wording, evidence, or format.
+
+Reject unexplained `bounded pass`, `carried finding`, `cited dossier`, `corpus`, and `boundary`.
+
+### Reporter
+
+Wrong:
+
+```markdown
+Write the decided verdict as `summary`.
+```
+
+Right:
+
+```markdown
+- **Identity:** You are the final report writer for a completed code review.
+- **Place:** The examined codebase is available read-only in your working directory.
+- **Tools:** The assignment contains the Analyst's final verdict and required wording.
+- **Job:** Write `summary` for general readers and `details` for engineers.
+- **Stop:** Return both fields without reconsidering the supplied verdict.
+```
+
+### Seeker
+
+Wrong:
+
+```markdown
+Run one bounded pass over the scanned tree.
+```
+
+Right:
+
+```markdown
+- **Identity:** You are the code-search specialist in a security review.
+- **Place:** Work inside the unfamiliar codebase in your working directory.
+- **Tools:** `knowledge` contains its file map and saved queries.
+- **Job:** Search file contents for one assigned or untried suspicious pattern.
+- **Stop:** Save each query, then return one match or `nothing`.
+```
+
+## Complete Contract
+
+Define four facts for every agent:
+
+| Fact | Meaning |
+|---|---|
+| Input | Data and evidence it sees |
+| Action | Transformation, investigation, or decision it owns |
+| Output | Exact tools, fields, types, and limits |
+| Stop | Completion, empty result, or negative result |
+
+Put each fact at its narrowest stable layer:
+
+| Surface | Content |
+|---|---|
+| Role | Stable behavior shared by every claimed task |
+| Task | One assignment and its instance facts |
+| Handoff | Exact facts established upstream |
+| Schema | Field meaning, evidence source, and conditionality |
+| Tool description | Facts needed to choose and call the tool |
+| Shared fragment | One unchanged rule used by multiple prompts |
+
+- DO NOT repeat a fact across layers.
+- Name a consumer ONLY when it changes the returned evidence, wording, or shape.
+- Omit hosts, queues, labels, storage, assemblers, installers, parsers, retries, and validators.
+
+## Context and Data
+
+- Include a runtime value ONLY when it changes an action.
+- Prefer a specific value such as `{date}` or `{task_id}` over `{context}`.
+- Wrap injected requests, findings, research, and upstream results in descriptive XML tags.
+- Mark an injected block as data when it could contain instructions.
+- Carry exact upstream fields instead of paraphrasing them.
+- Make optional input and output visibly conditional.
+- NEVER ask an agent to retype a value the caller can carry exactly.
 
 ## Compression
 
 Drop:
 
-- Articles, filler (just, really, basically, actually, simply), pleasantries, hedging.
-- Connective fluff: however, furthermore, additionally, in addition.
-- Implementation rationales. State the required behavior and its task-facing consequence instead.
-- Restatements. Each fact appears once, in one section.
-- Capability framing. A strengths block does not change the agent's decisions.
-- Internal data structures, hidden state, storage, queues, schema machinery, routing, orchestration mechanics, and parser internals. Describe only observable inputs and outcomes.
+- Filler, hedging, marketing, and capability claims.
+- Restatements, schema-enforced rules, and internal vocabulary.
+- Advice without a check and rationales with obvious consequences.
 
 Keep:
 
-- Every marker: `IMPORTANT`, `CRITICAL`, `NEVER`, `DO NOT`, `MUST`, `NOT`, `ONLY`. Each has a distinct severity. Preserve it exactly.
-- `not`, `never`, `no`, `only`, `except`. Preserve the meaning of every restriction.
-- One task-facing reason or consequence where a rule is non-obvious or a prohibition needs weight. Attach it after a colon. NEVER an em dash: `agentdocs/style.md` bans it repo-wide.
+- Actions, decisions, outputs, stops, and recovery.
+- Exact names, placeholders, fields, enums, numbers, paths, URLs, and literals.
+- Every restriction and its original semantic force.
+- Reasons, prohibition consequences, and sequence words that change behavior.
 
-Verbatim, never compressed:
+Preserve force deliberately:
 
-- Tool names in backticks, `{placeholder}` bindings, output field names.
-- Required literal strings, numbers, units.
-- Code fences, file paths, URLs.
+- `NEVER`: absolute prohibition.
+- `DO NOT`: recoverable prohibition.
+- `NOT`: required contrast.
+- `ONLY`: strict scope.
+- Preserve existing `IMPORTANT`, `CRITICAL`, and `MUST` markers when their force remains required.
 
-NEVER invent an abbreviation (`cfg`, `impl`, `req`, `res`, `fn`): it obscures meaning without reliably reducing length. No arrows as a because-linker. No emoji, no decorative banners.
+Remove obsolete placeholders, duplicate markers, and redundant examples ONLY after auditing their call sites.
 
-IMPORTANT: keep every conjunction needed to make an ordered procedure unambiguous.
+Style:
 
-## Role file
+- Use plain words and direct imperatives.
+- Use one instruction per bullet.
+- Keep body bullets below 24 words where practical.
+- Avoid semicolons and nested conditions.
+- Use decision tables for rules with multiple branches.
+- NEVER invent abbreviations such as `cfg`, `impl`, `req`, `res`, or `fn`.
+- NEVER use an em dash.
 
-Fill ONLY the sections the agent needs.
+## Prompt Surfaces
 
-````markdown
-# <Role>
+### Role
 
-{context}
+- Start with the Room Test.
+- Follow required section order and list ONLY granted tools.
+- Put instance facts in the task and cap free-text fields.
+- End with the task boundary.
 
-## Role
+### Task and Handoff
 
-<What you do and output. Name a consumer ONLY when its needs change the work. One to two sentences.>
+- Give one assignment and delimit its data.
+- Omit stable role policy.
+- Carry upstream fields the receiver cannot reconstruct.
 
-## Behavior
+### Schema Description
 
-- <bare imperative>
-- IMPORTANT: <the step most often skipped>
-- NEVER <prohibition>
+- Define meaning, evidence, and conditionality.
+- DO NOT describe routing, storage, parsers, installers, or schema machinery.
 
-## Tools
+### Tool Description
 
-`tool_a` `tool_b` `finish`. Any other name fails.
+Write only what selects and invokes the tool:
 
-## Task
+```markdown
+<Imperative affordance and returned result.>
 
-{instruction}
+- <Constraint preventing a wrong call.>
 
-One `finish` with:
-- `<field>` (≤N chars): <one phrase>
+## When NOT to Use
+
+- <Overlapping case>: use `<other_tool>`.
+```
+
+Omit `When NOT to Use` without an overlapping tool.
+
+### Directive and Shared Fragment
+
+- State the failure and next valid action.
+- Bind byte-identical shared text once.
+
+## Examples
+
+Add examples ONLY when required or prose cannot show the shape.
+
+- Show the input before the output.
+- Derive every output fact from that shown input.
+- Make every tool call schema-valid.
+- NEVER invent a package, path, filename, citation, verdict reason, or literal.
+- Use decision tables to avoid seeding. Use balanced cases when two examples are required.
 
 ## Verification
 
-- <observable check the output passes>
+Verify rendered prompts:
 
-NOTE: <what this task is not>
-````
+- Every placeholder resolves.
+- Named and granted task-critical tools match.
+- Each requested field is available or conditional.
+- Every example satisfies the active schema.
+- Every injected data block is delimited.
+- Conditional inputs produce conditional instructions and outputs.
+- Shared context appears once.
+- The opening passes the Room Test.
+- The consumer receives exactly what it needs.
 
-- Keep the tool list on one line. Include a per-tool bullet ONLY when omitting it would make the agent choose the wrong tool.
-- One example output, added ONLY when the field list leaves the shape unclear and a neutral example is possible.
-- Examples teach shape ONLY. Use inert values such as `"..."`; NEVER seed a verdict, recommendation, label, status, path, filename, factual answer, or strategy the model could copy.
-- List enums and decision rules outside examples. Omit an example when no valid neutral shape exists.
-- Cap every text field with a character or sentence budget. Uncapped fields run long.
-- NEVER grant a tool the input did not name: an unavailable tool call wastes the turn.
+## Report
 
-## Tool definition
+Report:
 
-`*.tool.md` contains only prose the model needs to choose and call the tool.
+- Per-prompt and aggregate character counts.
+- Semantic contract changes.
+- Validation results and skipped checks.
 
-`````markdown
-<Imperative one-liner: the agent acts, the tool exposes the action. Then what it returns, and its limits.>
-
-- <constraint the model needs to call it correctly>
-
-## When NOT to use
-
-- <neighbouring case>: use `<other tool>`.
-`````
-
-- Voice is the affordance: `Find files by glob pattern`, never `This tool finds files`.
-- `## When NOT to use` appears ONLY where a sibling tool overlaps.
-- Do NOT repeat argument behavior unless it changes tool choice or prevents an invalid call.
-
-## Directive
-
-State the failure and next action without a fixed template or state-management details.
-
-## Shared fragments
-
-Move a block repeated across role files into one shared fragment so every agent receives the same rule.
-
-## Rewrite protocol
-
-1. Read the target.
-2. Apply the rules above, preserving every verbatim class.
-3. Write in place.
-4. Report the before and after character counts on one line.
-
-## Example
-
-Before:
-
-```markdown
-After all work has been completed, call the finish tool exactly once and put your final answer
-inside the result argument. Do not add any other text because it will not be returned.
-```
-
-After:
-
-```markdown
-Call `finish({"result":"..."})` once after the work is complete. Text outside it is not returned.
-```
-
-NOTE: Write the sections the agent needs, then stop. A one-line directive does not grow into a role file.
+NOTE: Compression starts after the contract is complete. A short prompt with a missing premise still fails.


### PR DESCRIPTION
## Strengthen prompt contract guidance

### Purpose

- Agent-facing text can disagree with its runtime contract
- Autonomous roles need identity, place, tools, job, and stop conditions
- Rendered prompts need verification before compression

### What changed

- `Contract Audit` traces inputs, schemas, tools, and consumers before edits
- `Room Test` standardizes openings for autonomous roles
- `Complete Contract` assigns facts to their narrowest stable prompt surface
- `Verification` checks values, conditionals, examples, and shared context

### Examples

```markdown
- **Identity:** You are the final report writer for a completed code review.
- **Stop:** Return both fields without reconsidering the supplied verdict.
```

```xml
<upstream_result data="true">...</upstream_result>
```
