### PR TITLE
Unify AQL across tasks, events, and joined queries

### DIFF
--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -341,18 +341,20 @@ The rules the tables never repeat.
 
 | Language | Item | Visibility |
 |----------|------|------------|
-| Rust | `trait Matcher<R: Queryable> { into_query(): Query<R> }` | pub |
-| Rust | `impl Matcher<R> for F where F: Fn(R) => boolean + Send + Sync + 'static` | pub |
+| Rust | `trait Matcher<R> { into_query(): Query }` | pub |
+| Rust | `impl Matcher<Task> for F where F: Fn(Task) => boolean + Send + Sync + 'static` | pub |
+| Rust | `impl Matcher<Event> for F where F: Fn(Event) => boolean + Send + Sync + 'static` | pub |
 | Rust | `impl Matcher<R> for &str` | pub |
 | Rust | `impl Matcher<R> for String` | pub |
-| Rust | `impl Matcher<R> for Query<R>` | pub |
+| Rust | `impl Matcher<R> for Query` | pub |
 | Python | an AQL string or a callable stands in for the `Query` wherever one is accepted | |
-| Rust | `Query<R: Queryable = Task>(Compiled<R.Field>)` | pub |
-| Python | `Query(query: str)`: one class over both field sets, compiled over each at construction | |
+| Rust | `Query(Compiled)` | pub with private fields |
+| Python | `Query(query: str)`: one class whose task or event origin is inferred at construction | |
 | Rust | `.new(query: string): this throws QueryError` | pub |
-| Rust | `impl From<&str> for Query<R>` | pub |
-| Rust | `impl From<String> for Query<R>` | pub |
-| Rust | `enum QueryError { TermsMissing, FieldUnrecognized, StatusUnrecognized, TimeMalformed, OperatorNotAllowed, FieldRepeated, TokenRejected, TermUnfinished }` | pub |
+| Rust | `.expects_task(): void throws QueryError` | pub, hidden from docs |
+| Rust | `impl From<&str> for Query` | pub |
+| Rust | `impl From<String> for Query` | pub |
+| Rust | `enum QueryError { TermsMissing, FieldUnrecognized, OriginsMixed, OriginMismatch, StatusUnrecognized, TimeMalformed, OperatorNotAllowed, FieldRepeated, TokenRejected, TermUnfinished }` | pub |
 | Rust | `impl Display for QueryError` | pub |
 | Rust | `impl Error for QueryError` | pub |
 
@@ -360,51 +362,77 @@ The rules the tables never repeat.
 
 | Language | Item | Visibility |
 |----------|------|------------|
-| Rust | `trait Queryable { Field }` | private |
-| Rust | `impl Queryable for Task` | private |
-| Rust | `impl Queryable for Event` | private |
 | Rust | `Query.all(): this` | crate |
-| Rust | `.matches(record: R): boolean` | crate |
-| Rust | `.and(other: Query<R>): this` | crate |
+| Rust | `.matches_task(task: Task): boolean` | crate |
+| Rust | `.matches_event(event: Event): boolean` | crate |
+| Rust | `.and(other: Query): this` | crate |
 | Rust | `.is_ordered(): boolean` | crate |
-| Rust | `.sort(records: R[]): void` | crate |
-| Rust | `Query<Task>.default_status(status: Status): this` | crate |
-| Rust | `.and_status(status: Status): this` | crate |
-| Rust | `.and_result(): this` | crate |
-| Rust | `enum Condition<F: QueryField> { All(Condition<F>[]), Any(Condition<F>[]), Not(Condition<F>), Term(F, Match), Test(Predicate<F.Record>) }` | private |
-| Rust | `.matches(record: F.Record): boolean` | private |
-| Rust | `.mentions(field: F): boolean` | private |
-| Rust | `Predicate<R>((record: R) => boolean)` | private |
-| Rust | `impl Clone for Predicate<R>` | private |
-| Rust | `impl Debug for Predicate<R>` | private |
-| Rust | `Compiled<F: QueryField> { root: Condition<F>, order: Sort<F>? }` | private |
+| Rust | `.sort_tasks(records: Task[]): void` | crate |
+| Rust | `.sort_events(records: Event[]): void` | crate |
+| Rust | `.task(): this` | crate |
+| Rust | `.task_if_originless(): this` | crate |
+| Rust | `.event_if_originless(): this` | crate |
+| Rust | `.is_event(): boolean` | crate |
+| Rust | `.assert_origin(expected: Origin): void` | private |
+| Rust | `.and_task_status(status: Status): this` | crate |
+| Rust | `.default_task_status(status: Status): this` | crate |
+| Rust | `.and_task_result(): this` | crate |
+| Rust | `enum Condition { All(Condition[]), Any(Condition[]), Not(Condition), Term(Field, Match), Test(Predicate) }` | private |
+| Rust | `.matches(record: View): boolean` | private |
+| Rust | `.mentions(field: Field): boolean` | private |
+| Rust | `enum Predicate { Task((task: Task) => boolean), Event((event: Event) => boolean) }` | private |
+| Rust | `.test(record: View): boolean` | private |
+| Rust | `impl Clone for Predicate` | private |
+| Rust | `impl Debug for Predicate` | private |
+| Rust | `Compiled { root: Condition, order: Sort?, origin: Origin? }` | private |
 | Rust | `.new(query: string): this throws QueryError` | private |
 | Rust | `.all(): this` | private |
-| Rust | `.test(check: (record: F.Record) => boolean): this` | private |
-| Rust | `.term(field: F, matcher: Match): this` | private |
-| Rust | `.rooted(root: Condition<F>): this` | private |
-| Rust | `.and(other: Compiled<F>): this` | private |
-| Rust | `.matches(record: F.Record): boolean` | private |
-| Rust | `.mentions(field: F): boolean` | private |
+| Rust | `.test(check: Predicate): this` | private |
+| Rust | `.term(field: Field, matcher: Match): this` | private |
+| Rust | `.rooted(root: Condition): this` | private |
+| Rust | `.and(other: Compiled): this` | private |
+| Rust | `.matches(record: View): boolean` | private |
+| Rust | `.mentions(field: Field): boolean` | private |
 | Rust | `.is_ordered(): boolean` | private |
-| Rust | `.sort(records: T[]): void` | private |
-| Rust | `trait QueryField: Copy + PartialEq + Debug + 'static { Record, FIELDS, of, kind, is_optional, shorthand, label, tie_break, sort_unordered, canonical, compare, named, name, spellings, allows, operators }` | private |
-| Rust | `enum TaskField { Id, Label, Status, Pending, Cancelled, Agent, Parent, Task, Result, Errors, Created, Started, Finished, Failed }` | private |
-| Rust | `impl QueryField for TaskField` | private |
-| Rust | `enum EventField { Event, Agent, Task, Label, Created, Payload }` | private |
-| Rust | `impl QueryField for EventField` | private |
+| Rust | `.sort_tasks(records: Task[]): void` | private |
+| Rust | `.sort_events(records: Event[]): void` | private |
+| Rust | `.expects(expected: Origin): void throws QueryError` | private |
+| Rust | `.bind(expected: Origin): void` | private |
+| Rust | `.bind_if_originless(origin: Origin): void` | private |
+| Rust | `enum Origin { Task, Event }` | private |
+| Rust | `.name(): string` | private |
+| Rust | `merge_origins(left: Origin?, right: Origin?): Origin? throws QueryError` | private |
+| Rust | `enum View { Task(Task), Event(Event) }` | private |
+| Rust | `.value(field: Field): string?` | private |
+| Rust | `.tie_break(): [number, number]` | private |
+| Rust | `enum Field { TaskId, TaskLabel, TaskStatus, TaskPending, TaskCancelled, TaskAssignee, TaskParentId, TaskInput, TaskResult, TaskErrors, TaskCreated, TaskStarted, TaskFinished, TaskFailed, EventName, EventAgentId, EventTaskId, EventLabel, EventCreated, EventData }` | private |
+| Rust | `.FIELDS: [string, Field][]` | private |
+| Rust | `.named(name: string): Field?` | private |
+| Rust | `.spellings(): string` | private |
+| Rust | `.name(): string` | private |
+| Rust | `.origin(): Origin` | private |
+| Rust | `.kind(): Kind` | private |
+| Rust | `.is_optional(): boolean` | private |
+| Rust | `.allows(matcher: Match): boolean` | private |
+| Rust | `.operators(): string` | private |
+| Rust | `.canonical(value: string): string throws QueryError` | private |
+| Rust | `.literal(value: string): string throws QueryError` | private |
+| Rust | `.compare(left: string, right: string): Ordering` | private |
+| Rust | `.of_task(task: Task): string?` | private |
+| Rust | `.of_event(event: Event): string?` | private |
 | Rust | `enum Kind { Value, Text, Time }` | private |
+| Rust | `serialized_errors(task: Task): string?` | private |
 | Rust | `is_task_id(word: string): boolean` | private |
 | Rust | `carried(value: string): string?` | private |
 | Rust | `event_named(value: string): string?` | private |
 | Rust | `as_text(value: json): string` | private |
-| Rust | `Sort<F: QueryField> { field: F, descending: boolean }` | private |
-| Rust | `.compare(left: F.Record, right: F.Record): Ordering` | private |
+| Rust | `Sort { field: Field, descending: boolean }` | private |
+| Rust | `.compare(left: View, right: View): Ordering` | private |
 | Rust | `STATUSES: Status[]` | private |
 | Rust | `millis_text(millis: number): string` | private |
 | Rust | `bool_text(value: boolean): string` | private |
 | Rust | `millis(value: string): number` | private |
-| Rust | `time_value(field: F, value: string): number throws QueryError` | private |
+| Rust | `time_value(field: Field, value: string): number throws QueryError` | private |
 | Rust | `ago(offset: string): number?` | private |
 | Rust | `date_millis(value: string): number?` | private |
 | Rust | `status_rank(value: string): number` | private |
@@ -414,20 +442,27 @@ The rules the tables never repeat.
 | Rust | `.spelling(): string` | private |
 | Rust | `.is_keyword(keyword: string): boolean` | private |
 | Rust | `tokenize(query: string): Token[] throws QueryError` | private |
-| Rust | `parse_query<F>(query: string): [Condition<F>, Sort<F>?] throws QueryError` | private |
-| Rust | `Parser<F: QueryField> { tokens: Token[], at: number }` | private |
+| Rust | `parse_query(query: string): [Condition, Sort?, Origin] throws QueryError` | private |
+| Rust | `Parser { tokens: Token[], at: number, origin_field: Field? }` | private |
+| Rust | `.peek(): Token?` | private |
+| Rust | `.peek_after(): Token?` | private |
+| Rust | `.next(): Token?` | private |
+| Rust | `.take_keyword(keyword: string): boolean` | private |
 | Rust | `.at_order_by(): boolean` | private |
-| Rust | `.order_by(): Sort<F>? throws QueryError` | private |
-| Rust | `.any(): Condition<F> throws QueryError` | private |
-| Rust | `.all(): Condition<F> throws QueryError` | private |
-| Rust | `.unary(): Condition<F> throws QueryError` | private |
-| Rust | `.term(): Condition<F> throws QueryError` | private |
-| Rust | `.operator(field: F): Match throws QueryError` | private |
-| Rust | `.value(field: F): string throws QueryError` | private |
-| Rust | `.time(field: F): number throws QueryError` | private |
-| Rust | `.values(field: F): string[] throws QueryError` | private |
-| Rust | `one_or<F>(group: (Condition<F>[]) => Condition<F>, terms: Condition<F>[]): Condition<F>` | private |
-| Rust | `reject_repeated_field<F>(terms: Condition<F>[]): void throws QueryError` | private |
+| Rust | `.order_by(): Sort? throws QueryError` | private |
+| Rust | `.any(): Condition throws QueryError` | private |
+| Rust | `.all(): Condition throws QueryError` | private |
+| Rust | `.unary(): Condition throws QueryError` | private |
+| Rust | `.term(): Condition throws QueryError` | private |
+| Rust | `.at_operator(): boolean` | private |
+| Rust | `.operator(field: Field): Match throws QueryError` | private |
+| Rust | `.value(field: Field): string throws QueryError` | private |
+| Rust | `.time(field: Field): number throws QueryError` | private |
+| Rust | `.values(field: Field): string[] throws QueryError` | private |
+| Rust | `.field(name: string): Field throws QueryError` | private |
+| Rust | `.record_field(field: Field): void throws QueryError` | private |
+| Rust | `one_or(group: (Condition[]) => Condition, terms: Condition[]): Condition` | private |
+| Rust | `reject_repeated_field(terms: Condition[]): void throws QueryError` | private |
 
 ## `crates/agentwerk/src/agents/tasks/error.rs`
 
@@ -638,11 +673,13 @@ The rules the tables never repeat.
 | both | `.emit_event(event: Event): Event` | pub |
 | both | `.get_task(id: string): Task?` | pub |
 | both | `.get_tasks(): Task[]` | pub |
-| both | `.find_tasks(predicate: Matcher<Task>): Task[]` | pub |
-| Python | `.find_tasks(predicate)`: accepts a `Query` or a callable | |
-| both | `.find_task(predicate: Matcher<Task>): Task?` | pub |
-| both | `.find_events(matcher: Matcher<Event>): Event[]`: an AQL string stands in for the `Query<Event>` | pub |
-| both | `.find_event(matcher: Matcher<Event>): Event?` | pub |
+| both | `.find_tasks(predicate: Matcher<Task>): Task[]`: AQL selects tasks directly or through matching events | pub |
+| Python | `.find_tasks(predicate)`: accepts a `Query`, AQL string, or task callable | |
+| both | `.find_task(predicate: Matcher<Task>): Task?`: singular form of `find_tasks` | pub |
+| Python | `.find_task(predicate)`: accepts a `Query`, AQL string, or task callable | |
+| both | `.find_events(matcher: Matcher<Event>): Event[]`: AQL selects events directly or through matching tasks | pub |
+| both | `.find_event(matcher: Matcher<Event>): Event?`: singular form of `find_events` | pub |
+| Python | `.find_events(matches)` and `.find_event(matches)`: accept a `Query`, AQL string, or event callable | |
 | both | `.cancel_tasks(matches: Matcher<Task>): this` | pub |
 | Python | `.cancel_tasks(matches)`: accepts a `Query` or a callable | |
 | both | `.cancel_all_tasks(): this` | pub |
@@ -655,10 +692,10 @@ The rules the tables never repeat.
 | Rust | `.get_finish_reason(): FinishReason?` | pub |
 | Python | `.get_finish_reason(): str?`: the string it prints as, such as `policy_violated(turns)` | |
 | both | `.get_results(): json[]` | pub |
-| both | `.find_results(matches: Matcher<Task>): json[]` | pub |
-| both | `.find_results(query)`: an AQL string stands in for the `Query` | |
-| both | `.find_result(matches: Matcher<Task>): json?` | pub |
-| both | `.find_result(query)`: an AQL string stands in for the `Query` | |
+| both | `.find_results(matches: Matcher<Task>): json[]`: AQL selects producing tasks directly or through matching events | pub |
+| Python | `.find_results(query)`: accepts a `Query`, AQL string, or task callable | |
+| both | `.find_result(matches: Matcher<Task>): json?`: singular form of `find_results` | pub |
+| Python | `.find_result(query)`: accepts a `Query`, AQL string, or task callable | |
 
 ### Internal
 
@@ -695,10 +732,13 @@ The rules the tables never repeat.
 | Rust | `.label_for(id: string): string?` | private |
 | Rust | `.result_path(id: string): string` | crate |
 | Rust | `.dispatch(task: Task): string` | private |
+| Rust | `.tasks_selected_by(query: Query): Task[]` | private |
 | Rust | `.matching_tasks(query: Query): Task[]` | private |
 | Rust | `.first_matching_task(query: Query): Task?` | private |
-| Python | `Werk.find_task(predicate)`: accepts a `Query` or a callable | |
-| Rust | `.collect_events(query: Query<Event>, wanted: number): Event[]` | private |
+| Rust | `.tasks_referenced_by(query: Query): Task[]` | private |
+| Rust | `.matching_events(query: Query): Event[]` | private |
+| Rust | `.events_referencing_tasks(query: Query): Event[]` | private |
+| Rust | `.collect_events(query: Query, wanted: number): Event[]` | private |
 | Rust | `.pending(matches: Query): boolean` | crate |
 | Rust | `.ending_reason(): FinishReason?` | crate |
 | Rust | `.anything_claimable(): boolean` | private |
@@ -709,7 +749,7 @@ The rules the tables never repeat.
 | Rust | `.has_agent(id: string): boolean` | crate |
 | Rust | `.clone_agents(): Agent[]` | crate |
 | Rust | `.next_event_or_end(stream: Event): Promise<boolean>` | private |
-| Rust | `results_of(matches: Matcher<Task>): Query` | private |
+| Rust | `.result_tasks(matches: Matcher<Task>): Task[]` | private |
 
 ## `crates/agentwerk/src/agents/tasks/trajectory.rs`
 
@@ -2266,24 +2306,24 @@ Binds `providers/`.
 
 ## `crates/agentwerk-py/src/query.rs`
 
-Binds `agents/query.rs`. One class covers both field sets: Python carries no type parameter, so the string is compiled over the task fields and the event fields at once.
+Binds `agents/query.rs`. Python stores the same single, origin-aware compiled query as Rust.
 
 ### Public
 
 | Language | Item | Visibility |
 |----------|------|------------|
-| Rust | `PyQuery { source: string, tasks: Query<Task> throws QueryError, events: Query<Event> throws QueryError }` | python |
-| Rust | `.new(query: string): this throws PyErr`, raising only where both field sets reject the string | python |
+| Rust | `PyQuery { source: string, query: Query }` | python with private fields |
+| Rust | `.new(query: string): this throws PyErr` | python |
 | Rust | `.__repr__(): string` | python |
 
 ### Internal
 
 | Language | Item | Visibility |
 |----------|------|------------|
-| Rust | `rejected(over_tasks: QueryError, over_events: QueryError): PyErr` | private |
 | Rust | `value_error(message: string): PyErr` | private |
-| Rust | `to_task_matcher(arg: any): Query<Task> throws PyErr` | crate |
-| Rust | `to_event_matcher(arg: any): Query<Event> throws PyErr` | crate |
+| Rust | `to_task_matcher(arg: any): Query throws PyErr` | crate |
+| Rust | `to_task_finder(arg: any): Query throws PyErr` | crate |
+| Rust | `to_event_matcher(arg: any): Query throws PyErr` | crate |
 | Rust | `task_predicate(predicate: any, task: Task): boolean` | private |
 | Rust | `event_predicate(predicate: any, event: Event): boolean` | private |
 

--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -349,12 +349,11 @@ The rules the tables never repeat.
 | Rust | `impl Matcher<R> for Query` | pub |
 | Python | an AQL string or a callable stands in for the `Query` wherever one is accepted | |
 | Rust | `Query(Compiled)` | pub with private fields |
-| Python | `Query(query: str)`: one class whose task or event origin is inferred at construction | |
+| Python | `Query(query: str)`: one class whose task, event, or joined source is inferred at construction | |
 | Rust | `.new(query: string): this throws QueryError` | pub |
-| Rust | `.expects_task(): void throws QueryError` | pub, hidden from docs |
 | Rust | `impl From<&str> for Query` | pub |
 | Rust | `impl From<String> for Query` | pub |
-| Rust | `enum QueryError { TermsMissing, FieldUnrecognized, OriginsMixed, OriginMismatch, StatusUnrecognized, TimeMalformed, OperatorNotAllowed, FieldRepeated, TokenRejected, TermUnfinished }` | pub |
+| Rust | `enum QueryError { TermsMissing, FieldUnrecognized, StatusUnrecognized, TimeMalformed, OperatorNotAllowed, FieldRepeated, TokenRejected, TermUnfinished }` | pub |
 | Rust | `impl Display for QueryError` | pub |
 | Rust | `impl Error for QueryError` | pub |
 
@@ -365,14 +364,16 @@ The rules the tables never repeat.
 | Rust | `Query.all(): this` | crate |
 | Rust | `.matches_task(task: Task): boolean` | crate |
 | Rust | `.matches_event(event: Event): boolean` | crate |
+| Rust | `.matches_joined(task: Task, event: Event): boolean` | crate |
 | Rust | `.and(other: Query): this` | crate |
 | Rust | `.is_ordered(): boolean` | crate |
 | Rust | `.sort_tasks(records: Task[]): void` | crate |
 | Rust | `.sort_events(records: Event[]): void` | crate |
+| Rust | `.sort_joined(records: [Task, Event][]): void` | crate |
 | Rust | `.task(): this` | crate |
 | Rust | `.task_if_originless(): this` | crate |
 | Rust | `.event_if_originless(): this` | crate |
-| Rust | `.is_event(): boolean` | crate |
+| Rust | `.origin(): Origin` | crate |
 | Rust | `.assert_origin(expected: Origin): void` | private |
 | Rust | `.and_task_status(status: Status): this` | crate |
 | Rust | `.default_task_status(status: Status): this` | crate |
@@ -396,13 +397,12 @@ The rules the tables never repeat.
 | Rust | `.is_ordered(): boolean` | private |
 | Rust | `.sort_tasks(records: Task[]): void` | private |
 | Rust | `.sort_events(records: Event[]): void` | private |
-| Rust | `.expects(expected: Origin): void throws QueryError` | private |
+| Rust | `.sort_joined(records: [Task, Event][]): void` | private |
 | Rust | `.bind(expected: Origin): void` | private |
 | Rust | `.bind_if_originless(origin: Origin): void` | private |
-| Rust | `enum Origin { Task, Event }` | private |
-| Rust | `.name(): string` | private |
-| Rust | `merge_origins(left: Origin?, right: Origin?): Origin? throws QueryError` | private |
-| Rust | `enum View { Task(Task), Event(Event) }` | private |
+| Rust | `enum Origin { Task, Event, Joined }` | crate |
+| Rust | `merge_origins(left: Origin?, right: Origin?): Origin?` | private |
+| Rust | `enum View { Task(Task), Event(Event), Joined(Task, Event) }` | private |
 | Rust | `.value(field: Field): string?` | private |
 | Rust | `.tie_break(): [number, number]` | private |
 | Rust | `enum Field { TaskId, TaskLabel, TaskStatus, TaskPending, TaskCancelled, TaskAssignee, TaskParentId, TaskInput, TaskResult, TaskErrors, TaskCreated, TaskStarted, TaskFinished, TaskFailed, EventName, EventAgentId, EventTaskId, EventLabel, EventCreated, EventData }` | private |
@@ -443,7 +443,7 @@ The rules the tables never repeat.
 | Rust | `.is_keyword(keyword: string): boolean` | private |
 | Rust | `tokenize(query: string): Token[] throws QueryError` | private |
 | Rust | `parse_query(query: string): [Condition, Sort?, Origin] throws QueryError` | private |
-| Rust | `Parser { tokens: Token[], at: number, origin_field: Field? }` | private |
+| Rust | `Parser { tokens: Token[], at: number, origin: Origin? }` | private |
 | Rust | `.peek(): Token?` | private |
 | Rust | `.peek_after(): Token?` | private |
 | Rust | `.next(): Token?` | private |
@@ -460,7 +460,7 @@ The rules the tables never repeat.
 | Rust | `.time(field: Field): number throws QueryError` | private |
 | Rust | `.values(field: Field): string[] throws QueryError` | private |
 | Rust | `.field(name: string): Field throws QueryError` | private |
-| Rust | `.record_field(field: Field): void throws QueryError` | private |
+| Rust | `.record_field(field: Field): void` | private |
 | Rust | `one_or(group: (Condition[]) => Condition, terms: Condition[]): Condition` | private |
 | Rust | `reject_repeated_field(terms: Condition[]): void throws QueryError` | private |
 
@@ -643,7 +643,7 @@ The rules the tables never repeat.
 | Python | a string, such as `policy_violated(turns)` | |
 | Rust | `.Drained`, `.PolicyViolated(PolicyViolation)`, `.Cancelled` | pub |
 | Rust | `impl Display for FinishReason` | pub |
-| both | `Werk { weak_self: Weak<Werk>, tasks: Record<string, Task>, agents: Agent[], policy: Policy, run: Run, cancel_filters: Query[], terminal_transitions_in_flight: number, stats: Stats, event_handlers: EventHandler[], awaited_events: AwaitedEvents, event_stream: Sender<Event>, dir: string, events_lock: void, join_handle: JoinHandle<void>?, next_task_id: number? }` | pub |
+| both | `Werk { weak_self: Weak<Werk>, tasks: Record<string, Task>, agents: Agent[], policy: Policy, run: Run, cancel_filters: CancelFilter[], terminal_transitions_in_flight: number, stats: Stats, event_handlers: EventHandler[], awaited_events: AwaitedEvents, event_stream: Sender<Event>, dir: string, events_lock: void, join_handle: JoinHandle<void>?, next_task_id: number? }` | pub |
 | Rust | `.new(): this` | pub |
 | Python | `Werk()` | |
 | both | `.load(werk_dir: string): this throws io::Error` | pub |
@@ -673,26 +673,26 @@ The rules the tables never repeat.
 | both | `.emit_event(event: Event): Event` | pub |
 | both | `.get_task(id: string): Task?` | pub |
 | both | `.get_tasks(): Task[]` | pub |
-| both | `.find_tasks(predicate: Matcher<Task>): Task[]`: AQL selects tasks directly or through matching events | pub |
+| both | `.find_tasks(predicate: Matcher<Task>): Task[]`: AQL selects tasks directly, through matching events, or through joined task-event rows | pub |
 | Python | `.find_tasks(predicate)`: accepts a `Query`, AQL string, or task callable | |
 | both | `.find_task(predicate: Matcher<Task>): Task?`: singular form of `find_tasks` | pub |
 | Python | `.find_task(predicate)`: accepts a `Query`, AQL string, or task callable | |
-| both | `.find_events(matcher: Matcher<Event>): Event[]`: AQL selects events directly or through matching tasks | pub |
+| both | `.find_events(matcher: Matcher<Event>): Event[]`: AQL selects events directly, through matching tasks, or through joined task-event rows | pub |
 | both | `.find_event(matcher: Matcher<Event>): Event?`: singular form of `find_events` | pub |
 | Python | `.find_events(matches)` and `.find_event(matches)`: accept a `Query`, AQL string, or event callable | |
-| both | `.cancel_tasks(matches: Matcher<Task>): this` | pub |
+| both | `.cancel_tasks(matches: Matcher<Task>): this`: Task AQL remains live; Event and Joined AQL snapshot current task IDs | pub |
 | Python | `.cancel_tasks(matches)`: accepts a `Query` or a callable | |
 | both | `.cancel_all_tasks(): this` | pub |
 | both | `.add_agent(agent: Agent): this` | pub |
 | both | `.start(): this` | pub |
-| both | `.finish_tasks(matches: Matcher<Task>): Promise<json[]>` | pub |
+| both | `.finish_tasks(matches: Matcher<Task>): Promise<json[]>`: Event and Joined AQL snapshot current task IDs | pub |
 | Python | `.finish_tasks(matches)`: accepts a `Query` or a callable | |
 | both | `.finish_all_tasks(): Promise<json[]>` | pub |
 | both | `.finish_task(matches: Matcher<Task>): Promise<json?>` | pub |
 | Rust | `.get_finish_reason(): FinishReason?` | pub |
 | Python | `.get_finish_reason(): str?`: the string it prints as, such as `policy_violated(turns)` | |
 | both | `.get_results(): json[]` | pub |
-| both | `.find_results(matches: Matcher<Task>): json[]`: AQL selects producing tasks directly or through matching events | pub |
+| both | `.find_results(matches: Matcher<Task>): json[]`: AQL selects producing tasks directly, through matching events, or through joined task-event rows | pub |
 | Python | `.find_results(query)`: accepts a `Query`, AQL string, or task callable | |
 | both | `.find_result(matches: Matcher<Task>): json?`: singular form of `find_results` | pub |
 | Python | `.find_result(query)`: accepts a `Query`, AQL string, or task callable | |
@@ -703,6 +703,8 @@ The rules the tables never repeat.
 |----------|------|------------|
 | Rust | `EventHandler = (werk: Werk, event: Event) => void` | private |
 | Rust | `EVENT_STREAM_CAPACITY: number = 1024` | private |
+| Rust | `enum CancelFilter { Live(Query), Snapshot(Set<string>) }` | crate |
+| Rust | `CancelFilter.matches(task: Task): boolean` | super |
 | Rust | `is_task_event(event: Event): boolean` | private |
 | Rust | `is_failure(event: Event): boolean` | private |
 | Rust | `is_recorded_failure(event: Event): boolean` | private |
@@ -732,14 +734,18 @@ The rules the tables never repeat.
 | Rust | `.label_for(id: string): string?` | private |
 | Rust | `.result_path(id: string): string` | crate |
 | Rust | `.dispatch(task: Task): string` | private |
-| Rust | `.tasks_selected_by(query: Query): Task[]` | private |
+| Rust | `.tasks_selected_by(query: Query): Task[]` | super |
 | Rust | `.matching_tasks(query: Query): Task[]` | private |
 | Rust | `.first_matching_task(query: Query): Task?` | private |
 | Rust | `.tasks_referenced_by(query: Query): Task[]` | private |
+| Rust | `.matching_task_events(query: Query): [Task, Event][]` | private |
+| Rust | `.events_selected_by(query: Query): Event[]` | private |
 | Rust | `.matching_events(query: Query): Event[]` | private |
 | Rust | `.events_referencing_tasks(query: Query): Event[]` | private |
 | Rust | `.collect_events(query: Query, wanted: number): Event[]` | private |
 | Rust | `.pending(matches: Query): boolean` | crate |
+| Rust | `.pending_ids(ids: string[]): boolean` | private |
+| Rust | `.task_is_pending(task: Task, interactive: Set<string>): boolean` | private |
 | Rust | `.ending_reason(): FinishReason?` | crate |
 | Rust | `.anything_claimable(): boolean` | private |
 | Rust | `.anything_pending(): boolean` | private |
@@ -2322,7 +2328,6 @@ Binds `agents/query.rs`. Python stores the same single, origin-aware compiled qu
 |----------|------|------------|
 | Rust | `value_error(message: string): PyErr` | private |
 | Rust | `to_task_matcher(arg: any): Query throws PyErr` | crate |
-| Rust | `to_task_finder(arg: any): Query throws PyErr` | crate |
 | Rust | `to_event_matcher(arg: any): Query throws PyErr` | crate |
 | Rust | `task_predicate(predicate: any, task: Task): boolean` | private |
 | Rust | `event_predicate(predicate: any, event: Event): boolean` | private |

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test test_integration fmt clean update use_case litellm bump doc hooks skills python python_test python_test_integration check_names
+.PHONY: build test test_integration bench_aql fmt clean update use_case litellm bump doc hooks skills python python_test python_test_integration check_names
 
 CLAUDE_SKILLS_DIR := $(HOME)/.claude/skills
 OPENCODE_SKILLS_DIR := $(HOME)/.config/opencode/skills
@@ -27,6 +27,12 @@ ifdef name
 else
 	RUSTFLAGS="-D warnings" cargo test --test integration -- --nocapture --test-threads=1
 endif
+
+# Benchmark AQL compilation and selection. Pass benchmark arguments with args.
+# Usage: make bench_aql
+#        make bench_aql args='joined/find_tasks --save-baseline before'
+bench_aql:
+	cargo bench -p agentwerk --bench aql -- $(args)
 
 # Build and install the Python bindings into the active environment.
 python:

--- a/README.md
+++ b/README.md
@@ -302,24 +302,21 @@ See [`Werk`](https://docs.rs/agentwerk/latest/agentwerk/struct.Werk.html).
 
 ### Queries
 
-Agent Query Language (AQL) filters tasks, events, and results. Pass an AQL
-string directly, or compile it with `Query::new` to reuse it.
-
-Each query selects tasks with `task.*` fields or events with `event.*` fields;
-it cannot mix the two. All `find_*` methods accept either query. A task query
-passed to `find_events` returns events attached to the matching tasks. An event
-query passed to a task or result finder returns the referenced tasks or their
-results.
+Agent Query Language (AQL) filters tasks and events. Pass an AQL string
+directly, or compile it with `Query::new` to reuse it.
 
 ```rust
 // Find tasks labeled `scan`.
-werk.find_tasks("task.label = scan");
+werk.find_tasks("scan");
 
 // Find tasks referenced by failed tool-call events.
 werk.find_tasks("event.name = tool_call_failed");
 
 // Find events attached to tasks labeled `scan`.
-werk.find_events("task.label = scan");
+werk.find_events("scan");
+
+// Find failed tool calls from scan tasks.
+werk.find_events("scan AND event.name = tool_call_failed");
 
 // Find the result produced by task `t-3`.
 werk.find_results("t-3");
@@ -341,7 +338,8 @@ werk.find_results("event.name = task_finished");
 | **Search** | `field ~ text`, `field !~ text` | Include or exclude case-insensitive text. |
 | **Compare** | `field > value`, `>=`, `<`, `<=` | Compare a time field. |
 | **Combine** | `A AND B`, `A OR B`, `NOT A`, `(A OR B)` | Combine or group conditions. |
-| **Task ID** | `t-3` | Short for `task.id = t-3`; this is the only unqualified form. |
+| **Task label** | `scan`, `"needs review"` | Short for `task.label = scan`; quote labels containing spaces or query words. |
+| **Task ID** | `t-3` | Short for `task.id = t-3`; IDs take precedence over labels. |
 | **Sort** | `ORDER BY field DESC` | Sort matches; `ASC` is the default. |
 
 #### Fields
@@ -351,9 +349,17 @@ werk.find_results("event.name = task_finished");
 | **Task** | `task.id`, `task.label`, `task.status`, `task.pending`, `task.cancelled`, `task.assignee`, `task.parent_id`, `task.input`, `task.result`, `task.errors`, `task.created`, `task.started`, `task.finished`, `task.failed` |
 | **Event** | `event.name`, `event.agent_id`, `event.task_id`, `event.label`, `event.created`, `event.data` |
 
-Result finders return raw results from referenced tasks. Task queries default
-`task.status` to `finished` unless they name a status; Event queries always
-select finished tasks. Tasks without results are skipped.
+Queries using both namespaces are inner joins: events without a task and events
+whose task no longer exists do not match. Without `ORDER BY`, joined matches
+stay in event-log order. Ordering may use a task or event field.
+
+Result finders return raw task results. They require `task.result` to be present
+and default `task.status` to `finished` unless the query names a status.
+
+Task, event, and joined AQL also work with `finish_*` and `cancel_tasks`. Event
+and joined queries snapshot the task IDs they reference when the operation
+starts. Task-only cancellation stays live and also applies to later matching
+tasks.
 
 #### Rules
 
@@ -366,7 +372,7 @@ Write the field, followed by what it must match:
 
 Missing values do not match `!=`. For example, `task.label != scan` leaves out tasks with no label. To include them, use `task.label IS EMPTY OR task.label != scan`.
 
-Quote values containing spaces: `task.label = "needs review"`. Put lists in parentheses: `task.label IN (scan, report)`.
+Use a lone value as task-label shorthand: `scan` means `task.label = scan`, and `"needs review"` supports spaces or query words. Qualify fields in full expressions such as `task.label = scan`. Put lists in parentheses: `task.label IN (scan, report)`.
 
 Use parentheses when mixing `AND` and `OR` to make the order clear. `NOT` applies to the condition or parenthesized group after it. Query words such as `AND` ignore case; labels and IDs do not.
 
@@ -377,7 +383,7 @@ Times accept UTC dates such as `2026-08-30`, epoch milliseconds, or offsets such
 #### Examples
 
 ```rust
-werk.find_results("task.label = report AND task.result ~ risk");
+werk.find_results("report AND task.result ~ risk");
 werk.find_tasks("task.errors ~ tool_call_failed");
 werk.find_tasks("task.status = todo AND task.assignee IS EMPTY");
 werk.find_tasks("task.failed > -1h ORDER BY task.failed DESC");

--- a/README.md
+++ b/README.md
@@ -302,12 +302,30 @@ See [`Werk`](https://docs.rs/agentwerk/latest/agentwerk/struct.Werk.html).
 
 ### Queries
 
-Use queries to choose tasks by label, ID, status, or time.
+Agent Query Language (AQL) filters tasks, events, and results. Pass an AQL
+string directly, or compile it with `Query::new` to reuse it.
+
+Each query selects tasks with `task.*` fields or events with `event.*` fields;
+it cannot mix the two. All `find_*` methods accept either query. A task query
+passed to `find_events` returns events attached to the matching tasks. An event
+query passed to a task or result finder returns the referenced tasks or their
+results.
 
 ```rust
-werk.find_tasks("scan");                          // Tasks labeled scan.
-werk.find_results("t-3");                         // The result of task t-3.
-werk.find_results("scan ORDER BY finished DESC"); // Scan results, newest first.
+// Find tasks labeled `scan`.
+werk.find_tasks("task.label = scan");
+
+// Find tasks referenced by failed tool-call events.
+werk.find_tasks("event.name = tool_call_failed");
+
+// Find events attached to tasks labeled `scan`.
+werk.find_events("task.label = scan");
+
+// Find the result produced by task `t-3`.
+werk.find_results("t-3");
+
+// Find results produced by tasks with finished events.
+werk.find_results("event.name = task_finished");
 ```
 
 <details>
@@ -323,45 +341,46 @@ werk.find_results("scan ORDER BY finished DESC"); // Scan results, newest first.
 | **Search** | `field ~ text`, `field !~ text` | Include or exclude case-insensitive text. |
 | **Compare** | `field > value`, `>=`, `<`, `<=` | Compare a time field. |
 | **Combine** | `A AND B`, `A OR B`, `NOT A`, `(A OR B)` | Combine or group conditions. |
-| **Shorthand** | `scan`, `t-3` | Short for `label = scan` and `id = t-3`. |
+| **Task ID** | `t-3` | Short for `task.id = t-3`; this is the only unqualified form. |
 | **Sort** | `ORDER BY field DESC` | Sort matches; `ASC` is the default. |
 
 #### Fields
 
-| Kind | Fields | Meaning |
-|------|--------|---------|
-| **Identity** | `id`, `label`, `status` | Task identity and current state (`todo`, `in_progress`, `finished`, or `failed`). |
-| **Run state** | `pending`, `cancelled` | Whether this run may schedule the task. |
-| **Relationship** | `agent`, `parent` | Claiming agent and handover parent. |
-| **Text** | `task`, `result`, `errors` | Task body, result, and recorded failures. |
-| **Time** | `created`, `started`, `finished`, `failed` | Creation, start, finish, and failure times. |
+| Origin | Fields |
+|--------|--------|
+| **Task** | `task.id`, `task.label`, `task.status`, `task.pending`, `task.cancelled`, `task.assignee`, `task.parent_id`, `task.input`, `task.result`, `task.errors`, `task.created`, `task.started`, `task.finished`, `task.failed` |
+| **Event** | `event.name`, `event.agent_id`, `event.task_id`, `event.label`, `event.created`, `event.data` |
+
+Result finders return raw results from referenced tasks. Task queries default
+`task.status` to `finished` unless they name a status; Event queries always
+select finished tasks. Tasks without results are skipped.
 
 #### Rules
 
 Write the field, followed by what it must match:
 
-- Exact value: `label = scan`
-- Contains text: `result ~ timeout`
-- Time range: `failed > -1h`
-- Has no value: `agent IS EMPTY`
+- Exact value: `task.label = scan`
+- Contains text: `task.result ~ timeout`
+- Time range: `task.failed > -1h`
+- Has no value: `task.assignee IS EMPTY`
 
-Missing values do not match `!=`. For example, `label != scan` leaves out tasks with no label. To include them, use `label IS EMPTY OR label != scan`.
+Missing values do not match `!=`. For example, `task.label != scan` leaves out tasks with no label. To include them, use `task.label IS EMPTY OR task.label != scan`.
 
-Quote values containing spaces: `label = "needs review"`. Put lists in parentheses: `label IN (scan, report)`.
+Quote values containing spaces: `task.label = "needs review"`. Put lists in parentheses: `task.label IN (scan, report)`.
 
 Use parentheses when mixing `AND` and `OR` to make the order clear. `NOT` applies to the condition or parenthesized group after it. Query words such as `AND` ignore case; labels and IDs do not.
 
 Times accept UTC dates such as `2026-08-30`, epoch milliseconds, or offsets such as `-30m`, `-2h`, `-7d`, and `-1w`.
 
-`ORDER BY field` sorts from lowest to highest. Add `DESC` for the reverse. Tasks with no value for that field come last. Without `ORDER BY`, tasks remain in creation order.
+`ORDER BY field` sorts source records from lowest to highest. Add `DESC` for the reverse. Records with no value for that field come last. Projected tasks and results follow matching event order, with each task returned once. Projected events are grouped by matching task order and retain log order within each task.
 
 #### Examples
 
 ```rust
-werk.find_results("report AND result ~ risk");           // reports that mention risk
-werk.find_tasks("errors ~ tool_call_failed");          // saw a tool call fail
-werk.find_tasks("status = todo AND agent IS EMPTY");   // waiting, never claimed
-werk.find_tasks("failed > -1h ORDER BY failed DESC");  // the last hour's failures
+werk.find_results("task.label = report AND task.result ~ risk");
+werk.find_tasks("task.errors ~ tool_call_failed");
+werk.find_tasks("task.status = todo AND task.assignee IS EMPTY");
+werk.find_tasks("task.failed > -1h ORDER BY task.failed DESC");
 werk.find_tasks(|t: &Task| t.get_replies().len() > 4);   // a closure, for what no field carries
 ```
 
@@ -391,7 +410,7 @@ if let Some(answer) = werk.finish_task(task).await {
 | **Cancel** | `cancel_tasks(query)` | Stop work on matching tasks. |
 | | `cancel_all_tasks()` | Stop work on every task. |
 
-Cancellation applies only to the current execution: it does not change `status` or remain attached to the task. `start()` clears cancellation so unfinished tasks can resume. Use `task.is_cancelled()` for a task you hold, or `cancelled = true` and `pending = true` to select by execution state.
+Cancellation applies only to the current execution: it does not change `status` or remain attached to the task. `start()` clears cancellation so unfinished tasks can resume. Use `task.is_cancelled()` for a task you hold, or `task.cancelled = true` and `task.pending = true` to select by execution state.
 
 Task members:
 
@@ -756,7 +775,7 @@ werk.on_event(|_, event| {
     println!("{}", event.get_name());
 });
 
-let events = werk.find_events("event = event_name");
+let events = werk.find_events("event.name = event_name");
 ```
 
 Event names are open-ended; lowercase snake case is conventional. Publishing an event does not change the task's status. The exception is the built-in `task_finished` event, which has the same result and handover behavior as `FinishTool`:
@@ -911,8 +930,8 @@ Events are saved to `.agentwerk/events.jsonl`. `text_chunk_received` events are 
 | Method | Description |
 |--------|-------------|
 | `emit_event(event)` | Publish an event for querying and observation. |
-| `find_event(query)` | Get the first matching event in query order. Without `ORDER BY`, this is the earliest one. |
-| `find_events(query)` | Get every matching event in query order. Without `ORDER BY`, this is oldest first. |
+| `find_event(query)` | Get the first event selected directly or through a matching task. |
+| `find_events(query)` | Get events selected directly or through matching tasks, in query order. |
 | `get_input_tokens()` / `get_output_tokens()` | Get token counts across the run's requests. |
 | `get_duration()` | Get the elapsed execution duration. |
 
@@ -926,30 +945,26 @@ An event handler usually checks `get_name()` and then reads its payload with `ge
 You can query events with AQL or a condition you supply.
 
 ```rust
-werk.find_events("tool_call_failed");
-werk.find_events("event = request_finished AND agent = research-1");
-werk.find_events("task = t-3 ORDER BY created DESC");
-werk.find_events("payload ~ timeout AND created > -1h");
+werk.find_events("event.name = tool_call_failed");
+werk.find_events("event.name = request_finished AND event.agent_id = research-1");
+werk.find_events("event.task_id = t-3 ORDER BY event.created DESC");
+werk.find_events("event.data ~ timeout AND event.created > -1h");
 ```
 
 | | Field | Description |
 |-|-------|-------------|
-| **Match** | `event` | The event name, such as `run_started` or `tool_call_failed`. |
-| | `agent` | The attributed agent ID, when the event has agent context. |
-| | `task` | The attributed task ID, when the event has task context. |
-| | `label` | The attributed task's label, when the task is known and labelled. |
-| **Search** | `payload` | Search the event name and data together as text. |
-| **Compare** | `created` | When the event was recorded. |
+| **Match** | `event.name` | The event name, such as `run_started` or `tool_call_failed`. |
+| | `event.agent_id` | The attributed agent ID, when the event has agent context. |
+| | `event.task_id` | The attributed task ID, when the event has task context. |
+| | `event.label` | The attributed task's label, when the task is known and labelled. |
+| **Search** | `event.data` | Search only the serialized raw event data as text. |
+| **Compare** | `event.created` | When the event was recorded. |
 
-Event queries follow the same [rules as task queries](#queries). Match `event`, `agent`, `task`, and `label` exactly; use `~` to search `payload`; and use `<` or `>` with `created`. Some events have no agent, task, or label. Find them with `IS EMPTY`. Without `ORDER BY`, events remain oldest first.
+Event queries follow the same [rules as task queries](#queries). Some events
+have no agent, task, or label; find them with `IS EMPTY`. `event.data` does not
+include the event name. Without `ORDER BY`, events remain oldest first.
 
-You can also search with one word. Agentwerk reads it as:
-
-1. A task ID such as `t-3` means `task = t-3`.
-2. A built-in event name such as `tool_call_failed` means `event = tool_call_failed`.
-3. Any other value such as `scan` means `label = scan`.
-
-For your own event names, write `event = document_indexed`. If a label has the same name as a built-in event, write `label = knowledge_read`.
+For your own event names, write `event.name = document_indexed`. Event labels use `event.label`, so they are never ambiguous with names.
 
 </details>
 

--- a/agentdocs/architecture.md
+++ b/agentdocs/architecture.md
@@ -22,10 +22,10 @@ The invariants that govern orchestration, tools, providers, events, and durable 
 
 ## Queries and Lifecycle
 
-**Use AQL for every string selection over tasks or events.**
+**Use origin-qualified AQL for every string selection over tasks or events.**
 
-- Accept `Matcher<Task>` in task selectors; reserve `Query<Event>` for recorded events.
-- Treat a bare `t-<n>` as an ID and another bare word as a label; require `label = t-3` for an ID-shaped label.
+- Keep `Query` non-generic; its namespaced fields infer one private task or event source origin at runtime. Read finders may project between them through `Event::task_id`; lifecycle operations remain Task-only.
+- Treat a bare `t-<n>` as `task.id = t-<n>`; reject every other unqualified field or shorthand.
 - Use `Query::new` for runtime input so invalid AQL returns `QueryError`; infallible string conversions may panic.
 - Define pending work as unfinished, uncancelled work selected by the query; a task paused for caller input does not keep a `finish_*` wait open.
 - Keep cancellation scoped to the current run: `start()` clears cancellation without changing `Status`.

--- a/agentdocs/architecture.md
+++ b/agentdocs/architecture.md
@@ -22,10 +22,11 @@ The invariants that govern orchestration, tools, providers, events, and durable 
 
 ## Queries and Lifecycle
 
-**Use origin-qualified AQL for every string selection over tasks or events.**
+**Use origin-qualified fields in AQL selections over tasks or events.**
 
-- Keep `Query` non-generic; its namespaced fields infer one private task or event source origin at runtime. Read finders may project between them through `Event::task_id`; lifecycle operations remain Task-only.
-- Treat a bare `t-<n>` as `task.id = t-<n>`; reject every other unqualified field or shorthand.
+- Keep `Query` non-generic; its namespaced fields infer a private task, event, or joined source at runtime. A joined query evaluates `(Task, Event)` pairs linked through `Event::task_id`, and every finder or lifecycle operation projects those matches to tasks.
+- Snapshot task IDs when an event or joined query enters a lifecycle operation. Keep task-only cancellation queries live so they also apply to tasks added later.
+- Treat a lone value as `task.label = value`, except that a bare `t-<n>` takes precedence as `task.id = t-<n>`. Keep fields in full expressions origin-qualified.
 - Use `Query::new` for runtime input so invalid AQL returns `QueryError`; infallible string conversions may panic.
 - Define pending work as unfinished, uncancelled work selected by the query; a task paused for caller input does not keep a `finish_*` wait open.
 - Keep cancellation scoped to the current run: `start()` clears cancellation without changing `Status`.

--- a/agentdocs/workflow.md
+++ b/agentdocs/workflow.md
@@ -34,6 +34,23 @@ make test_integration name=command_usage
 - Set `name=<test name>` to filter the Rust integration binary.
 - Export provider variables in the shell before live tests; the target does not load a `.env` file.
 
+## AQL Benchmarks
+
+**Compare parser, matcher, storage, and join costs without making machine timing a CI contract.**
+
+```bash
+make bench_aql
+make bench_aql args='joined/find_tasks --save-baseline before'
+make bench_aql args='joined/find_tasks --baseline before'
+make bench_aql args='joined/find_tasks --profile-time 20'
+```
+
+- The full suite builds deterministic sessions up to 10,000 tasks and 100,000 events before measurement starts.
+- The harness reports warm-cache median latency, its 10th–90th percentile range, and throughput without adding a benchmarking dependency.
+- Saved baselines live under `target/aql-bench` and compare changes on the same machine.
+- Use `--profile-time` with a CPU or allocation profiler to repeat one named scenario without sampling overhead.
+- Benchmarks are diagnostic and local. CI compiles them but enforces no machine-dependent timing threshold.
+
 ## Python Bindings
 
 **Build and test the extension inside an activated virtual environment.**

--- a/crates/agentwerk-py/README.md
+++ b/crates/agentwerk-py/README.md
@@ -328,24 +328,26 @@ See [`Werk`](https://docs.rs/agentwerk/latest/agentwerk/struct.Werk.html).
 
 ### Queries
 
-Agent Query Language (AQL) filters tasks, events, and results. Pass an AQL
-string directly, or compile it with `Query` to reuse it.
+Agent Query Language (AQL) filters tasks and events. Pass an AQL string
+directly, or compile it with `Query` to reuse it.
 
-Each query selects tasks with `task.*` fields or events with `event.*` fields;
-it cannot mix the two. All `find_*` methods accept either query. A task query
-passed to `find_events` returns events attached to the matching tasks. An event
-query passed to a task or result finder returns the referenced tasks or their
-results.
+Use `task.*` fields for task state and `event.*` fields for recorded activity.
+You can combine both in one query: AQL evaluates each task together with each
+event that references it through `event.task_id`. The method you call decides
+whether those matches return tasks, events, or task results.
 
 ```python
 # Find tasks labeled "scan".
-werk.find_tasks("task.label = scan")
+werk.find_tasks("scan")
 
 # Find tasks referenced by failed tool-call events.
 werk.find_tasks("event.name = tool_call_failed")
 
 # Find events attached to tasks labeled "scan".
-werk.find_events("task.label = scan")
+werk.find_events("scan")
+
+# Find failed tool calls from scan tasks.
+werk.find_events("scan AND event.name = tool_call_failed")
 
 # Find the result produced by task "t-3".
 werk.find_results("t-3")
@@ -367,7 +369,8 @@ werk.find_results("event.name = task_finished")
 | **Search** | `field ~ text`, `field !~ text` | Include or exclude case-insensitive text. |
 | **Compare** | `field > value`, `>=`, `<`, `<=` | Compare a time field. |
 | **Combine** | `A AND B`, `A OR B`, `NOT A`, `(A OR B)` | Combine or group conditions. |
-| **Task ID** | `t-3` | Short for `task.id = t-3`; this is the only unqualified form. |
+| **Task label** | `scan`, `"needs review"` | Short for `task.label = scan`; quote labels containing spaces or query words. |
+| **Task ID** | `t-3` | Short for `task.id = t-3`; IDs take precedence over labels. |
 | **Sort** | `ORDER BY field DESC` | Sort matches; `ASC` is the default. |
 
 #### Fields
@@ -377,9 +380,17 @@ werk.find_results("event.name = task_finished")
 | **Task** | `task.id`, `task.label`, `task.status`, `task.pending`, `task.cancelled`, `task.assignee`, `task.parent_id`, `task.input`, `task.result`, `task.errors`, `task.created`, `task.started`, `task.finished`, `task.failed` |
 | **Event** | `event.name`, `event.agent_id`, `event.task_id`, `event.label`, `event.created`, `event.data` |
 
-Result finders return raw results from referenced tasks. Task queries default
-`task.status` to `finished` unless they name a status; Event queries always
-select finished tasks. Tasks without results are skipped.
+Queries using both namespaces are inner joins: events without a task and events
+whose task no longer exists do not match. Without `ORDER BY`, joined matches
+stay in event-log order. Ordering may use a task or event field.
+
+Result finders return raw task results. They require `task.result` to be present
+and default `task.status` to `finished` unless the query names a status.
+
+Task, event, and joined AQL also work with `finish_*` and `cancel_tasks`. Event
+and joined queries snapshot the task IDs they reference when the operation
+starts. Task-only cancellation stays live and also applies to later matching
+tasks.
 
 #### Rules
 
@@ -392,7 +403,7 @@ Write the field, followed by what it must match:
 
 Missing values do not match `!=`. For example, `task.label != scan` leaves out tasks with no label. To include them, use `task.label IS EMPTY OR task.label != scan`.
 
-Quote values containing spaces: `task.label = "needs review"`. Put lists in parentheses: `task.label IN (scan, report)`.
+Use a lone value as task-label shorthand: `scan` means `task.label = scan`, and `"needs review"` supports spaces or query words. Qualify fields in full expressions such as `task.label = scan`. Put lists in parentheses: `task.label IN (scan, report)`.
 
 Use parentheses when mixing `AND` and `OR` to make the order clear. `NOT` applies to the condition or parenthesized group after it. Query words such as `AND` ignore case; labels and IDs do not.
 
@@ -403,7 +414,7 @@ Relative times such as `-30m`, `-2h`, `-7d`, and `-1w` are measured when the que
 #### Examples
 
 ```python
-werk.find_results("task.label = report AND task.result ~ risk")
+werk.find_results("report AND task.result ~ risk")
 werk.find_tasks("task.errors ~ tool_call_failed")
 werk.find_tasks("task.status = todo AND task.assignee IS EMPTY")
 werk.find_tasks("task.failed > -1h ORDER BY task.failed DESC")

--- a/crates/agentwerk-py/README.md
+++ b/crates/agentwerk-py/README.md
@@ -328,12 +328,30 @@ See [`Werk`](https://docs.rs/agentwerk/latest/agentwerk/struct.Werk.html).
 
 ### Queries
 
-Use queries to choose tasks by label, ID, status, or time.
+Agent Query Language (AQL) filters tasks, events, and results. Pass an AQL
+string directly, or compile it with `Query` to reuse it.
+
+Each query selects tasks with `task.*` fields or events with `event.*` fields;
+it cannot mix the two. All `find_*` methods accept either query. A task query
+passed to `find_events` returns events attached to the matching tasks. An event
+query passed to a task or result finder returns the referenced tasks or their
+results.
 
 ```python
-werk.find_tasks("scan")                          # Tasks labeled scan.
-werk.find_results("t-3")                         # The result of task t-3.
-werk.find_results("scan ORDER BY finished DESC") # Scan results, newest first.
+# Find tasks labeled "scan".
+werk.find_tasks("task.label = scan")
+
+# Find tasks referenced by failed tool-call events.
+werk.find_tasks("event.name = tool_call_failed")
+
+# Find events attached to tasks labeled "scan".
+werk.find_events("task.label = scan")
+
+# Find the result produced by task "t-3".
+werk.find_results("t-3")
+
+# Find results produced by tasks with finished events.
+werk.find_results("event.name = task_finished")
 ```
 
 <details>
@@ -349,45 +367,46 @@ werk.find_results("scan ORDER BY finished DESC") # Scan results, newest first.
 | **Search** | `field ~ text`, `field !~ text` | Include or exclude case-insensitive text. |
 | **Compare** | `field > value`, `>=`, `<`, `<=` | Compare a time field. |
 | **Combine** | `A AND B`, `A OR B`, `NOT A`, `(A OR B)` | Combine or group conditions. |
-| **Shorthand** | `scan`, `t-3` | Short for `label = scan` and `id = t-3`. |
+| **Task ID** | `t-3` | Short for `task.id = t-3`; this is the only unqualified form. |
 | **Sort** | `ORDER BY field DESC` | Sort matches; `ASC` is the default. |
 
 #### Fields
 
-| Kind | Fields | Meaning |
-|------|--------|---------|
-| **Identity** | `id`, `label`, `status` | Task identity and current state. |
-| **Run state** | `pending`, `cancelled` | Whether this run may schedule the task. |
-| **Relationship** | `agent`, `parent` | Claiming agent and handover parent. |
-| **Text** | `task`, `result`, `errors` | Task body, result, and recorded failures. |
-| **Time** | `created`, `started`, `finished`, `failed` | Creation, start, finish, and failure times. |
+| Origin | Fields |
+|--------|--------|
+| **Task** | `task.id`, `task.label`, `task.status`, `task.pending`, `task.cancelled`, `task.assignee`, `task.parent_id`, `task.input`, `task.result`, `task.errors`, `task.created`, `task.started`, `task.finished`, `task.failed` |
+| **Event** | `event.name`, `event.agent_id`, `event.task_id`, `event.label`, `event.created`, `event.data` |
+
+Result finders return raw results from referenced tasks. Task queries default
+`task.status` to `finished` unless they name a status; Event queries always
+select finished tasks. Tasks without results are skipped.
 
 #### Rules
 
 Write the field, followed by what it must match:
 
-- Exact value: `label = scan`
-- Contains text: `result ~ timeout`
-- Time range: `failed > -1h`
-- Has no value: `agent IS EMPTY`
+- Exact value: `task.label = scan`
+- Contains text: `task.result ~ timeout`
+- Time range: `task.failed > -1h`
+- Has no value: `task.assignee IS EMPTY`
 
-Missing values do not match `!=`. For example, `label != scan` leaves out tasks with no label. To include them, use `label IS EMPTY OR label != scan`.
+Missing values do not match `!=`. For example, `task.label != scan` leaves out tasks with no label. To include them, use `task.label IS EMPTY OR task.label != scan`.
 
-Quote values containing spaces: `label = "needs review"`. Put lists in parentheses: `label IN (scan, report)`.
+Quote values containing spaces: `task.label = "needs review"`. Put lists in parentheses: `task.label IN (scan, report)`.
 
 Use parentheses when mixing `AND` and `OR` to make the order clear. `NOT` applies to the condition or parenthesized group after it. Query words such as `AND` ignore case; labels and IDs do not.
 
 Relative times such as `-30m`, `-2h`, `-7d`, and `-1w` are measured when the query runs.
 
-`ORDER BY field` sorts from lowest to highest. Add `DESC` for the reverse. Tasks with no value for that field come last. Without `ORDER BY`, tasks remain in creation order.
+`ORDER BY field` sorts source records from lowest to highest. Add `DESC` for the reverse. Records with no value for that field come last. Projected tasks and results follow matching event order, with each task returned once. Projected events are grouped by matching task order and retain log order within each task.
 
 #### Examples
 
 ```python
-werk.find_results("report AND result ~ risk")           # reports that mention risk
-werk.find_tasks("errors ~ tool_call_failed")          # saw a tool call fail
-werk.find_tasks("status = todo AND agent IS EMPTY")   # waiting, never claimed
-werk.find_tasks("failed > -1h ORDER BY failed DESC")  # the last hour's failures
+werk.find_results("task.label = report AND task.result ~ risk")
+werk.find_tasks("task.errors ~ tool_call_failed")
+werk.find_tasks("task.status = todo AND task.assignee IS EMPTY")
+werk.find_tasks("task.failed > -1h ORDER BY task.failed DESC")
 werk.find_tasks(lambda t: len(t.get_replies()) > 4)       # a callable, for what no field carries
 ```
 
@@ -417,7 +436,7 @@ if answer is not None:
 | **Cancel** | `cancel_tasks(query)` | Stop work on matching tasks. |
 | | `cancel_all_tasks()` | Stop work on every task. |
 
-Cancellation applies only to the current execution: it does not change `status` or remain attached to the task. `start()` clears cancellation so unfinished tasks can resume. Use `task.is_cancelled()` for a task you hold, or `cancelled = true` and `pending = true` to select by execution state.
+Cancellation applies only to the current execution: it does not change `status` or remain attached to the task. `start()` clears cancellation so unfinished tasks can resume. Use `task.is_cancelled()` for a task you hold, or `task.cancelled = true` and `task.pending = true` to select by execution state.
 
 Task members:
 
@@ -770,7 +789,7 @@ Agentwerk records the current task and agent on every event. Werk handlers can r
 
 ```python
 werk.on_event(lambda _, event: print(event.get_name()))
-events = werk.find_events("event = event_name")
+events = werk.find_events("event.name = event_name")
 ```
 
 Event names are open-ended; lowercase snake case is conventional. Publishing an event does not change the task's status. The exception is the built-in `task_finished` event, which has the same result and handover behavior as `FinishTool()`:
@@ -915,8 +934,8 @@ Events are saved to `.agentwerk/events.jsonl`. `text_chunk_received` events are 
 | Method | Description |
 |--------|-------------|
 | `emit_event(event)` | Publish an event for querying and observation. |
-| `find_event(query)` | Get the first matching event in query order. Without `ORDER BY`, this is the earliest one. |
-| `find_events(query)` | Get every matching event in query order. Without `ORDER BY`, this is oldest first. |
+| `find_event(query)` | Get the first event selected directly or through a matching task. |
+| `find_events(query)` | Get events selected directly or through matching tasks, in query order. |
 | `get_input_tokens()` / `get_output_tokens()` | Get token counts across the run's requests. |
 | `get_duration()` | Get the elapsed execution duration. |
 
@@ -930,30 +949,26 @@ An event handler usually checks `get_name()` and then reads its payload with `ge
 You can query events with AQL or a condition you supply.
 
 ```python
-werk.find_events("tool_call_failed")
-werk.find_events("event = request_finished AND agent = research-1")
-werk.find_events("task = t-3 ORDER BY created DESC")
-werk.find_events("payload ~ timeout AND created > -1h")
+werk.find_events("event.name = tool_call_failed")
+werk.find_events("event.name = request_finished AND event.agent_id = research-1")
+werk.find_events("event.task_id = t-3 ORDER BY event.created DESC")
+werk.find_events("event.data ~ timeout AND event.created > -1h")
 ```
 
 | | Field | Description |
 |-|-------|-------------|
-| **Match** | `event` | The event name, such as `run_started` or `tool_call_failed`. |
-| | `agent` | The attributed agent ID, when the event has agent context. |
-| | `task` | The attributed task ID, when the event has task context. |
-| | `label` | The attributed task's label, when the task is known and labelled. |
-| **Search** | `payload` | Search the event name and data together as text. |
-| **Compare** | `created` | When the event was recorded. |
+| **Match** | `event.name` | The event name, such as `run_started` or `tool_call_failed`. |
+| | `event.agent_id` | The attributed agent ID, when the event has agent context. |
+| | `event.task_id` | The attributed task ID, when the event has task context. |
+| | `event.label` | The attributed task's label, when the task is known and labelled. |
+| **Search** | `event.data` | Search only the serialized raw event data as text. |
+| **Compare** | `event.created` | When the event was recorded. |
 
-Event queries follow the same [rules as task queries](#queries). Match `event`, `agent`, `task`, and `label` exactly; use `~` to search `payload`; and use `<` or `>` with `created`. Some events have no agent, task, or label. Find them with `IS EMPTY`. Without `ORDER BY`, events remain oldest first.
+Event queries follow the same [rules as task queries](#queries). Some events
+have no agent, task, or label; find them with `IS EMPTY`. `event.data` does not
+include the event name. Without `ORDER BY`, events remain oldest first.
 
-You can also search with one word. Agentwerk reads it as:
-
-1. A task ID such as `t-3` means `task = t-3`.
-2. A built-in event name such as `tool_call_failed` means `event = tool_call_failed`.
-3. Any other value such as `scan` means `label = scan`.
-
-For your own event names, write `event = document_indexed`. If a label has the same name as a built-in event, write `label = knowledge_read`.
+For your own event names, write `event.name = document_indexed`. Event labels use `event.label`, so they are never ambiguous with names.
 
 An invalid query string raises `ValueError`. `Query(query)` checks a query without running it and raises the same error.
 

--- a/crates/agentwerk-py/examples/apparat_fabrik.py
+++ b/crates/agentwerk-py/examples/apparat_fabrik.py
@@ -329,12 +329,12 @@ async def main(pruefer, meister, monteur):
     )
     rulings = [
         task.get_result()
-        for task in werk.find_tasks("label = abnahme AND status = finished")
+        for task in werk.find_tasks("task.label = abnahme AND task.status = finished")
         if isinstance(task.get_result(), dict)
     ]
     fitted = [
         task.get_result()
-        for task in werk.find_tasks("label = montage AND status = finished")
+        for task in werk.find_tasks("task.label = montage AND task.status = finished")
         if isinstance(task.get_result(), dict) and task.get_result().get("eingebaut")
     ]
     scrap = [ruling for ruling in rulings if not ruling.get("passt")]

--- a/crates/agentwerk-py/examples/divide_and_conquer.py
+++ b/crates/agentwerk-py/examples/divide_and_conquer.py
@@ -154,7 +154,9 @@ async def main(n, partitions, agents):
         else:
             failures.append((task.get_id(), task.get_status()))
 
-    event_counts = Counter(event.get_name() for event in werk.find_events("ORDER BY created"))
+    event_counts = Counter(
+        event.get_name() for event in werk.find_events("ORDER BY event.created")
+    )
     duration = werk.get_duration() or 0.0
     print(
         f"\nfinished in {duration:.1f}s: "

--- a/crates/agentwerk-py/python/agentwerk/__init__.pyi
+++ b/crates/agentwerk-py/python/agentwerk/__init__.pyi
@@ -123,11 +123,13 @@ class Reply:
     def __repr__(self) -> str: ...
 
 class Query:
-    """Select tasks or recorded events with AQL.
+    """Select tasks, events, or joined task-event rows with AQL.
 
-    Fields are qualified with ``task.`` or ``event.`` and infer the query's
-    source origin. Read finders project between tasks and events through
-    ``event.task_id``. The query may include ``ORDER BY <field> ASC | DESC``.
+    A lone value is task-label shorthand, except that ``t-N`` selects a task
+    ID. Fields in full expressions are qualified with ``task.`` or ``event.``.
+    Using both evaluates task-event pairs linked through ``event.task_id``. The
+    receiving operation projects matches to its return type. Queries may
+    include ``ORDER BY <field> ASC | DESC``.
     """
 
     def __init__(self, query: str) -> None: ...

--- a/crates/agentwerk-py/python/agentwerk/__init__.pyi
+++ b/crates/agentwerk-py/python/agentwerk/__init__.pyi
@@ -125,7 +125,9 @@ class Reply:
 class Query:
     """Select tasks or recorded events with AQL.
 
-    The query may include ``ORDER BY <field> ASC | DESC``. Construction raises ``ValueError`` only when both task and event fields reject the query; a query valid for one field set may still fail when used with the other.
+    Fields are qualified with ``task.`` or ``event.`` and infer the query's
+    source origin. Read finders project between tasks and events through
+    ``event.task_id``. The query may include ``ORDER BY <field> ASC | DESC``.
     """
 
     def __init__(self, query: str) -> None: ...

--- a/crates/agentwerk-py/src/query.rs
+++ b/crates/agentwerk-py/src/query.rs
@@ -1,4 +1,4 @@
-//! Exposes origin-aware AQL queries through one Python class.
+//! Exposes task, event, and joined AQL queries through one Python class.
 
 use agentwerk::agents::Matcher;
 use agentwerk::event::Event;
@@ -8,7 +8,7 @@ use pyo3::prelude::*;
 use crate::event::to_py_event;
 use crate::task::PyTask;
 
-/// Selects tasks or events by origin-qualified field values.
+/// Selects tasks, events, or joined task-event rows by qualified field values.
 #[pyclass(name = "Query")]
 pub struct PyQuery {
     source: String,
@@ -36,33 +36,11 @@ fn value_error(message: impl Into<String>) -> PyErr {
     pyo3::exceptions::PyValueError::new_err(message.into())
 }
 
-/// Read a Python argument as a task query: a `Query`, a string in AQL, or a
-/// callable as a condition of its own. A string that does not compile raises
-/// `ValueError` rather than panicking across the binding.
+/// Read a Python argument for an operation that ultimately selects tasks: a
+/// `Query`, a string in AQL, or a callable as a condition of its own. Named
+/// AQL may originate from tasks, events, or their join; callables receive a
+/// task. A string that does not compile raises `ValueError`.
 pub fn to_task_matcher(py: Python<'_>, arg: &Py<PyAny>) -> PyResult<Query> {
-    if let Ok(query) = arg.extract::<PyRef<'_, PyQuery>>(py) {
-        query
-            .query
-            .expects_task()
-            .map_err(|error| value_error(error.to_string()))?;
-        return Ok(query.query.clone());
-    }
-    if let Ok(query) = arg.extract::<String>(py) {
-        let query = Query::new(&query).map_err(|error| value_error(error.to_string()))?;
-        query
-            .expects_task()
-            .map_err(|error| value_error(error.to_string()))?;
-        return Ok(query);
-    }
-    let callable = arg.clone_ref(py);
-    Ok(Matcher::into_query(move |task: &Task| {
-        task_predicate(&callable, task)
-    }))
-}
-
-/// Read a task or result finder's query. Named AQL may originate from tasks
-/// or events; callables continue to receive the destination task.
-pub fn to_task_finder(py: Python<'_>, arg: &Py<PyAny>) -> PyResult<Query> {
     if let Ok(query) = arg.extract::<PyRef<'_, PyQuery>>(py) {
         return Ok(query.query.clone());
     }

--- a/crates/agentwerk-py/src/query.rs
+++ b/crates/agentwerk-py/src/query.rs
@@ -1,6 +1,6 @@
-//! Exposes AQL queries over tasks and events through one Python class.
+//! Exposes origin-aware AQL queries through one Python class.
 
-use agentwerk::agents::{Matcher, QueryError};
+use agentwerk::agents::Matcher;
 use agentwerk::event::Event;
 use agentwerk::{Query, Task};
 use pyo3::prelude::*;
@@ -8,48 +8,27 @@ use pyo3::prelude::*;
 use crate::event::to_py_event;
 use crate::task::PyTask;
 
-/// Selects tasks or recorded events by field values, compiled from AQL.
+/// Selects tasks or events by origin-qualified field values.
 #[pyclass(name = "Query")]
 pub struct PyQuery {
     source: String,
-    tasks: Result<Query<Task>, QueryError>,
-    events: Result<Query<Event>, QueryError>,
+    query: Query,
 }
 
 #[pymethods]
 impl PyQuery {
     /// Compile an AQL string, the same syntax a string argument carries.
     ///
-    /// A string the task fields reject still selects events, and the other
-    /// way round. Only one the two field sets both reject raises here.
     #[new]
     fn new(query: &str) -> PyResult<Self> {
-        let compiled = PyQuery {
+        Ok(PyQuery {
             source: query.to_string(),
-            tasks: Query::<Task>::new(query),
-            events: Query::<Event>::new(query),
-        };
-        match (&compiled.tasks, &compiled.events) {
-            (Err(over_tasks), Err(over_events)) => Err(rejected(over_tasks, over_events)),
-            _ => Ok(compiled),
-        }
+            query: Query::new(query).map_err(|error| value_error(error.to_string()))?,
+        })
     }
 
     fn __repr__(&self) -> String {
         format!("Query({:?})", self.source)
-    }
-}
-
-/// The error a string neither field set accepts raises. One message where both
-/// answered the same, so a malformed query is not reported twice.
-fn rejected(over_tasks: &QueryError, over_events: &QueryError) -> PyErr {
-    let over_tasks = over_tasks.to_string();
-    let over_events = over_events.to_string();
-    match over_tasks == over_events {
-        true => value_error(over_tasks),
-        false => value_error(format!(
-            "Over tasks: {over_tasks} Over events: {over_events}"
-        )),
     }
 }
 
@@ -60,15 +39,20 @@ fn value_error(message: impl Into<String>) -> PyErr {
 /// Read a Python argument as a task query: a `Query`, a string in AQL, or a
 /// callable as a condition of its own. A string that does not compile raises
 /// `ValueError` rather than panicking across the binding.
-pub fn to_task_matcher(py: Python<'_>, arg: &Py<PyAny>) -> PyResult<Query<Task>> {
+pub fn to_task_matcher(py: Python<'_>, arg: &Py<PyAny>) -> PyResult<Query> {
     if let Ok(query) = arg.extract::<PyRef<'_, PyQuery>>(py) {
-        return match &query.tasks {
-            Ok(compiled) => Ok(compiled.clone()),
-            Err(error) => Err(value_error(error.to_string())),
-        };
+        query
+            .query
+            .expects_task()
+            .map_err(|error| value_error(error.to_string()))?;
+        return Ok(query.query.clone());
     }
     if let Ok(query) = arg.extract::<String>(py) {
-        return Query::<Task>::new(&query).map_err(|error| value_error(error.to_string()));
+        let query = Query::new(&query).map_err(|error| value_error(error.to_string()))?;
+        query
+            .expects_task()
+            .map_err(|error| value_error(error.to_string()))?;
+        return Ok(query);
     }
     let callable = arg.clone_ref(py);
     Ok(Matcher::into_query(move |task: &Task| {
@@ -76,16 +60,29 @@ pub fn to_task_matcher(py: Python<'_>, arg: &Py<PyAny>) -> PyResult<Query<Task>>
     }))
 }
 
-/// Read a Python argument as an event query, the way a task filter is read.
-pub fn to_event_matcher(py: Python<'_>, arg: &Py<PyAny>) -> PyResult<Query<Event>> {
+/// Read a task or result finder's query. Named AQL may originate from tasks
+/// or events; callables continue to receive the destination task.
+pub fn to_task_finder(py: Python<'_>, arg: &Py<PyAny>) -> PyResult<Query> {
     if let Ok(query) = arg.extract::<PyRef<'_, PyQuery>>(py) {
-        return match &query.events {
-            Ok(compiled) => Ok(compiled.clone()),
-            Err(error) => Err(value_error(error.to_string())),
-        };
+        return Ok(query.query.clone());
     }
     if let Ok(query) = arg.extract::<String>(py) {
-        return Query::<Event>::new(&query).map_err(|error| value_error(error.to_string()));
+        return Query::new(&query).map_err(|error| value_error(error.to_string()));
+    }
+    let callable = arg.clone_ref(py);
+    Ok(Matcher::into_query(move |task: &Task| {
+        task_predicate(&callable, task)
+    }))
+}
+
+/// Read an event finder's query. Named AQL may originate from tasks or events;
+/// callables continue to receive the destination event.
+pub fn to_event_matcher(py: Python<'_>, arg: &Py<PyAny>) -> PyResult<Query> {
+    if let Ok(query) = arg.extract::<PyRef<'_, PyQuery>>(py) {
+        return Ok(query.query.clone());
+    }
+    if let Ok(query) = arg.extract::<String>(py) {
+        return Query::new(&query).map_err(|error| value_error(error.to_string()));
     }
     let callable = arg.clone_ref(py);
     Ok(Matcher::into_query(move |event: &Event| {

--- a/crates/agentwerk-py/src/werk.rs
+++ b/crates/agentwerk-py/src/werk.rs
@@ -13,7 +13,7 @@ use crate::agent::PyAgent;
 use crate::convert::{py_to_value, runtime_error, value_to_py};
 use crate::event::{to_py_event, PyEvent};
 use crate::policy::PyPolicy;
-use crate::query::{to_event_matcher, to_task_finder, to_task_matcher};
+use crate::query::{to_event_matcher, to_task_matcher};
 use crate::reply::{py_to_replies, replies_to_py};
 use crate::task::{to_task, PyTask};
 
@@ -237,10 +237,10 @@ impl PyWerk {
             .collect()
     }
 
-    /// Get tasks selected directly by a task query or through an event query.
+    /// Get tasks selected directly, through events, or through joined rows.
     /// A callable always receives a task.
     fn find_tasks(&self, py: Python<'_>, predicate: Py<PyAny>) -> PyResult<Vec<Py<PyTask>>> {
-        let tasks = self.inner.find_tasks(to_task_finder(py, &predicate)?);
+        let tasks = self.inner.find_tasks(to_task_matcher(py, &predicate)?);
         tasks
             .iter()
             .map(|task| Py::new(py, PyTask::from_task(task)))
@@ -250,7 +250,7 @@ impl PyWerk {
     /// Get the first task selected directly or through a matching event.
     /// A callable always receives a task.
     fn find_task(&self, py: Python<'_>, predicate: Py<PyAny>) -> PyResult<Option<Py<PyTask>>> {
-        let task = self.inner.find_task(to_task_finder(py, &predicate)?);
+        let task = self.inner.find_task(to_task_matcher(py, &predicate)?);
         match task {
             Some(task) => Ok(Some(Py::new(py, PyTask::from_task(&task))?)),
             None => Ok(None),
@@ -406,7 +406,7 @@ impl PyWerk {
         slf
     }
 
-    /// Get events selected directly by an event query or through a task query.
+    /// Get events selected directly, through tasks, or through joined rows.
     /// A callable always receives an event.
     fn find_events(&self, matches: Py<PyAny>, py: Python<'_>) -> PyResult<Vec<PyEvent>> {
         let found = self.inner.find_events(to_event_matcher(py, &matches)?);
@@ -445,15 +445,15 @@ impl PyWerk {
             .collect()
     }
 
-    /// Get results selected through matching tasks or events, in source-query
-    /// order. A callable receives a task. Task queries default status to
-    /// `"finished"`; event queries always return finished task results.
+    /// Get results selected through matching tasks, events, or joined rows, in
+    /// source-query order. A callable receives a task. Status defaults to
+    /// `"finished"` unless the query names one.
     fn find_results<'py>(
         &self,
         py: Python<'py>,
         query: Py<PyAny>,
     ) -> PyResult<Vec<Bound<'py, PyAny>>> {
-        let results = self.inner.find_results(to_task_finder(py, &query)?);
+        let results = self.inner.find_results(to_task_matcher(py, &query)?);
         results.iter().map(|value| value_to_py(py, value)).collect()
     }
 
@@ -463,7 +463,7 @@ impl PyWerk {
         py: Python<'py>,
         query: Py<PyAny>,
     ) -> PyResult<Option<Bound<'py, PyAny>>> {
-        let result = self.inner.find_result(to_task_finder(py, &query)?);
+        let result = self.inner.find_result(to_task_matcher(py, &query)?);
         match result {
             Some(value) => Ok(Some(value_to_py(py, &value)?)),
             None => Ok(None),

--- a/crates/agentwerk-py/src/werk.rs
+++ b/crates/agentwerk-py/src/werk.rs
@@ -13,7 +13,7 @@ use crate::agent::PyAgent;
 use crate::convert::{py_to_value, runtime_error, value_to_py};
 use crate::event::{to_py_event, PyEvent};
 use crate::policy::PyPolicy;
-use crate::query::{to_event_matcher, to_task_matcher};
+use crate::query::{to_event_matcher, to_task_finder, to_task_matcher};
 use crate::reply::{py_to_replies, replies_to_py};
 use crate::task::{to_task, PyTask};
 
@@ -237,18 +237,20 @@ impl PyWerk {
             .collect()
     }
 
-    /// Get every task matching a Query or callable.
+    /// Get tasks selected directly by a task query or through an event query.
+    /// A callable always receives a task.
     fn find_tasks(&self, py: Python<'_>, predicate: Py<PyAny>) -> PyResult<Vec<Py<PyTask>>> {
-        let tasks = self.inner.find_tasks(to_task_matcher(py, &predicate)?);
+        let tasks = self.inner.find_tasks(to_task_finder(py, &predicate)?);
         tasks
             .iter()
             .map(|task| Py::new(py, PyTask::from_task(task)))
             .collect()
     }
 
-    /// Get the first task matching a Query or callable.
+    /// Get the first task selected directly or through a matching event.
+    /// A callable always receives a task.
     fn find_task(&self, py: Python<'_>, predicate: Py<PyAny>) -> PyResult<Option<Py<PyTask>>> {
-        let task = self.inner.find_task(to_task_matcher(py, &predicate)?);
+        let task = self.inner.find_task(to_task_finder(py, &predicate)?);
         match task {
             Some(task) => Ok(Some(Py::new(py, PyTask::from_task(&task))?)),
             None => Ok(None),
@@ -404,16 +406,15 @@ impl PyWerk {
         slf
     }
 
-    /// Get every recorded event matching a `Query`, an AQL string, or a
-    /// callable, oldest first. Counting is `len()`, and a total is a fold over
-    /// the events themselves.
+    /// Get events selected directly by an event query or through a task query.
+    /// A callable always receives an event.
     fn find_events(&self, matches: Py<PyAny>, py: Python<'_>) -> PyResult<Vec<PyEvent>> {
         let found = self.inner.find_events(to_event_matcher(py, &matches)?);
         Ok(found.iter().map(to_py_event).collect())
     }
 
-    /// Get the earliest recorded event matching a `Query`, an AQL string, or a
-    /// callable, or the first in the order an `ORDER BY` names.
+    /// Get the first event selected directly or through a matching task.
+    /// A callable always receives an event.
     fn find_event(&self, matches: Py<PyAny>, py: Python<'_>) -> PyResult<Option<PyEvent>> {
         let found = self.inner.find_event(to_event_matcher(py, &matches)?);
         Ok(found.as_ref().map(to_py_event))
@@ -444,25 +445,25 @@ impl PyWerk {
             .collect()
     }
 
-    /// Get every result whose task matches the Query or callable, in query
-    /// order. Status defaults to `"finished"`.
+    /// Get results selected through matching tasks or events, in source-query
+    /// order. A callable receives a task. Task queries default status to
+    /// `"finished"`; event queries always return finished task results.
     fn find_results<'py>(
         &self,
         py: Python<'py>,
         query: Py<PyAny>,
     ) -> PyResult<Vec<Bound<'py, PyAny>>> {
-        let results = self.inner.find_results(to_task_matcher(py, &query)?);
+        let results = self.inner.find_results(to_task_finder(py, &query)?);
         results.iter().map(|value| value_to_py(py, value)).collect()
     }
 
-    /// Get the first result whose task matches the Query or callable.
-    /// Status defaults to `"finished"`.
+    /// Get the first result selected through a matching task or event.
     fn find_result<'py>(
         &self,
         py: Python<'py>,
         query: Py<PyAny>,
     ) -> PyResult<Option<Bound<'py, PyAny>>> {
-        let result = self.inner.find_result(to_task_matcher(py, &query)?);
+        let result = self.inner.find_result(to_task_finder(py, &query)?);
         match result {
             Some(value) => Ok(Some(value_to_py(py, &value)?)),
             None => Ok(None),

--- a/crates/agentwerk-py/tests/test_live.py
+++ b/crates/agentwerk-py/tests/test_live.py
@@ -38,7 +38,7 @@ async def test_invokes_a_builtin_tool(tmp_path):
     agent.add_task("Read secret.txt and report the exact token it contains.")
     werk = agent.start()
     assert "THE-TOKEN-IS-42" in str(
-        await werk.finish_task("ORDER BY created DESC")
+        await werk.finish_task("ORDER BY task.created DESC")
     )
 
 

--- a/crates/agentwerk-py/tests/test_tasks.py
+++ b/crates/agentwerk-py/tests/test_tasks.py
@@ -54,11 +54,11 @@ def test_unstarted_task_carries_its_id_and_no_messages(werk):
 def test_task_selection_uses_aql_status_and_pending_fields(werk):
     id = werk.add_task(aw.Task("scan the corpus"))
 
-    assert [task.get_id() for task in werk.find_tasks("status = todo")] == [id]
-    assert [task.get_id() for task in werk.find_tasks("pending = true")] == [id]
-    assert werk.find_tasks("status = in_progress") == []
-    assert werk.find_tasks("status = finished") == []
-    assert werk.find_tasks("status = failed") == []
+    assert [task.get_id() for task in werk.find_tasks("task.status = todo")] == [id]
+    assert [task.get_id() for task in werk.find_tasks("task.pending = true")] == [id]
+    assert werk.find_tasks("task.status = in_progress") == []
+    assert werk.find_tasks("task.status = finished") == []
+    assert werk.find_tasks("task.status = failed") == []
 
 
 def test_task_predicates_follow_label_status_and_cancellation(werk):
@@ -75,7 +75,7 @@ def test_task_predicates_follow_label_status_and_cancellation(werk):
     unlabeled_key = werk.add_task(aw.Task("unscoped"))
     assert werk.get_task(unlabeled_key).get_label() is None
 
-    werk.cancel_tasks("label = scan")
+    werk.cancel_tasks("task.label = scan")
     cancelled = werk.get_task(todo_key)
     assert cancelled.is_cancelled()
     assert not cancelled.is_pending()
@@ -185,7 +185,7 @@ def test_find_task_returns_the_first_match(werk):
     werk.add_task(aw.Task("alpha", label="a"))
     werk.add_task(aw.Task("beta", label="b"))
 
-    found = werk.find_task("status = todo")
+    found = werk.find_task("task.status = todo")
     assert found.get_task() == "alpha"
 
 
@@ -193,7 +193,7 @@ def test_find_tasks_filters_by_query(werk):
     werk.add_task(aw.Task("alpha", label="a"))
     werk.add_task(aw.Task("beta", label="b"))
 
-    matches = werk.find_tasks(aw.Query("label = a"))
+    matches = werk.find_tasks(aw.Query("task.label = a"))
     assert [t.get_task() for t in matches] == ["alpha"]
 
 
@@ -201,8 +201,8 @@ def test_find_tasks_compiles_the_string_as_a_query(werk):
     werk.add_task(aw.Task("alpha", label="a"))
     werk.add_task(aw.Task("beta", label="b"))
 
-    assert [t.get_task() for t in werk.find_tasks("b")] == ["beta"]
-    assert [t.get_task() for t in werk.find_tasks("label = a")] == ["alpha"]
+    assert [t.get_task() for t in werk.find_tasks("task.label = b")] == ["beta"]
+    assert [t.get_task() for t in werk.find_tasks("task.label = a")] == ["alpha"]
 
 
 def test_a_malformed_query_string_raises_value_error(werk):
@@ -212,12 +212,18 @@ def test_a_malformed_query_string_raises_value_error(werk):
 
 def test_a_query_compiles_its_string_on_construction():
     with pytest.raises(ValueError):
-        aw.Query("label =")
+        aw.Query("task.label =")
 
-
-def test_an_event_query_raises_where_tasks_are_selected(werk):
     with pytest.raises(ValueError):
-        werk.find_tasks(aw.Query("event = task_finished"))
+        aw.Query("result.value ~ clean")
+
+
+def test_an_event_query_projects_its_referenced_tasks(werk):
+    id = werk.add_task("seed")
+    query = aw.Query("event.name = task_created")
+
+    assert [task.get_id() for task in werk.find_tasks(query)] == [id]
+    assert werk.find_task("event.name = task_created").get_id() == id
 
 
 def test_task_takes_a_bare_task_without_a_task_object(werk):
@@ -232,8 +238,10 @@ def test_find_results_selects_by_label(werk):
     werk.set_task_finished(scan, {"verdict": "clean"})
     werk.set_task_finished(report, {"summary": "nothing found"})
 
-    assert werk.find_results("scan") == [{"verdict": "clean"}]
-    assert werk.find_result(aw.Query("label = report")) == {"summary": "nothing found"}
+    assert werk.find_results("task.label = scan") == [{"verdict": "clean"}]
+    assert werk.find_result(aw.Query("task.label = report")) == {
+        "summary": "nothing found"
+    }
 
 
 def test_find_results_takes_a_callable(werk):
@@ -243,6 +251,24 @@ def test_find_results_takes_a_callable(werk):
     werk.set_task_finished(report, {"summary": "nothing found"})
 
     assert werk.find_results(lambda task: task.get_label() == "scan") == [{"verdict": "clean"}]
+
+
+def test_result_finders_query_the_producing_tasks(werk):
+    scan = werk.add_task(aw.Task({"kind": "scan"}, label="scan"))
+    unfinished = werk.add_task(aw.Task({"kind": "draft"}, label="scan"))
+    werk.set_task_finished(scan, {"verdict": "clean"})
+    werk.get_task(unfinished)
+
+    query = aw.Query("task.input ~ scan AND task.result ~ clean")
+    assert werk.find_results(query) == [
+        {"verdict": "clean"}
+    ]
+    assert [task.get_id() for task in werk.find_tasks(query)] == [scan]
+    assert werk.find_results("task.status = todo") == []
+    assert werk.find_results(aw.Query("event.name = task_finished")) == [
+        {"verdict": "clean"}
+    ]
+    assert werk.find_result("event.name = task_finished") == {"verdict": "clean"}
 
 
 def test_get_task_returns_none_for_unknown_id(werk):
@@ -312,7 +338,7 @@ def test_find_tasks_returns_every_status_not_just_finished(werk):
     werk.add_task(aw.Task("alpha", label="a"))
     werk.add_task(aw.Task("beta", label="b"))
 
-    tasks = [task.get_task() for task in werk.find_tasks("label = a")]
+    tasks = [task.get_task() for task in werk.find_tasks("task.label = a")]
     assert tasks == ["alpha"]
 
 
@@ -330,39 +356,41 @@ def test_cancel_takes_the_matching_tasks_off_the_queue(werk):
     scan = werk.add_task(aw.Task("scan the corpus", label="scan"))
     werk.add_task(aw.Task("write it up", label="report"))
 
-    assert isinstance(werk.cancel_tasks("label = scan"), aw.Werk)
+    assert isinstance(werk.cancel_tasks("task.label = scan"), aw.Werk)
 
-    assert [task.get_id() for task in werk.find_tasks("cancelled = true")] == [scan]
-    assert [task.get_label() for task in werk.find_tasks("cancelled = false")] == ["report"]
+    assert [task.get_id() for task in werk.find_tasks("task.cancelled = true")] == [scan]
+    assert [task.get_label() for task in werk.find_tasks("task.cancelled = false")] == [
+        "report"
+    ]
     assert werk.get_task(scan).is_cancelled()
 
 
 def test_cancel_applies_to_matching_tasks_inserted_later(werk):
-    werk.cancel_tasks("label = scan")
+    werk.cancel_tasks("task.label = scan")
 
     scan = werk.add_task(aw.Task("scan the corpus", label="scan"))
     werk.add_task(aw.Task("write it up", label="report"))
 
-    assert werk.find_task("cancelled = true").get_id() == scan
+    assert werk.find_task("task.cancelled = true").get_id() == scan
 
 
 async def test_start_clears_cancellation_flags_and_filters(werk):
     werk.add_task(aw.Task("first", label="scan"))
-    werk.cancel_tasks("label = scan")
-    assert len(werk.find_tasks("cancelled = true")) == 1
+    werk.cancel_tasks("task.label = scan")
+    assert len(werk.find_tasks("task.cancelled = true")) == 1
 
     werk.start()
     werk.add_task(aw.Task("second", label="scan"))
 
-    assert werk.find_tasks("cancelled = true") == []
-    assert len(werk.find_tasks("pending = true")) == 2
+    assert werk.find_tasks("task.cancelled = true") == []
+    assert len(werk.find_tasks("task.pending = true")) == 2
     werk.cancel_all_tasks()
     await werk.finish_all_tasks()
 
 
 def test_task_json_does_not_persist_cancellation(werk, tmp_path):
     id = werk.add_task(aw.Task("scan", label="scan"))
-    werk.cancel_tasks("label = scan")
+    werk.cancel_tasks("task.label = scan")
     werk.set_task_failed(id)
 
     record = json.loads((tmp_path / "tasks" / id / "task.json").read_text())
@@ -371,8 +399,8 @@ def test_task_json_does_not_persist_cancellation(werk, tmp_path):
     assert "cancelled" not in record
 
     reopened = aw.Werk.load(str(tmp_path))
-    assert reopened.find_tasks("cancelled = true") == []
-    assert len(reopened.find_tasks("cancelled = false")) == 1
+    assert reopened.find_tasks("task.cancelled = true") == []
+    assert len(reopened.find_tasks("task.cancelled = false")) == 1
 
 
 def test_a_werk_that_has_not_run_records_nothing(werk):
@@ -414,10 +442,12 @@ def test_find_events_takes_an_aql_string(werk, tmp_path):
     werk.add_task(aw.Task("scan", label="scout"))
     werk.add_task("two")
 
-    assert len(werk.find_events("task_created")) == 2
-    assert len(werk.find_events("event = task_created AND label = scout")) == 1
-    assert len(werk.find_events("t-2")) == 1
-    assert werk.find_events("run_finished") == []
+    assert len(werk.find_events("event.name = task_created")) == 2
+    assert len(
+        werk.find_events("event.name = task_created AND event.label = scout")
+    ) == 1
+    assert len(werk.find_events("event.task_id = t-2")) == 1
+    assert werk.find_events("event.name = run_finished") == []
 
     events_path = tmp_path / "events.jsonl"
     records = [json.loads(line) for line in events_path.read_text().splitlines()]
@@ -425,17 +455,26 @@ def test_find_events_takes_an_aql_string(werk, tmp_path):
         record["created_at"] = created_at
     events_path.write_text("".join(f"{json.dumps(record)}\n" for record in records))
 
-    newest = werk.find_event("task_created ORDER BY created DESC")
+    newest = werk.find_event("event.name = task_created ORDER BY event.created DESC")
     assert newest.get_task_id() == "t-2"
 
 
 def test_find_events_takes_a_compiled_query(werk):
     werk.add_task("seed")
 
-    assert len(werk.find_events(aw.Query("task_created"))) == 1
-    assert werk.find_events(aw.Query("event = task_exploded")) == []
+    assert len(werk.find_events(aw.Query("event.name = task_created"))) == 1
+    assert werk.find_events(aw.Query("event.name = task_exploded")) == []
     with pytest.raises(ValueError):
-        werk.find_events("event = ")
+        werk.find_events("event.name = ")
+
+
+def test_event_data_does_not_include_the_event_name(werk):
+    werk.emit_event(aw.Event("needle").data({"message": "other"}))
+    werk.emit_event(aw.Event("other").data({"message": "needle"}))
+
+    assert len(werk.find_events("event.name = needle")) == 1
+    found = werk.find_events("event.data ~ needle")
+    assert [event.get_name() for event in found] == ["other"]
 
 
 def test_emit_event_publishes_named_data_with_optional_context(werk, tmp_path):
@@ -460,7 +499,7 @@ def test_emit_event_publishes_named_data_with_optional_context(werk, tmp_path):
     assert len(seen) == 1
     assert seen[0].get_name() == "document_indexed"
     assert seen[0].get_data() == {"documents": 42}
-    assert werk.find_event("event = document_indexed").get_data() == {"documents": 42}
+    assert werk.find_event("event.name = document_indexed").get_data() == {"documents": 42}
 
     records = [json.loads(line) for line in (tmp_path / "events.jsonl").read_text().splitlines()]
     record = next(record for record in records if record["name"] == "document_indexed")
@@ -468,7 +507,7 @@ def test_emit_event_publishes_named_data_with_optional_context(werk, tmp_path):
     assert "task_key" not in record
 
     reopened = aw.Werk.load(str(tmp_path))
-    restored = reopened.find_event("event = document_indexed")
+    restored = reopened.find_event("event.name = document_indexed")
     assert restored.get_data() == {"documents": 42}
     assert restored.get_label() == "scout"
 
@@ -518,21 +557,30 @@ def test_emit_event_accepts_arbitrary_names(werk, name):
     emitted = werk.emit_event(aw.Event(name))
 
     assert emitted.get_name() == name
-    assert werk.find_event(f'event = "{name}"').get_name() == name
+    assert werk.find_event(f'event.name = "{name}"').get_name() == name
 
 
-def test_a_query_neither_field_set_accepts_raises_on_construction():
+def test_an_unqualified_field_raises_on_query_construction():
     with pytest.raises(ValueError):
         aw.Query("assignee = alice")
 
 
-def test_a_task_query_raises_where_events_are_selected(werk):
-    werk.add_task("seed")
-    tasks_only = aw.Query("status = finished")
+def test_a_task_query_projects_the_tasks_events(werk):
+    id = werk.add_task("seed")
+    tasks_only = aw.Query("task.status = todo")
 
-    assert werk.find_tasks(tasks_only) == []
+    assert [task.get_id() for task in werk.find_tasks(tasks_only)] == [id]
+    assert [event.get_task_id() for event in werk.find_events(tasks_only)] == [id]
+    assert werk.find_event("task.status = todo").get_task_id() == id
+
+
+def test_event_queries_remain_invalid_for_task_lifecycle_operations(werk):
+    query = aw.Query("event.name = task_created")
+
     with pytest.raises(ValueError):
-        werk.find_events(tasks_only)
+        werk.cancel_tasks(query)
+    with pytest.raises(ValueError):
+        werk.finish_tasks(query)
 
 
 def test_an_event_carries_the_label_of_the_task_it_concerns(werk):
@@ -630,7 +678,7 @@ def test_on_event_files_a_follow_up_for_any_kind(werk):
 
     werk.set_task_finished(id, {"verdict": "clean"})
 
-    filed = werk.find_tasks("label = report")
+    filed = werk.find_tasks("task.label = report")
     assert [t.get_task() for t in filed] == ["report"]
 
 
@@ -888,11 +936,11 @@ async def test_finish_task_hands_back_the_first_result_in_query_order(werk):
     werk.set_task_finished(report, {"pages": 2})
     werk.set_task_finished(scan, {"verdict": "clean"})
 
-    assert await werk.finish_task("ORDER BY id DESC") == {"pages": 2}
+    assert await werk.finish_task("ORDER BY task.id DESC") == {"pages": 2}
 
 
 async def test_finish_task_is_none_when_nothing_finished(werk):
-    assert await werk.finish_task("status = finished") is None
+    assert await werk.finish_task("task.status = finished") is None
 
 
 async def test_a_cancelled_run_reports_its_reason(werk):

--- a/crates/agentwerk-py/tests/test_tasks.py
+++ b/crates/agentwerk-py/tests/test_tasks.py
@@ -201,8 +201,14 @@ def test_find_tasks_compiles_the_string_as_a_query(werk):
     werk.add_task(aw.Task("alpha", label="a"))
     werk.add_task(aw.Task("beta", label="b"))
 
-    assert [t.get_task() for t in werk.find_tasks("task.label = b")] == ["beta"]
-    assert [t.get_task() for t in werk.find_tasks("task.label = a")] == ["alpha"]
+    assert [t.get_task() for t in werk.find_tasks("b")] == ["beta"]
+    assert [t.get_task() for t in werk.find_tasks("a")] == ["alpha"]
+
+
+def test_quoted_label_shorthand_supports_spaces(werk):
+    werk.add_task(aw.Task("review it", label="needs review"))
+
+    assert werk.find_task('"needs review"').get_task() == "review it"
 
 
 def test_a_malformed_query_string_raises_value_error(werk):
@@ -226,6 +232,23 @@ def test_an_event_query_projects_its_referenced_tasks(werk):
     assert werk.find_task("event.name = task_created").get_id() == id
 
 
+def test_a_mixed_query_projects_joined_rows_to_each_finder(werk):
+    scan = werk.add_task(aw.Task("scan", label="scan"))
+    report = werk.add_task(aw.Task("report", label="report"))
+    werk.set_task_finished(scan, {"verdict": "clean"})
+    werk.set_task_finished(report, {"summary": "done"})
+    werk.emit_event(aw.Event("selected").task_id(scan))
+    werk.emit_event(aw.Event("selected").task_id(report))
+    query = aw.Query("scan AND event.name = selected")
+
+    assert [task.get_id() for task in werk.find_tasks(query)] == [scan]
+    assert werk.find_task(query).get_id() == scan
+    assert [event.get_task_id() for event in werk.find_events(query)] == [scan]
+    assert werk.find_event(query).get_task_id() == scan
+    assert werk.find_results(query) == [{"verdict": "clean"}]
+    assert werk.find_result(query) == {"verdict": "clean"}
+
+
 def test_task_takes_a_bare_task_without_a_task_object(werk):
     id = werk.add_task("scan the corpus")
 
@@ -238,8 +261,8 @@ def test_find_results_selects_by_label(werk):
     werk.set_task_finished(scan, {"verdict": "clean"})
     werk.set_task_finished(report, {"summary": "nothing found"})
 
-    assert werk.find_results("task.label = scan") == [{"verdict": "clean"}]
-    assert werk.find_result(aw.Query("task.label = report")) == {
+    assert werk.find_results("scan") == [{"verdict": "clean"}]
+    assert werk.find_result(aw.Query("report")) == {
         "summary": "nothing found"
     }
 
@@ -356,7 +379,7 @@ def test_cancel_takes_the_matching_tasks_off_the_queue(werk):
     scan = werk.add_task(aw.Task("scan the corpus", label="scan"))
     werk.add_task(aw.Task("write it up", label="report"))
 
-    assert isinstance(werk.cancel_tasks("task.label = scan"), aw.Werk)
+    assert isinstance(werk.cancel_tasks("scan"), aw.Werk)
 
     assert [task.get_id() for task in werk.find_tasks("task.cancelled = true")] == [scan]
     assert [task.get_label() for task in werk.find_tasks("task.cancelled = false")] == [
@@ -574,13 +597,22 @@ def test_a_task_query_projects_the_tasks_events(werk):
     assert werk.find_event("task.status = todo").get_task_id() == id
 
 
-def test_event_queries_remain_invalid_for_task_lifecycle_operations(werk):
+def test_event_cancellation_snapshots_current_referenced_tasks(werk):
+    first = werk.add_task("first")
     query = aw.Query("event.name = task_created")
+    werk.cancel_tasks(query)
+    second = werk.add_task("second")
 
-    with pytest.raises(ValueError):
-        werk.cancel_tasks(query)
-    with pytest.raises(ValueError):
-        werk.finish_tasks(query)
+    assert werk.get_task(first).is_cancelled()
+    assert not werk.get_task(second).is_cancelled()
+
+
+@pytest.mark.asyncio
+async def test_event_query_is_accepted_by_finish(werk):
+    task_id = werk.add_task("done")
+    werk.set_task_finished(task_id, {"answer": 42})
+
+    assert await werk.finish_tasks("event.name = task_finished") == [{"answer": 42}]
 
 
 def test_an_event_carries_the_label_of_the_task_it_concerns(werk):
@@ -915,9 +947,10 @@ async def test_on_result_async_runs_the_handler_on_the_callers_event_loop(werk):
 
 
 async def test_finish_hands_back_the_results_its_filter_named(werk):
-    id = werk.add_task("work")
-    werk.set_task_finished(id, {"verdict": "clean"})
-    assert await werk.finish_tasks(lambda t: t.get_id() == id) == [{"verdict": "clean"}]
+    scan = werk.add_task(aw.Task("work", label="scan"))
+    werk.add_task(aw.Task("other", label="report"))
+    werk.set_task_finished(scan, {"verdict": "clean"})
+    assert await werk.finish_tasks("scan") == [{"verdict": "clean"}]
 
 
 async def test_finish_all_hands_back_the_results_of_every_pool(werk):

--- a/crates/agentwerk/Cargo.toml
+++ b/crates/agentwerk/Cargo.toml
@@ -20,3 +20,7 @@ ignore = "0.4"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "process", "time", "signal", "test-util"] }
+
+[[bench]]
+name = "aql"
+harness = false

--- a/crates/agentwerk/benches/aql.rs
+++ b/crates/agentwerk/benches/aql.rs
@@ -1,0 +1,751 @@
+use std::collections::BTreeMap;
+use std::env;
+use std::hint::black_box;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, OnceLock};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use agentwerk::{Event, Query, Task, Werk};
+use serde_json::json;
+
+const EVENTS_PER_TASK: usize = 10;
+const FIXTURE_SIZES: [usize; 3] = [100, 1_000, 10_000];
+const DEFAULT_SAMPLES: usize = 10;
+const CALIBRATION_TIME: Duration = Duration::from_millis(20);
+const WARM_UP_TIME: Duration = Duration::from_millis(200);
+const TAIL_EVENT: &str = "benchmark_tail";
+const SYNTHETIC_EVENTS: [&str; EVENTS_PER_TASK - 1] = [
+    Event::TOOL_CALL_STARTED,
+    Event::TOOL_CALL_FINISHED,
+    Event::TOOL_CALL_FAILED,
+    Event::REQUEST_STARTED,
+    Event::REQUEST_FINISHED,
+    Event::TURN_STARTED,
+    "document_selected",
+    "document_indexed",
+    "document_archived",
+];
+
+fn main() {
+    let config = Config::from_args().unwrap_or_else(|message| {
+        eprintln!("{message}");
+        eprintln!("Run with --help for usage.");
+        std::process::exit(2);
+    });
+    if config.help {
+        print_help();
+        return;
+    }
+    let mut runner = Runner::new(config).unwrap_or_else(|message| {
+        eprintln!("{message}");
+        std::process::exit(2);
+    });
+    benchmarks(&mut runner);
+    runner.finish().unwrap_or_else(|error| {
+        eprintln!("could not save benchmark baseline: {error}");
+        std::process::exit(1);
+    });
+}
+
+fn benchmarks(runner: &mut Runner) {
+    benchmark_compilation(runner);
+
+    let fixtures = FIXTURE_SIZES.map(LazyFixture::new);
+    benchmark_scaling(runner, &fixtures);
+    let large = fixtures.last().expect("at least one AQL fixture");
+    benchmark_task_selection(runner, large);
+    benchmark_event_selection(runner, large);
+    benchmark_cross_origin_and_joined(runner, large);
+}
+
+struct Fixture {
+    _dir: TempDir,
+    werk: Arc<Werk>,
+    events_path: PathBuf,
+    task_count: usize,
+    event_count: usize,
+    scan_count: usize,
+    rare_count: usize,
+}
+
+struct LazyFixture {
+    task_count: usize,
+    fixture: OnceLock<Fixture>,
+}
+
+impl LazyFixture {
+    fn new(task_count: usize) -> Self {
+        Self {
+            task_count,
+            fixture: OnceLock::new(),
+        }
+    }
+
+    fn get(&self) -> &Fixture {
+        self.fixture.get_or_init(|| Fixture::new(self.task_count))
+    }
+}
+
+impl Fixture {
+    fn new(task_count: usize) -> Self {
+        assert_eq!(task_count % 100, 0, "fixture counts assume full cycles");
+
+        eprintln!(
+            "Building fixture with {task_count} tasks and {} events...",
+            task_count * EVENTS_PER_TASK
+        );
+        let dir = TempDir::new().expect("create AQL benchmark directory");
+        let werk = Werk::new();
+        werk.set_dir(dir.path());
+        werk.on_event(|_, _| {});
+
+        let task_body = "t".repeat(512);
+        let event_body = "e".repeat(256);
+        for task_index in 0..task_count {
+            let marker = if task_index % 10 == 0 {
+                "needle"
+            } else {
+                "haystack"
+            };
+            let id = werk.add_task(Task::labeled(
+                task_label(task_index),
+                json!({
+                    "index": task_index,
+                    "marker": marker,
+                    "body": task_body,
+                }),
+            ));
+
+            for (event_index, event_name) in SYNTHETIC_EVENTS.iter().enumerate() {
+                let event_name =
+                    if task_index + 1 == task_count && event_index + 1 == SYNTHETIC_EVENTS.len() {
+                        TAIL_EVENT
+                    } else {
+                        event_name
+                    };
+                let marker = if (task_index + event_index) % 10 == 0 {
+                    "needle"
+                } else {
+                    "haystack"
+                };
+                werk.emit_event(
+                    Event::new(event_name)
+                        .task_id(&id)
+                        .agent_id(format!("agent-{}", task_index % 8))
+                        .data(json!({
+                            "index": event_index,
+                            "marker": marker,
+                            "body": event_body,
+                        })),
+                );
+            }
+        }
+
+        let fixture = Self {
+            _dir: dir,
+            events_path: werk.get_dir().join("events.jsonl"),
+            werk,
+            task_count,
+            event_count: task_count * EVENTS_PER_TASK,
+            scan_count: task_count / 4 - task_count / 100,
+            rare_count: task_count / 100,
+        };
+        fixture.validate();
+        fixture
+    }
+
+    fn validate(&self) {
+        assert_eq!(self.werk.get_tasks().len(), self.task_count);
+        assert_eq!(read_event_log(&self.events_path).len(), self.event_count);
+        assert_eq!(
+            self.werk.find_tasks("task.label = scan").len(),
+            self.scan_count
+        );
+        assert_eq!(
+            self.werk.find_tasks("task.label = rare").len(),
+            self.rare_count
+        );
+        assert_eq!(
+            self.werk.find_events("event.name = tool_call_failed").len(),
+            self.task_count
+        );
+        assert_eq!(
+            self.werk
+                .find_events("task.label = scan AND event.name = tool_call_failed")
+                .len(),
+            self.scan_count
+        );
+        assert_eq!(
+            self.werk
+                .find_events(format!("event.name = {TAIL_EVENT}"))
+                .len(),
+            1
+        );
+    }
+}
+
+fn task_label(index: usize) -> &'static str {
+    if index.is_multiple_of(100) {
+        return "rare";
+    }
+    match index % 4 {
+        0 => "scan",
+        1 => "review",
+        2 => "report",
+        _ => "archive",
+    }
+}
+
+fn read_event_log(path: &Path) -> Vec<Event> {
+    std::fs::read_to_string(path)
+        .expect("read benchmark event log")
+        .lines()
+        .map(|line| serde_json::from_str(line).expect("deserialize benchmark event"))
+        .collect()
+}
+
+fn benchmark_compilation(runner: &mut Runner) {
+    let queries = [
+        ("compile/simple", "task.label = scan".to_string()),
+        (
+            "compile/compound",
+            "NOT (task.label IN (scan, review) OR task.status = failed) \
+             AND task.assignee IS EMPTY ORDER BY task.created DESC"
+                .to_string(),
+        ),
+        (
+            "compile/joined",
+            "task.label = scan AND event.name = tool_call_failed \
+             ORDER BY event.created DESC"
+                .to_string(),
+        ),
+        (
+            "compile/membership_64",
+            format!(
+                "task.id IN ({})",
+                (1..=64)
+                    .map(|id| format!("t-{id}"))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ),
+        ),
+    ];
+    for (name, query) in queries {
+        let work = Work::bytes(query.len());
+        runner.bench(name, work, || {
+            black_box(Query::new(black_box(&query)).expect("valid benchmark query"));
+        });
+    }
+}
+
+fn benchmark_task_selection(runner: &mut Runner, lazy: &LazyFixture) {
+    const NAMES: [&str; 9] = [
+        "task/find_tasks/label_closure",
+        "task/find_tasks/label_aql_compiled",
+        "task/find_tasks/label_aql_string",
+        "task/find_tasks/json_text_compiled",
+        "task/find_tasks/rare_default_order",
+        "task/find_tasks/broad_default_order",
+        "task/find_tasks/label_explicit_order",
+        "task/find_task/rare_default_order",
+        "task/find_task/rare_explicit_order",
+    ];
+    if !runner.any_selected(&NAMES) {
+        return;
+    }
+    let fixture = lazy.get();
+    let work = Work::records(fixture.task_count);
+    let label = Query::new("task.label = scan").unwrap();
+    let input = Query::new("task.input ~ needle").unwrap();
+    let rare = Query::new("task.label = rare").unwrap();
+    let all = Query::new("task.status = todo").unwrap();
+    let rare_ordered = Query::new("task.label = rare ORDER BY task.id DESC").unwrap();
+    let scan_ordered = Query::new("task.label = scan ORDER BY task.id DESC").unwrap();
+
+    runner.bench(NAMES[0], work, || {
+        black_box(
+            fixture
+                .werk
+                .find_tasks(|task: &Task| task.get_label() == Some("scan")),
+        );
+    });
+    runner.bench(NAMES[1], work, || {
+        black_box(fixture.werk.find_tasks(label.clone()));
+    });
+    runner.bench(NAMES[2], work, || {
+        black_box(fixture.werk.find_tasks("task.label = scan"));
+    });
+    runner.bench(NAMES[3], work, || {
+        black_box(fixture.werk.find_tasks(input.clone()));
+    });
+    runner.bench(NAMES[4], work, || {
+        black_box(fixture.werk.find_tasks(rare.clone()));
+    });
+    runner.bench(NAMES[5], work, || {
+        black_box(fixture.werk.find_tasks(all.clone()));
+    });
+    runner.bench(NAMES[6], work, || {
+        black_box(fixture.werk.find_tasks(scan_ordered.clone()));
+    });
+    runner.bench(NAMES[7], work, || {
+        black_box(fixture.werk.find_task(rare.clone()));
+    });
+    runner.bench(NAMES[8], work, || {
+        black_box(fixture.werk.find_task(rare_ordered.clone()));
+    });
+}
+
+fn benchmark_event_selection(runner: &mut Runner, lazy: &LazyFixture) {
+    const NAMES: [&str; 8] = [
+        "event/storage/read_file",
+        "event/storage/read_and_deserialize",
+        "event/find_events/name_closure",
+        "event/find_events/name_aql_compiled",
+        "event/find_events/json_text_compiled",
+        "event/find_events/name_explicit_order",
+        "event/find_event/first_match",
+        "event/find_event/tail_match",
+    ];
+    if !runner.any_selected(&NAMES) {
+        return;
+    }
+    let fixture = lazy.get();
+    let work = Work::records(fixture.event_count);
+    let name = Query::new("event.name = tool_call_failed").unwrap();
+    let data = Query::new("event.data ~ needle").unwrap();
+    let ordered = Query::new("event.name = tool_call_failed ORDER BY event.created DESC").unwrap();
+    let first = Query::new("event.name = task_created").unwrap();
+    let tail = Query::new(&format!("event.name = {TAIL_EVENT}")).unwrap();
+
+    runner.bench(NAMES[0], work, || {
+        black_box(std::fs::read_to_string(&fixture.events_path).unwrap());
+    });
+    runner.bench(NAMES[1], work, || {
+        black_box(read_event_log(&fixture.events_path));
+    });
+    runner.bench(NAMES[2], work, || {
+        black_box(
+            fixture
+                .werk
+                .find_events(|event: &Event| event.get_name() == Event::TOOL_CALL_FAILED),
+        );
+    });
+    runner.bench(NAMES[3], work, || {
+        black_box(fixture.werk.find_events(name.clone()));
+    });
+    runner.bench(NAMES[4], work, || {
+        black_box(fixture.werk.find_events(data.clone()));
+    });
+    runner.bench(NAMES[5], work, || {
+        black_box(fixture.werk.find_events(ordered.clone()));
+    });
+    runner.bench(NAMES[6], work, || {
+        black_box(fixture.werk.find_event(first.clone()));
+    });
+    runner.bench(NAMES[7], work, || {
+        black_box(fixture.werk.find_event(tail.clone()));
+    });
+}
+
+fn benchmark_cross_origin_and_joined(runner: &mut Runner, lazy: &LazyFixture) {
+    const NAMES: [&str; 7] = [
+        "joined/find_events/task_selected",
+        "joined/find_tasks/event_selected_deduplicated",
+        "joined/find_events/scan_and_failed",
+        "joined/find_tasks/scan_and_failed_deduplicated",
+        "joined/find_events/rare_and_failed",
+        "joined/find_events/scan_and_failed_ordered",
+        "joined/find_tasks/scan_and_failed_ordered_deduplicated",
+    ];
+    if !runner.any_selected(&NAMES) {
+        return;
+    }
+    let fixture = lazy.get();
+    let work = Work::records(fixture.event_count);
+    let task_to_events = Query::new("task.label = scan").unwrap();
+    let event_to_tasks = Query::new("event.name = tool_call_failed").unwrap();
+    let joined = Query::new("task.label = scan AND event.name = tool_call_failed").unwrap();
+    let joined_rare = Query::new("task.label = rare AND event.name = tool_call_failed").unwrap();
+    let joined_ordered = Query::new(
+        "task.label = scan AND event.name = tool_call_failed ORDER BY event.created DESC",
+    )
+    .unwrap();
+
+    runner.bench(NAMES[0], work, || {
+        black_box(fixture.werk.find_events(task_to_events.clone()));
+    });
+    runner.bench(NAMES[1], work, || {
+        black_box(fixture.werk.find_tasks(event_to_tasks.clone()));
+    });
+    runner.bench(NAMES[2], work, || {
+        black_box(fixture.werk.find_events(joined.clone()));
+    });
+    runner.bench(NAMES[3], work, || {
+        black_box(fixture.werk.find_tasks(joined.clone()));
+    });
+    runner.bench(NAMES[4], work, || {
+        black_box(fixture.werk.find_events(joined_rare.clone()));
+    });
+    runner.bench(NAMES[5], work, || {
+        black_box(fixture.werk.find_events(joined_ordered.clone()));
+    });
+    runner.bench(NAMES[6], work, || {
+        black_box(fixture.werk.find_tasks(joined_ordered.clone()));
+    });
+}
+
+fn benchmark_scaling(runner: &mut Runner, fixtures: &[LazyFixture]) {
+    let task = Query::new("task.label = scan").unwrap();
+    let event = Query::new("event.name = tool_call_failed").unwrap();
+    let joined = Query::new("task.label = scan AND event.name = tool_call_failed").unwrap();
+
+    for lazy in fixtures {
+        let names = [
+            format!("scale/task/find_tasks/{}", lazy.task_count),
+            format!(
+                "scale/event/find_events/{}",
+                lazy.task_count * EVENTS_PER_TASK
+            ),
+            format!(
+                "scale/joined/find_events/{}",
+                lazy.task_count * EVENTS_PER_TASK
+            ),
+        ];
+        if !names.iter().any(|name| runner.selected(name)) {
+            continue;
+        }
+        let fixture = lazy.get();
+        runner.bench(&names[0], Work::records(fixture.task_count), || {
+            black_box(fixture.werk.find_tasks(task.clone()));
+        });
+        runner.bench(&names[1], Work::records(fixture.event_count), || {
+            black_box(fixture.werk.find_events(event.clone()));
+        });
+        runner.bench(&names[2], Work::records(fixture.event_count), || {
+            black_box(fixture.werk.find_events(joined.clone()));
+        });
+    }
+}
+
+#[derive(Clone, Copy)]
+struct Work {
+    amount: u64,
+    unit: &'static str,
+}
+
+impl Work {
+    fn records(amount: usize) -> Self {
+        Self {
+            amount: amount as u64,
+            unit: "records/s",
+        }
+    }
+
+    fn bytes(amount: usize) -> Self {
+        Self {
+            amount: amount as u64,
+            unit: "bytes/s",
+        }
+    }
+}
+
+struct Runner {
+    config: Config,
+    baseline: BTreeMap<String, f64>,
+    results: BTreeMap<String, f64>,
+}
+
+impl Runner {
+    fn new(config: Config) -> Result<Self, String> {
+        let baseline = match &config.baseline {
+            Some(name) => load_baseline(name)?,
+            None => BTreeMap::new(),
+        };
+        Ok(Self {
+            config,
+            baseline,
+            results: BTreeMap::new(),
+        })
+    }
+
+    fn selected(&self, name: &str) -> bool {
+        match &self.config.filter {
+            Some(filter) => name.contains(filter),
+            None => true,
+        }
+    }
+
+    fn any_selected(&self, names: &[&str]) -> bool {
+        names.iter().any(|name| self.selected(name))
+    }
+
+    fn bench(&mut self, name: &str, work: Work, mut run: impl FnMut()) {
+        if !self.selected(name) {
+            return;
+        }
+        println!("Benchmarking {name}");
+        if let Some(duration) = self.config.profile_time {
+            let started = Instant::now();
+            let mut iterations = 0_u64;
+            while started.elapsed() < duration {
+                run();
+                iterations += 1;
+            }
+            let elapsed = started.elapsed();
+            println!(
+                "  profile: {iterations} iterations in {} ({})",
+                format_duration(elapsed.as_nanos() as f64),
+                format_rate(iterations as f64 / elapsed.as_secs_f64(), "iterations/s")
+            );
+            return;
+        }
+
+        let repetitions = calibrate(&mut run);
+        let warm_up = Instant::now();
+        while warm_up.elapsed() < WARM_UP_TIME {
+            run_batch(repetitions, &mut run);
+        }
+
+        let mut samples = Vec::with_capacity(self.config.samples);
+        for _ in 0..self.config.samples {
+            let started = Instant::now();
+            run_batch(repetitions, &mut run);
+            samples.push(started.elapsed().as_nanos() as f64 / repetitions as f64);
+        }
+        samples.sort_by(f64::total_cmp);
+        let median = median(&samples);
+        let low = percentile(&samples, 10);
+        let high = percentile(&samples, 90);
+        let throughput = work.amount as f64 / (median / 1_000_000_000.0);
+        println!(
+            "  time: [{} {} {}]  throughput: {}",
+            format_duration(low),
+            format_duration(median),
+            format_duration(high),
+            format_rate(throughput, work.unit)
+        );
+        if let Some(previous) = self.baseline.get(name) {
+            println!("  change: {:+.2}%", (median / previous - 1.0) * 100.0);
+        }
+        self.results.insert(name.to_string(), median);
+    }
+
+    fn finish(&self) -> io::Result<()> {
+        if let Some(name) = &self.config.save_baseline {
+            let path = baseline_path(name);
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+            std::fs::write(&path, serde_json::to_vec_pretty(&self.results)?)?;
+            println!("Saved baseline to {}", path.display());
+        }
+        Ok(())
+    }
+}
+
+fn calibrate(run: &mut impl FnMut()) -> u64 {
+    let mut repetitions = 1_u64;
+    loop {
+        let started = Instant::now();
+        run_batch(repetitions, run);
+        if started.elapsed() >= CALIBRATION_TIME || repetitions >= 1 << 30 {
+            return repetitions;
+        }
+        repetitions *= 2;
+    }
+}
+
+fn run_batch(repetitions: u64, run: &mut impl FnMut()) {
+    for _ in 0..repetitions {
+        run();
+    }
+}
+
+fn median(samples: &[f64]) -> f64 {
+    let middle = samples.len() / 2;
+    if samples.len().is_multiple_of(2) {
+        (samples[middle - 1] + samples[middle]) / 2.0
+    } else {
+        samples[middle]
+    }
+}
+
+fn percentile(samples: &[f64], percentile: usize) -> f64 {
+    samples[(samples.len() - 1) * percentile / 100]
+}
+
+fn format_duration(nanos: f64) -> String {
+    if nanos >= 1_000_000_000.0 {
+        format!("{:.3} s", nanos / 1_000_000_000.0)
+    } else if nanos >= 1_000_000.0 {
+        format!("{:.3} ms", nanos / 1_000_000.0)
+    } else if nanos >= 1_000.0 {
+        format!("{:.3} us", nanos / 1_000.0)
+    } else {
+        format!("{nanos:.3} ns")
+    }
+}
+
+fn format_rate(rate: f64, unit: &str) -> String {
+    if rate >= 1_000_000.0 {
+        format!("{:.3} M{unit}", rate / 1_000_000.0)
+    } else if rate >= 1_000.0 {
+        format!("{:.3} K{unit}", rate / 1_000.0)
+    } else {
+        format!("{rate:.3} {unit}")
+    }
+}
+
+#[derive(Default)]
+struct Config {
+    filter: Option<String>,
+    samples: usize,
+    profile_time: Option<Duration>,
+    save_baseline: Option<String>,
+    baseline: Option<String>,
+    help: bool,
+}
+
+impl Config {
+    fn from_args() -> Result<Self, String> {
+        let mut config = Self {
+            samples: DEFAULT_SAMPLES,
+            ..Self::default()
+        };
+        let mut args = env::args().skip(1);
+        while let Some(argument) = args.next() {
+            match argument.as_str() {
+                "-h" | "--help" => config.help = true,
+                // Cargo passes this to every custom benchmark harness.
+                "--bench" => {}
+                "--samples" => {
+                    config.samples = value(&mut args, "--samples")?
+                        .parse()
+                        .map_err(|_| "--samples must be a positive integer".to_string())?;
+                    if config.samples == 0 {
+                        return Err("--samples must be a positive integer".to_string());
+                    }
+                }
+                "--profile-time" => {
+                    let seconds: u64 = value(&mut args, "--profile-time")?
+                        .parse()
+                        .map_err(|_| "--profile-time must be positive seconds".to_string())?;
+                    if seconds == 0 {
+                        return Err("--profile-time must be positive seconds".to_string());
+                    }
+                    config.profile_time = Some(Duration::from_secs(seconds));
+                }
+                "--save-baseline" => {
+                    config.save_baseline =
+                        Some(baseline_name(value(&mut args, "--save-baseline")?)?);
+                }
+                "--baseline" => {
+                    config.baseline = Some(baseline_name(value(&mut args, "--baseline")?)?);
+                }
+                option if option.starts_with('-') => {
+                    return Err(format!("unknown option {option:?}"));
+                }
+                filter if config.filter.is_none() => config.filter = Some(filter.to_string()),
+                filter => return Err(format!("unexpected second filter {filter:?}")),
+            }
+        }
+        Ok(config)
+    }
+}
+
+fn value(args: &mut impl Iterator<Item = String>, option: &str) -> Result<String, String> {
+    args.next()
+        .ok_or_else(|| format!("{option} requires a value"))
+}
+
+fn baseline_name(name: String) -> Result<String, String> {
+    if !name.is_empty()
+        && name
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || "-_.".contains(character))
+    {
+        return Ok(name);
+    }
+    Err("baseline names may contain only letters, digits, '-', '_', and '.'".to_string())
+}
+
+fn load_baseline(name: &str) -> Result<BTreeMap<String, f64>, String> {
+    let path = baseline_path(name);
+    let body = std::fs::read_to_string(&path)
+        .map_err(|error| format!("could not read baseline {}: {error}", path.display()))?;
+    serde_json::from_str(&body)
+        .map_err(|error| format!("could not parse baseline {}: {error}", path.display()))
+}
+
+fn baseline_path(name: &str) -> PathBuf {
+    target_dir().join("aql-bench").join(format!("{name}.json"))
+}
+
+fn target_dir() -> PathBuf {
+    env::var_os("CARGO_TARGET_DIR").map_or_else(
+        || {
+            Path::new(env!("CARGO_MANIFEST_DIR"))
+                .parent()
+                .and_then(Path::parent)
+                .expect("agentwerk belongs to the workspace")
+                .join("target")
+        },
+        PathBuf::from,
+    )
+}
+
+fn print_help() {
+    println!(
+        "AQL performance benchmark\n\n\
+         Usage: cargo bench -p agentwerk --bench aql -- [FILTER] [OPTIONS]\n\n\
+         Options:\n\
+           --samples N          Samples per benchmark (default: {DEFAULT_SAMPLES})\n\
+           --profile-time SEC   Repeat matching benchmarks for the profiler\n\
+           --save-baseline NAME Save median timings under target/aql-bench\n\
+           --baseline NAME      Compare medians with a saved baseline\n\
+           -h, --help           Print this help"
+    );
+}
+
+struct TempDir {
+    path: PathBuf,
+}
+
+impl TempDir {
+    fn new() -> io::Result<Self> {
+        let base = env::temp_dir();
+        for _ in 0..16 {
+            let candidate = base.join(format!("agentwerk-aql-{}-{}", std::process::id(), unique()));
+            match std::fs::create_dir(&candidate) {
+                Ok(()) => return Ok(Self { path: candidate }),
+                Err(error) if error.kind() == io::ErrorKind::AlreadyExists => continue,
+                Err(error) => return Err(error),
+            }
+        }
+        Err(io::Error::new(
+            io::ErrorKind::AlreadyExists,
+            "could not allocate an AQL benchmark directory",
+        ))
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.path);
+    }
+}
+
+fn unique() -> u64 {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos() as u64)
+        .unwrap_or(0);
+    nanos.wrapping_add(COUNTER.fetch_add(1, Ordering::Relaxed))
+}

--- a/crates/agentwerk/src/agents/loop/agent.rs
+++ b/crates/agentwerk/src/agents/loop/agent.rs
@@ -545,7 +545,7 @@ mod tests {
             if done.get_label() != Some("scan") {
                 return;
             }
-            let scans = werk.find_results("label = scan AND status = finished");
+            let scans = werk.find_results("task.label = scan AND task.status = finished");
             if scans.len() < 2 || filed.swap(true, Ordering::SeqCst) {
                 return;
             }
@@ -574,14 +574,14 @@ mod tests {
             .await
             .expect("finish did not finish within 5s");
 
-        let report = werk.find_task("label = report").unwrap();
+        let report = werk.find_task("task.label = report").unwrap();
         assert_eq!(
             report.task,
             serde_json::json!("Write the report from \"clean\" and \"clean\".")
         );
         assert_eq!(report.status, Status::Finished);
         assert_eq!(
-            werk.find_results("label = report"),
+            werk.find_results("task.label = report"),
             vec![serde_json::json!("report-done")]
         );
     }
@@ -1108,7 +1108,7 @@ mod tests {
 
         // Cancel research tasks in the current execution before adding both tasks; analysis continues.
         werk.start();
-        werk.cancel_tasks("label = research");
+        werk.cancel_tasks("task.label = research");
         werk.add_task(Task::new("hunt").label("research"));
         werk.add_task(Task::new("triage").label("analysis"));
 

--- a/crates/agentwerk/src/agents/query.rs
+++ b/crates/agentwerk/src/agents/query.rs
@@ -1,4 +1,4 @@
-//! Parses origin-qualified AQL into queries over tasks and events.
+//! Parses AQL into queries over tasks, events, and task-event joins.
 
 use std::borrow::{Borrow, Cow};
 use std::cmp::Ordering;
@@ -19,10 +19,11 @@ use crate::event::Event;
 ///
 /// # fn run() -> Result<(), Box<dyn std::error::Error>> {
 /// let werk = Werk::new();
-/// werk.find_tasks("task.label = research");
+/// werk.find_tasks("research");
 /// werk.find_tasks(Query::new("task.label = research AND task.assignee = research-1")?);
 /// werk.find_tasks(|t: &Task| t.get_label() == Some("research"));
 /// werk.find_events("event.name = tool_call_failed");
+/// werk.find_events("research AND event.name = tool_call_failed");
 /// werk.find_events(|e: &Event| e.get_name().ends_with("_failed"));
 /// # Ok(())
 /// # }
@@ -34,7 +35,7 @@ pub trait Matcher<R> {
 }
 
 #[cfg(test)]
-mod origin_tests {
+mod tests {
     use super::*;
     use serde_json::json;
 
@@ -72,26 +73,64 @@ mod origin_tests {
 
         for (source, origin) in cases {
             let query = Query::new(source).unwrap_or_else(|error| panic!("{source}: {error}"));
-            assert_eq!(query.0.origin, Some(origin), "{source}");
+            assert_eq!(query.origin(), origin, "{source}");
         }
     }
 
     #[test]
-    fn bare_task_id_and_order_only_queries_infer_an_origin() {
-        assert_eq!(Query::new("t-3").unwrap().0.origin, Some(Origin::Task));
+    fn bare_values_are_task_label_shorthand() {
+        let scan = task("t-1");
+        let review = task("t-2").label("needs review");
+
+        for (source, subject) in [("scan", &scan), ("\"needs review\"", &review)] {
+            let query = Query::new(source).unwrap();
+            assert_eq!(query.origin(), Origin::Task, "{source}");
+            assert!(query.matches_task(subject), "{source}");
+        }
+    }
+
+    #[test]
+    fn bare_task_ids_take_precedence_over_label_shorthand() {
+        let id_match = task("t-3").label("other");
+        let label_match = task("t-4").label("t-3");
+        let query = Query::new("t-3").unwrap();
+
+        assert!(query.matches_task(&id_match));
+        assert!(!query.matches_task(&label_match));
+    }
+
+    #[test]
+    fn order_only_queries_infer_an_origin() {
         assert_eq!(
-            Query::new("ORDER BY event.created DESC").unwrap().0.origin,
-            Some(Origin::Event)
+            Query::new("ORDER BY event.created DESC").unwrap().origin(),
+            Origin::Event
         );
     }
 
     #[test]
-    fn unqualified_and_mixed_fields_are_rejected() {
+    fn blank_queries_are_rejected() {
         assert!(matches!(Query::new("  "), Err(QueryError::TermsMissing)));
-        assert!(matches!(
-            Query::new("label = scan"),
-            Err(QueryError::FieldUnrecognized { .. })
-        ));
+    }
+
+    #[test]
+    fn unqualified_field_expressions_are_rejected() {
+        let error = Query::new("label = scan").unwrap_err();
+
+        assert!(matches!(&error, QueryError::FieldUnrecognized { .. }));
+        assert!(error.to_string().contains("task.label"));
+    }
+
+    #[test]
+    fn bare_event_names_are_task_labels_not_event_shorthand() {
+        let labelled = task("t-1").label(Event::TOOL_CALL_FAILED);
+        let query = Query::new("tool_call_failed").unwrap();
+
+        assert_eq!(query.origin(), Origin::Task);
+        assert!(query.matches_task(&labelled));
+    }
+
+    #[test]
+    fn the_removed_result_namespace_is_rejected() {
         for field in [
             "result.task_id",
             "result.label",
@@ -116,51 +155,94 @@ mod origin_tests {
                 "{field}"
             );
         }
-        assert!(matches!(
-            Query::new("task.label = scan AND event.label = scan"),
-            Err(QueryError::OriginsMixed {
-                first: "task.label",
-                second: "event.label"
-            })
-        ));
-        assert!(matches!(
-            Query::new("task.label = scan ORDER BY event.created"),
-            Err(QueryError::OriginsMixed {
-                first: "task.label",
-                second: "event.created"
-            })
-        ));
     }
 
     #[test]
-    fn grouping_boolean_presence_membership_status_and_time_still_compile() {
+    fn using_both_namespaces_infers_a_joined_source() {
         for source in [
-            "NOT (task.label = scan OR task.status IN (todo, failed))",
-            "task.label != scan",
-            "task.label NOT IN (scan, report)",
-            "task.assignee IS EMPTY",
-            "task.assignee IS NOT EMPTY",
-            "task.input ~ retry",
-            "task.input !~ retry",
-            "task.created > 0",
-            "task.created >= 2026-08-24",
-            "task.finished < -1h",
-            "task.finished <= -1w",
+            "scan AND event.name = task_finished",
+            "task.label = scan AND event.label = scan",
+            "task.label = scan OR event.label = scan",
+            "task.label = scan AND NOT event.name = task_failed",
+            "task.label = scan ORDER BY event.created",
         ] {
-            Query::new(source).unwrap_or_else(|error| panic!("{source}: {error}"));
+            assert_eq!(
+                Query::new(source).unwrap().origin(),
+                Origin::Joined,
+                "{source}"
+            );
         }
-        for status in ["todo", "IN_PROGRESS", "Finished", "failed"] {
-            Query::new(&format!("task.status = {status}"))
-                .unwrap_or_else(|error| panic!("{status}: {error}"));
-        }
-        for name in [
-            Event::TASK_CREATED,
-            Event::REQUEST_RETRIED,
-            "application_event",
+    }
+
+    #[test]
+    fn boolean_membership_presence_and_text_operators_match_tasks() {
+        let scan = task("t-1");
+        let mut report = task("t-2");
+        report.label = Some("report".into());
+        let mut unlabelled = task("t-3");
+        unlabelled.label = None;
+
+        for (source, subject, expected) in [
+            ("task.label IN (scan, review)", &scan, true),
+            ("task.label NOT IN (scan, review)", &report, true),
+            ("NOT (task.label = report OR task.id = t-2)", &scan, true),
+            ("task.assignee IS EMPTY", &scan, true),
+            ("task.assignee IS NOT EMPTY", &scan, false),
+            ("task.input ~ SCAN", &scan, true),
+            ("task.input !~ report", &scan, true),
+            ("task.label != scan", &unlabelled, false),
         ] {
-            Query::new(&format!("event.name = {name}"))
-                .unwrap_or_else(|error| panic!("{name}: {error}"));
+            assert_eq!(
+                Query::new(source).unwrap().matches_task(subject),
+                expected,
+                "{source}"
+            );
         }
+    }
+
+    #[test]
+    fn time_operators_compare_milliseconds_and_accept_dates_and_offsets() {
+        let mut subject = task("t-100");
+        subject.created_at = 100;
+
+        assert!(Query::new("task.created > 99")
+            .unwrap()
+            .matches_task(&subject));
+        assert!(Query::new("task.created <= 100")
+            .unwrap()
+            .matches_task(&subject));
+        assert!(Query::new("task.started IS EMPTY")
+            .unwrap()
+            .matches_task(&subject));
+        Query::new("task.created >= 2026-08-24").unwrap();
+        Query::new("task.finished < -1h").unwrap();
+    }
+
+    #[test]
+    fn statuses_are_canonicalized_before_matching() {
+        let mut subject = task("t-1");
+        subject.status = Status::InProgress;
+
+        for spelling in ["in_progress", "IN_PROGRESS", "In_Progress"] {
+            assert!(Query::new(&format!("task.status = {spelling}"))
+                .unwrap()
+                .matches_task(&subject));
+        }
+    }
+
+    #[test]
+    fn custom_event_names_match_exactly() {
+        let event = Event::new("ApplicationEvent");
+        assert!(Query::new("event.name = ApplicationEvent")
+            .unwrap()
+            .matches_event(&event));
+        assert!(!Query::new("event.name = applicationevent")
+            .unwrap()
+            .matches_event(&event));
+    }
+
+    #[test]
+    fn malformed_statuses_and_times_report_their_error_kind() {
         assert!(matches!(
             Query::new("task.status = unknown"),
             Err(QueryError::StatusUnrecognized { .. })
@@ -169,17 +251,42 @@ mod origin_tests {
             Query::new("task.created > tomorrow"),
             Err(QueryError::TimeMalformed { .. })
         ));
+    }
+
+    #[test]
+    fn fields_reject_operators_for_another_value_kind() {
+        for source in ["task.input = retry", "task.id ~ t-1", "task.created = 0"] {
+            assert!(
+                matches!(
+                    Query::new(source),
+                    Err(QueryError::OperatorNotAllowed { .. })
+                ),
+                "{source}"
+            );
+        }
+    }
+
+    #[test]
+    fn repeated_equalities_suggest_membership() {
+        let error = Query::new("task.id = t-1 AND task.id = t-2").unwrap_err();
+
+        assert!(matches!(&error, QueryError::FieldRepeated { .. }));
+        assert!(error.to_string().contains("task.id IN (a, b)"));
+    }
+
+    #[test]
+    fn trailing_tokens_are_rejected() {
         assert!(matches!(
-            Query::new("task.input = retry"),
-            Err(QueryError::OperatorNotAllowed { .. })
+            Query::new("task.id = t-1 trailing"),
+            Err(QueryError::TokenRejected { .. })
         ));
+    }
+
+    #[test]
+    fn unfinished_terms_are_rejected() {
         assert!(matches!(
-            Query::new("task.id ~ t-1"),
-            Err(QueryError::OperatorNotAllowed { .. })
-        ));
-        assert!(matches!(
-            Query::new("task.created = 0"),
-            Err(QueryError::OperatorNotAllowed { .. })
+            Query::new("task.id ="),
+            Err(QueryError::TermUnfinished)
         ));
     }
 
@@ -206,14 +313,10 @@ mod origin_tests {
         assert!(Query::new("task.result ~ clean")
             .unwrap()
             .matches_task(&finished));
-        assert!(matches!(
-            Query::new("result.value ~ clean"),
-            Err(QueryError::FieldUnrecognized { .. })
-        ));
     }
 
     #[test]
-    fn task_ids_statuses_and_missing_values_keep_their_sort_order() {
+    fn task_ids_sort_by_their_numeric_suffix() {
         let mut tasks = vec![task("t-10"), task("t-2"), task("t-1")];
         Query::new("ORDER BY task.id")
             .unwrap()
@@ -225,7 +328,11 @@ mod origin_tests {
                 .collect::<Vec<_>>(),
             ["t-1", "t-2", "t-10"]
         );
+    }
 
+    #[test]
+    fn statuses_sort_in_lifecycle_order() {
+        let mut tasks = vec![task("t-1"), task("t-2"), task("t-3")];
         tasks[0].status = Status::Failed;
         tasks[1].status = Status::Finished;
         tasks[2].status = Status::Todo;
@@ -236,7 +343,11 @@ mod origin_tests {
             tasks.iter().map(|task| task.status).collect::<Vec<_>>(),
             [Status::Todo, Status::Finished, Status::Failed]
         );
+    }
 
+    #[test]
+    fn missing_optional_values_sort_last_in_both_directions() {
+        let mut tasks = vec![task("t-1"), task("t-2"), task("t-3")];
         tasks[0].assignee = None;
         tasks[1].assignee = Some("a".into());
         tasks[2].assignee = Some("z".into());
@@ -244,18 +355,73 @@ mod origin_tests {
             .unwrap()
             .sort_tasks(&mut tasks);
         assert_eq!(tasks.last().unwrap().assignee, None);
+
+        Query::new("ORDER BY task.assignee")
+            .unwrap()
+            .sort_tasks(&mut tasks);
+        assert_eq!(tasks.last().unwrap().assignee, None);
     }
 
     #[test]
-    fn a_compiled_query_rejects_the_wrong_target() {
-        let query = Query::new("event.name = task_created").unwrap();
-        assert!(matches!(
-            query.expects_task(),
-            Err(QueryError::OriginMismatch {
-                expected: "task",
-                actual: "event"
-            })
-        ));
+    fn mixed_conditions_are_evaluated_against_one_joined_pair() {
+        let scan = task("t-1");
+        let matching = Event::new(Event::TASK_CREATED)
+            .task_id("t-1")
+            .data(json!({"kind": "scan"}));
+        let other = Event::new(Event::TASK_FAILED).task_id("t-1");
+        let wrong_task = task("t-2").label("report");
+        let query =
+            Query::new("task.label = scan AND event.name = task_created AND event.data ~ scan")
+                .unwrap();
+
+        assert!(query.matches_joined(&scan, &matching));
+        assert!(!query.matches_joined(&scan, &other));
+        assert!(!query.matches_joined(&wrong_task, &matching));
+    }
+
+    #[test]
+    fn joined_boolean_operators_evaluate_each_task_event_pair() {
+        let scan = task("t-1");
+        let report = task("t-2").label("report");
+        let selected = Event::new("selected");
+        let ordinary = Event::new("ordinary");
+        let either = Query::new("task.label = scan OR event.name = selected").unwrap();
+        let neither = Query::new("NOT task.label = report AND NOT event.name = selected").unwrap();
+
+        assert!(either.matches_joined(&scan, &ordinary));
+        assert!(either.matches_joined(&report, &selected));
+        assert!(!either.matches_joined(&report, &ordinary));
+        assert!(neither.matches_joined(&scan, &ordinary));
+        assert!(!neither.matches_joined(&report, &ordinary));
+        assert!(!neither.matches_joined(&scan, &selected));
+    }
+
+    #[test]
+    fn joined_sorting_can_order_events_by_a_task_field() {
+        let first = task("t-1");
+        let second = task("t-2");
+        let mut pairs = vec![
+            (second.clone(), Event::new("second-a")),
+            (first.clone(), Event::new("first-a")),
+            (second, Event::new("second-b")),
+            (first, Event::new("first-b")),
+        ];
+        Query::new("event.name IN (first-a, first-b, second-a, second-b) ORDER BY task.id")
+            .unwrap()
+            .sort_joined(&mut pairs);
+
+        assert_eq!(
+            pairs
+                .iter()
+                .map(|(task, event)| (task.id.as_str(), event.name.as_str()))
+                .collect::<Vec<_>>(),
+            [
+                ("t-1", "first-a"),
+                ("t-1", "first-b"),
+                ("t-2", "second-a"),
+                ("t-2", "second-b"),
+            ]
+        );
     }
 }
 
@@ -300,18 +466,23 @@ impl<R> Matcher<R> for Query {
 pub struct Query(Compiled);
 
 impl Query {
-    /// Compile an AQL string. Every named field must have one origin.
+    /// Compile an AQL string. Task and event fields may be joined through a
+    /// recorded event's task ID. A lone value matches `task.label`, except a
+    /// bare `t-N`, which matches `task.id`.
     ///
     /// ```
     /// use agentwerk::Query;
     ///
     /// # fn run() -> Result<(), Box<dyn std::error::Error>> {
+    /// Query::new("research")?;
+    /// Query::new("\"needs review\"")?;
     /// Query::new("task.status = finished AND task.label IN (scan, report)")?;
     /// Query::new("task.input ~ \"retry budget\" AND task.assignee IS EMPTY")?;
     /// Query::new("t-3")?;
     /// Query::new("task.label = scan ORDER BY task.finished DESC")?;
     /// Query::new("event.name = tool_call_failed")?;
     /// Query::new("event.data ~ timeout AND event.created > -1h")?;
+    /// Query::new("scan AND event.name = task_finished")?;
     /// # Ok(())
     /// # }
     /// # run().unwrap();
@@ -328,6 +499,11 @@ impl Query {
     pub(crate) fn matches_event(&self, event: &Event) -> bool {
         self.assert_origin(Origin::Event);
         self.0.matches(View::Event(event))
+    }
+
+    pub(crate) fn matches_joined(&self, task: &Task, event: &Event) -> bool {
+        self.assert_origin(Origin::Joined);
+        self.0.matches(View::Joined(task, event))
     }
 
     /// Every record, in its origin's default order.
@@ -357,6 +533,11 @@ impl Query {
         self.0.sort_events(records);
     }
 
+    pub(crate) fn sort_joined(&self, records: &mut [(Task, Event)]) {
+        self.assert_origin(Origin::Joined);
+        self.0.sort_joined(records);
+    }
+
     pub(crate) fn task(mut self) -> Query {
         self.0.bind(Origin::Task);
         self
@@ -372,19 +553,15 @@ impl Query {
         self
     }
 
-    pub(crate) fn is_event(&self) -> bool {
-        self.0.origin == Some(Origin::Event)
-    }
-
-    #[doc(hidden)]
-    pub fn expects_task(&self) -> Result<(), QueryError> {
-        self.0.expects(Origin::Task)
+    pub(crate) fn origin(&self) -> Origin {
+        self.0.origin.unwrap_or(Origin::Task)
     }
 
     fn assert_origin(&self, expected: Origin) {
-        self.0
-            .expects(expected)
-            .unwrap_or_else(|error| panic!("invalid query target: {error}"));
+        assert!(
+            self.0.origin.is_none() || self.0.origin == Some(expected),
+            "query resolver must match its source"
+        );
     }
 
     /// Also `status = <status>`, whatever the query already says.
@@ -469,6 +646,8 @@ impl Predicate {
         match (self, record) {
             (Predicate::Task(check), View::Task(task)) => check(task),
             (Predicate::Event(check), View::Event(event)) => check(event),
+            (Predicate::Task(check), View::Joined(task, _)) => check(task),
+            (Predicate::Event(check), View::Joined(_, event)) => check(event),
             _ => false,
         }
     }
@@ -536,8 +715,7 @@ impl Compiled {
     /// Both conditions. The order is this query's, since `other` is the term a
     /// caller never wrote and so never ordered by.
     fn and(self, other: Self) -> Self {
-        let origin = merge_origins(self.origin, other.origin)
-            .expect("internally combined queries must have one origin");
+        let origin = merge_origins(self.origin, other.origin);
         Self {
             root: Condition::All(vec![self.root, other.root]),
             order: self.order.or(other.order),
@@ -579,19 +757,22 @@ impl Compiled {
         }
     }
 
-    fn expects(&self, expected: Origin) -> Result<(), QueryError> {
-        match self.origin {
-            Some(actual) if actual != expected => Err(QueryError::OriginMismatch {
-                expected: expected.name(),
-                actual: actual.name(),
-            }),
-            _ => Ok(()),
+    fn sort_joined(&self, records: &mut [(Task, Event)]) {
+        if let Some(order) = &self.order {
+            records.sort_by(|(left_task, left_event), (right_task, right_event)| {
+                order.compare(
+                    View::Joined(left_task, left_event),
+                    View::Joined(right_task, right_event),
+                )
+            });
         }
     }
 
     fn bind(&mut self, expected: Origin) {
-        self.expects(expected)
-            .unwrap_or_else(|error| panic!("invalid query target: {error}"));
+        assert!(
+            self.origin.is_none() || self.origin == Some(expected),
+            "query binding must not replace its source"
+        );
         self.origin = Some(expected);
     }
 
@@ -603,31 +784,17 @@ impl Compiled {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum Origin {
+pub(crate) enum Origin {
     Task,
     Event,
+    Joined,
 }
 
-impl Origin {
-    fn name(self) -> &'static str {
-        match self {
-            Origin::Task => "task",
-            Origin::Event => "event",
-        }
-    }
-}
-
-fn merge_origins(
-    left: Option<Origin>,
-    right: Option<Origin>,
-) -> Result<Option<Origin>, QueryError> {
+fn merge_origins(left: Option<Origin>, right: Option<Origin>) -> Option<Origin> {
     match (left, right) {
-        (Some(left), Some(right)) if left != right => Err(QueryError::OriginsMixed {
-            first: left.name(),
-            second: right.name(),
-        }),
-        (Some(origin), _) | (_, Some(origin)) => Ok(Some(origin)),
-        (None, None) => Ok(None),
+        (Some(left), Some(right)) if left != right => Some(Origin::Joined),
+        (Some(origin), _) | (_, Some(origin)) => Some(origin),
+        (None, None) => None,
     }
 }
 
@@ -635,6 +802,7 @@ fn merge_origins(
 enum View<'a> {
     Task(&'a Task),
     Event(&'a Event),
+    Joined(&'a Task, &'a Event),
 }
 
 impl<'a> View<'a> {
@@ -642,6 +810,11 @@ impl<'a> View<'a> {
         match self {
             View::Task(task) => field.of_task(task),
             View::Event(event) => field.of_event(event),
+            View::Joined(task, event) => match field.origin() {
+                Origin::Task => field.of_task(task),
+                Origin::Event => field.of_event(event),
+                Origin::Joined => unreachable!("fields have one origin"),
+            },
         }
     }
 
@@ -649,6 +822,7 @@ impl<'a> View<'a> {
         match self {
             View::Task(task) => (task.created_at, numeric_id(&task.id)),
             View::Event(event) => (event.created_at, 0),
+            View::Joined(task, event) => (event.created_at, numeric_id(&task.id)),
         }
     }
 }
@@ -930,8 +1104,16 @@ impl Sort {
             true => placed.reverse(),
             false => placed,
         };
-        // Ties keep the record order, so one query always answers one list.
-        placed.then_with(|| left.tie_break().cmp(&right.tie_break()))
+        placed.then_with(|| match (self.field.origin(), left, right) {
+            (Origin::Task, View::Joined(left, _), View::Joined(right, _)) => {
+                (left.created_at, numeric_id(&left.id))
+                    .cmp(&(right.created_at, numeric_id(&right.id)))
+            }
+            (Origin::Event, View::Joined(_, left), View::Joined(_, right)) => {
+                left.created_at.cmp(&right.created_at)
+            }
+            _ => left.tie_break().cmp(&right.tie_break()),
+        })
     }
 }
 
@@ -1077,20 +1259,6 @@ pub enum QueryError {
         /// Valid fields for this record type.
         known: String,
     },
-    /// Fields from two record origins appeared in one query.
-    OriginsMixed {
-        /// Property inferred before the conflict.
-        first: &'static str,
-        /// Conflicting property.
-        second: &'static str,
-    },
-    /// A compiled query was supplied to an operation requiring another origin.
-    OriginMismatch {
-        /// Origin required by the receiving finder.
-        expected: &'static str,
-        /// Origin inferred when the query was compiled.
-        actual: &'static str,
-    },
     /// No status is spelled this way.
     StatusUnrecognized {
         /// Unrecognized status spelling.
@@ -1133,17 +1301,6 @@ impl fmt::Display for QueryError {
             ),
             Self::FieldUnrecognized { name, known } => {
                 write!(f, "No field named `{name}`. Use one of {known}.")
-            }
-            Self::OriginsMixed { first, second } => write!(
-                f,
-                "A query must use one record origin, but `{first}` conflicts with `{second}`."
-            ),
-            Self::OriginMismatch { expected, actual } => {
-                let article = if *expected == "event" { "an" } else { "a" };
-                write!(
-                    f,
-                    "This operation requires {article} {expected} query, but the query has {actual} origin."
-                )
             }
             Self::StatusUnrecognized { value } => write!(
                 f,
@@ -1278,7 +1435,7 @@ fn parse_query(query: &str) -> Result<(Condition, Option<Sort>, Origin), QueryEr
     let mut parser = Parser {
         tokens,
         at: 0,
-        origin_field: None,
+        origin: None,
     };
     // A query naming nothing but an order selects every record, which is how
     // the tasks tool asks for the newest without narrowing first.
@@ -1294,10 +1451,7 @@ fn parse_query(query: &str) -> Result<(Condition, Option<Sort>, Origin), QueryEr
         None => Ok((
             condition,
             order,
-            parser
-                .origin_field
-                .expect("a nonblank query names an origin")
-                .origin(),
+            parser.origin.expect("a nonblank query names an origin"),
         )),
     }
 }
@@ -1305,7 +1459,7 @@ fn parse_query(query: &str) -> Result<(Condition, Option<Sort>, Origin), QueryEr
 struct Parser {
     tokens: Vec<Token>,
     at: usize,
-    origin_field: Option<Field>,
+    origin: Option<Origin>,
 }
 
 impl Parser {
@@ -1399,15 +1553,14 @@ impl Parser {
         self.term()
     }
 
-    /// `field operator value?`, or a bare task ID.
+    /// `field operator value?`, a bare task ID, or a task-label shorthand.
     fn term(&mut self) -> Result<Condition, QueryError> {
         let token = self.next().ok_or(QueryError::TermUnfinished)?;
         let word = match token {
             Token::Word(word) => word,
             Token::Quoted(text) => {
-                return Err(QueryError::TokenRejected {
-                    token: format!("\"{text}\""),
-                })
+                self.record_field(Field::TaskLabel);
+                return Ok(Condition::Term(Field::TaskLabel, Match::Is(text)));
             }
             other => {
                 return Err(QueryError::TokenRejected {
@@ -1417,14 +1570,13 @@ impl Parser {
         };
 
         if !self.at_operator() {
-            if is_task_id(&word) {
-                self.record_field(Field::TaskId)?;
-                return Ok(Condition::Term(Field::TaskId, Match::Is(word)));
-            }
-            return Err(QueryError::FieldUnrecognized {
-                name: word,
-                known: Field::spellings(),
-            });
+            let field = if is_task_id(&word) {
+                Field::TaskId
+            } else {
+                Field::TaskLabel
+            };
+            self.record_field(field);
+            return Ok(Condition::Term(field, Match::Is(word)));
         }
         let field = self.field(word)?;
         let matcher = self.operator(field)?;
@@ -1556,22 +1708,12 @@ impl Parser {
             name,
             known: Field::spellings(),
         })?;
-        self.record_field(field)?;
+        self.record_field(field);
         Ok(field)
     }
 
-    fn record_field(&mut self, field: Field) -> Result<(), QueryError> {
-        if let Some(first) = self.origin_field {
-            if first.origin() != field.origin() {
-                return Err(QueryError::OriginsMixed {
-                    first: first.name(),
-                    second: field.name(),
-                });
-            }
-        } else {
-            self.origin_field = Some(field);
-        }
-        Ok(())
+    fn record_field(&mut self, field: Field) {
+        self.origin = merge_origins(self.origin, Some(field.origin()));
     }
 }
 

--- a/crates/agentwerk/src/agents/query.rs
+++ b/crates/agentwerk/src/agents/query.rs
@@ -1,4 +1,4 @@
-//! Parses AQL into queries over tasks and recorded events.
+//! Parses origin-qualified AQL into queries over tasks and events.
 
 use std::borrow::{Borrow, Cow};
 use std::cmp::Ordering;
@@ -7,22 +7,6 @@ use std::sync::Arc;
 
 use super::tasks::{now_millis, numeric_id, Status, Task};
 use crate::event::Event;
-
-/// A record a query selects, and the field set AQL names it by.
-///
-/// Implemented for [`Task`] and [`Event`]. Private, so the field sets and
-/// everything the parser builds stay inside this module.
-trait Queryable: fmt::Debug + Clone + Send + Sync + 'static {
-    type Field: QueryField<Record = Self>;
-}
-
-impl Queryable for Task {
-    type Field = TaskField;
-}
-
-impl Queryable for Event {
-    type Field = EventField;
-}
 
 /// A condition a record is tested against.
 ///
@@ -35,78 +19,299 @@ impl Queryable for Event {
 ///
 /// # fn run() -> Result<(), Box<dyn std::error::Error>> {
 /// let werk = Werk::new();
-/// werk.find_tasks("research");
-/// werk.find_tasks(Query::new("label = research AND agent = research-1")?);
+/// werk.find_tasks("task.label = research");
+/// werk.find_tasks(Query::new("task.label = research AND task.assignee = research-1")?);
 /// werk.find_tasks(|t: &Task| t.get_label() == Some("research"));
-/// werk.find_events("tool_call_failed");
+/// werk.find_events("event.name = tool_call_failed");
 /// werk.find_events(|e: &Event| e.get_name().ends_with("_failed"));
 /// # Ok(())
 /// # }
 /// ```
-#[allow(private_bounds)]
-pub trait Matcher<R: Queryable> {
+pub trait Matcher<R> {
     /// Compile into a [`Query`]. A closure becomes a condition of its own, so
     /// the Werk holds one kind of filter however the caller wrote it.
-    fn into_query(self) -> Query<R>;
+    fn into_query(self) -> Query;
 }
 
-impl<R: Queryable, F: Fn(&R) -> bool + Send + Sync + 'static> Matcher<R> for F {
-    fn into_query(self) -> Query<R> {
-        Query(Compiled::test(self))
+#[cfg(test)]
+mod origin_tests {
+    use super::*;
+    use serde_json::json;
+
+    fn task(id: &str) -> Task {
+        let mut task = Task::new(json!({"work": "scan"})).label("scan");
+        task.id = id.to_string();
+        task.created_at = numeric_id(id) as u64;
+        task
+    }
+
+    #[test]
+    fn every_supported_field_infers_its_origin_and_accepts_its_operator() {
+        let cases = [
+            ("task.id = t-1", Origin::Task),
+            ("task.label = scan", Origin::Task),
+            ("task.status = finished", Origin::Task),
+            ("task.pending = true", Origin::Task),
+            ("task.cancelled = false", Origin::Task),
+            ("task.assignee = agent-1", Origin::Task),
+            ("task.parent_id = t-1", Origin::Task),
+            ("task.input ~ scan", Origin::Task),
+            ("task.result ~ clean", Origin::Task),
+            ("task.errors ~ timeout", Origin::Task),
+            ("task.created > 0", Origin::Task),
+            ("task.started > 0", Origin::Task),
+            ("task.finished > 0", Origin::Task),
+            ("task.failed > 0", Origin::Task),
+            ("event.name = task_created", Origin::Event),
+            ("event.agent_id = agent-1", Origin::Event),
+            ("event.task_id = t-1", Origin::Event),
+            ("event.label = scan", Origin::Event),
+            ("event.created > 0", Origin::Event),
+            ("event.data ~ scan", Origin::Event),
+        ];
+
+        for (source, origin) in cases {
+            let query = Query::new(source).unwrap_or_else(|error| panic!("{source}: {error}"));
+            assert_eq!(query.0.origin, Some(origin), "{source}");
+        }
+    }
+
+    #[test]
+    fn bare_task_id_and_order_only_queries_infer_an_origin() {
+        assert_eq!(Query::new("t-3").unwrap().0.origin, Some(Origin::Task));
+        assert_eq!(
+            Query::new("ORDER BY event.created DESC").unwrap().0.origin,
+            Some(Origin::Event)
+        );
+    }
+
+    #[test]
+    fn unqualified_and_mixed_fields_are_rejected() {
+        assert!(matches!(Query::new("  "), Err(QueryError::TermsMissing)));
+        assert!(matches!(
+            Query::new("label = scan"),
+            Err(QueryError::FieldUnrecognized { .. })
+        ));
+        for field in [
+            "result.task_id",
+            "result.label",
+            "result.status",
+            "result.pending",
+            "result.cancelled",
+            "result.assignee",
+            "result.parent_id",
+            "result.input",
+            "result.value",
+            "result.errors",
+            "result.created",
+            "result.started",
+            "result.finished",
+            "result.failed",
+        ] {
+            assert!(
+                matches!(
+                    Query::new(&format!("{field} = value")),
+                    Err(QueryError::FieldUnrecognized { .. })
+                ),
+                "{field}"
+            );
+        }
+        assert!(matches!(
+            Query::new("task.label = scan AND event.label = scan"),
+            Err(QueryError::OriginsMixed {
+                first: "task.label",
+                second: "event.label"
+            })
+        ));
+        assert!(matches!(
+            Query::new("task.label = scan ORDER BY event.created"),
+            Err(QueryError::OriginsMixed {
+                first: "task.label",
+                second: "event.created"
+            })
+        ));
+    }
+
+    #[test]
+    fn grouping_boolean_presence_membership_status_and_time_still_compile() {
+        for source in [
+            "NOT (task.label = scan OR task.status IN (todo, failed))",
+            "task.label != scan",
+            "task.label NOT IN (scan, report)",
+            "task.assignee IS EMPTY",
+            "task.assignee IS NOT EMPTY",
+            "task.input ~ retry",
+            "task.input !~ retry",
+            "task.created > 0",
+            "task.created >= 2026-08-24",
+            "task.finished < -1h",
+            "task.finished <= -1w",
+        ] {
+            Query::new(source).unwrap_or_else(|error| panic!("{source}: {error}"));
+        }
+        for status in ["todo", "IN_PROGRESS", "Finished", "failed"] {
+            Query::new(&format!("task.status = {status}"))
+                .unwrap_or_else(|error| panic!("{status}: {error}"));
+        }
+        for name in [
+            Event::TASK_CREATED,
+            Event::REQUEST_RETRIED,
+            "application_event",
+        ] {
+            Query::new(&format!("event.name = {name}"))
+                .unwrap_or_else(|error| panic!("{name}: {error}"));
+        }
+        assert!(matches!(
+            Query::new("task.status = unknown"),
+            Err(QueryError::StatusUnrecognized { .. })
+        ));
+        assert!(matches!(
+            Query::new("task.created > tomorrow"),
+            Err(QueryError::TimeMalformed { .. })
+        ));
+        assert!(matches!(
+            Query::new("task.input = retry"),
+            Err(QueryError::OperatorNotAllowed { .. })
+        ));
+        assert!(matches!(
+            Query::new("task.id ~ t-1"),
+            Err(QueryError::OperatorNotAllowed { .. })
+        ));
+        assert!(matches!(
+            Query::new("task.created = 0"),
+            Err(QueryError::OperatorNotAllowed { .. })
+        ));
+    }
+
+    #[test]
+    fn event_data_searches_raw_data_but_not_the_event_name() {
+        let named_only = Event::new(Event::TOOL_CALL_FAILED).data(json!({"message": "boom"}));
+        let named_in_data = Event::new(Event::TURN_STARTED)
+            .data(json!({"kind": "tool_call_failed", "message": "boom"}));
+        let data = Query::new("event.data ~ tool_call_failed").unwrap();
+        let name = Query::new("event.name = tool_call_failed").unwrap();
+
+        assert!(!data.matches_event(&named_only));
+        assert!(data.matches_event(&named_in_data));
+        assert!(name.matches_event(&named_only));
+        assert!(!name.matches_event(&named_in_data));
+    }
+
+    #[test]
+    fn task_result_searches_the_optional_raw_result() {
+        let mut finished = task("t-1");
+        finished.status = Status::Finished;
+        finished.result = Some(json!({"finding": "clean"}));
+
+        assert!(Query::new("task.result ~ clean")
+            .unwrap()
+            .matches_task(&finished));
+        assert!(matches!(
+            Query::new("result.value ~ clean"),
+            Err(QueryError::FieldUnrecognized { .. })
+        ));
+    }
+
+    #[test]
+    fn task_ids_statuses_and_missing_values_keep_their_sort_order() {
+        let mut tasks = vec![task("t-10"), task("t-2"), task("t-1")];
+        Query::new("ORDER BY task.id")
+            .unwrap()
+            .sort_tasks(&mut tasks);
+        assert_eq!(
+            tasks
+                .iter()
+                .map(|task| task.id.as_str())
+                .collect::<Vec<_>>(),
+            ["t-1", "t-2", "t-10"]
+        );
+
+        tasks[0].status = Status::Failed;
+        tasks[1].status = Status::Finished;
+        tasks[2].status = Status::Todo;
+        Query::new("ORDER BY task.status")
+            .unwrap()
+            .sort_tasks(&mut tasks);
+        assert_eq!(
+            tasks.iter().map(|task| task.status).collect::<Vec<_>>(),
+            [Status::Todo, Status::Finished, Status::Failed]
+        );
+
+        tasks[0].assignee = None;
+        tasks[1].assignee = Some("a".into());
+        tasks[2].assignee = Some("z".into());
+        Query::new("ORDER BY task.assignee DESC")
+            .unwrap()
+            .sort_tasks(&mut tasks);
+        assert_eq!(tasks.last().unwrap().assignee, None);
+    }
+
+    #[test]
+    fn a_compiled_query_rejects_the_wrong_target() {
+        let query = Query::new("event.name = task_created").unwrap();
+        assert!(matches!(
+            query.expects_task(),
+            Err(QueryError::OriginMismatch {
+                expected: "task",
+                actual: "event"
+            })
+        ));
+    }
+}
+
+impl<F: Fn(&Task) -> bool + Send + Sync + 'static> Matcher<Task> for F {
+    fn into_query(self) -> Query {
+        Query(Compiled::test(Predicate::Task(Arc::new(self))))
+    }
+}
+
+impl<F: Fn(&Event) -> bool + Send + Sync + 'static> Matcher<Event> for F {
+    fn into_query(self) -> Query {
+        Query(Compiled::test(Predicate::Event(Arc::new(self))))
     }
 }
 
 /// Panics on a string that does not parse. Use [`Query::new`] for one built at
 /// run time.
-impl<R: Queryable> Matcher<R> for &str {
-    fn into_query(self) -> Query<R> {
+impl<R> Matcher<R> for &str {
+    fn into_query(self) -> Query {
         Query::from(self)
     }
 }
 
-impl<R: Queryable> Matcher<R> for String {
-    fn into_query(self) -> Query<R> {
+impl<R> Matcher<R> for String {
+    fn into_query(self) -> Query {
         Query::from(self)
     }
 }
 
-impl<R: Queryable> Matcher<R> for Query<R> {
-    fn into_query(self) -> Query<R> {
+impl<R> Matcher<R> for Query {
+    fn into_query(self) -> Query {
         self
     }
 }
 
 /// Select records by field values expressed in AQL.
 ///
-/// `Query` selects tasks and `Query<Event>` selects recorded events, over
-/// the same syntax and a different field set.
-///
 /// A string says the same query wherever a matcher is taken. Compile it here
 /// when the same filter runs over a large Werk or a long log, or when a
 /// string built at run time should answer with an error rather than a panic.
-#[allow(private_bounds)]
 #[derive(Debug, Clone)]
-pub struct Query<R: Queryable = Task>(Compiled<R::Field>);
+pub struct Query(Compiled);
 
-#[allow(private_bounds)]
-impl<R: Queryable> Query<R> {
-    /// Compile an AQL string over the record's fields.
+impl Query {
+    /// Compile an AQL string. Every named field must have one origin.
     ///
     /// ```
-    /// use agentwerk::{Event, Query, Task};
+    /// use agentwerk::Query;
     ///
     /// # fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// Query::<Task>::new("status = finished AND label IN (scan, report)")?;
-    /// Query::<Task>::new("task ~ \"retry budget\" AND agent IS EMPTY")?;
-    /// Query::<Task>::new("t-3")?;
-    /// Query::<Task>::new("status = finished ORDER BY finished DESC")?;
-    /// Query::<Task>::new("finished IS EMPTY ORDER BY created")?;
-    /// Query::<Task>::new("failed > -1h")?;
-    /// Query::<Task>::new("created >= 2026-08-24 AND created < 2026-08-25")?;
-    /// Query::<Event>::new("event = tool_call_failed")?;
-    /// Query::<Event>::new("event IN (request_failed, request_retried) AND agent = scout-1")?;
-    /// Query::<Event>::new("task = t-3 ORDER BY created DESC")?;
-    /// Query::<Event>::new("payload ~ timeout AND created > -1h")?;
+    /// Query::new("task.status = finished AND task.label IN (scan, report)")?;
+    /// Query::new("task.input ~ \"retry budget\" AND task.assignee IS EMPTY")?;
+    /// Query::new("t-3")?;
+    /// Query::new("task.label = scan ORDER BY task.finished DESC")?;
+    /// Query::new("event.name = tool_call_failed")?;
+    /// Query::new("event.data ~ timeout AND event.created > -1h")?;
     /// # Ok(())
     /// # }
     /// # run().unwrap();
@@ -115,17 +320,23 @@ impl<R: Queryable> Query<R> {
         Compiled::new(query).map(Query)
     }
 
-    pub(crate) fn matches(&self, record: &R) -> bool {
-        self.0.matches(record)
+    pub(crate) fn matches_task(&self, task: &Task) -> bool {
+        self.assert_origin(Origin::Task);
+        self.0.matches(View::Task(task))
     }
 
-    /// Every record, in the order the field set defaults to.
-    pub(crate) fn all() -> Query<R> {
+    pub(crate) fn matches_event(&self, event: &Event) -> bool {
+        self.assert_origin(Origin::Event);
+        self.0.matches(View::Event(event))
+    }
+
+    /// Every record, in its origin's default order.
+    pub(crate) fn all() -> Query {
         Query(Compiled::all())
     }
 
     /// Keeps this query's `ORDER BY`.
-    pub(crate) fn and(self, other: Query<R>) -> Query<R> {
+    pub(crate) fn and(self, other: Query) -> Query {
         Query(self.0.and(other.0))
     }
 
@@ -136,30 +347,61 @@ impl<R: Queryable> Query<R> {
 
     /// Takes both the borrowed records a store hands out and the owned ones a
     /// log read produces, so neither caller copies to be sorted.
-    pub(crate) fn sort<T: Borrow<R>>(&self, records: &mut [T]) {
-        self.0.sort(records);
+    pub(crate) fn sort_tasks<T: Borrow<Task>>(&self, records: &mut [T]) {
+        self.assert_origin(Origin::Task);
+        self.0.sort_tasks(records);
     }
-}
 
-impl Query<Task> {
-    /// Also `status = <status>`, unless the query names a status of its own. A
-    /// closure names none, so it always takes the default.
-    pub(crate) fn default_status(self, status: Status) -> Query {
-        match self.0.mentions(TaskField::Status) {
-            true => self,
-            false => self.and_status(status),
-        }
+    pub(crate) fn sort_events<T: Borrow<Event>>(&self, records: &mut [T]) {
+        self.assert_origin(Origin::Event);
+        self.0.sort_events(records);
+    }
+
+    pub(crate) fn task(mut self) -> Query {
+        self.0.bind(Origin::Task);
+        self
+    }
+
+    pub(crate) fn task_if_originless(mut self) -> Query {
+        self.0.bind_if_originless(Origin::Task);
+        self
+    }
+
+    pub(crate) fn event_if_originless(mut self) -> Query {
+        self.0.bind_if_originless(Origin::Event);
+        self
+    }
+
+    pub(crate) fn is_event(&self) -> bool {
+        self.0.origin == Some(Origin::Event)
+    }
+
+    #[doc(hidden)]
+    pub fn expects_task(&self) -> Result<(), QueryError> {
+        self.0.expects(Origin::Task)
+    }
+
+    fn assert_origin(&self, expected: Origin) {
+        self.0
+            .expects(expected)
+            .unwrap_or_else(|error| panic!("invalid query target: {error}"));
     }
 
     /// Also `status = <status>`, whatever the query already says.
-    pub(crate) fn and_status(self, status: Status) -> Query {
-        let term = Compiled::term(TaskField::Status, Match::Is(status.to_string()));
+    pub(crate) fn and_task_status(self, status: Status) -> Query {
+        let term = Compiled::term(Field::TaskStatus, Match::Is(status.to_string()));
         self.and(Query(term))
     }
 
-    /// Also `result IS NOT EMPTY`: finishing without one is not a result.
-    pub(crate) fn and_result(self) -> Query {
-        self.and(Query(Compiled::term(TaskField::Result, Match::NotEmpty)))
+    pub(crate) fn default_task_status(self, status: Status) -> Query {
+        match self.0.mentions(Field::TaskStatus) {
+            true => self,
+            false => self.and_task_status(status),
+        }
+    }
+
+    pub(crate) fn and_task_result(self) -> Query {
+        self.and(Query(Compiled::term(Field::TaskResult, Match::NotEmpty)))
     }
 }
 
@@ -167,13 +409,13 @@ impl Query<Task> {
 /// literal that does not compile is a mistake in the calling code, the way a
 /// tool schema document the compiler refuses is. Use [`Query::new`] for a
 /// string built at run time.
-impl<R: Queryable> From<&str> for Query<R> {
+impl From<&str> for Query {
     fn from(query: &str) -> Self {
         Query::new(query).unwrap_or_else(|error| panic!("invalid query {query:?}: {error}"))
     }
 }
 
-impl<R: Queryable> From<String> for Query<R> {
+impl From<String> for Query {
     fn from(query: String) -> Self {
         Query::from(query.as_str())
     }
@@ -181,28 +423,28 @@ impl<R: Queryable> From<String> for Query<R> {
 
 /// One node of a parsed query.
 #[derive(Debug, Clone)]
-enum Condition<F: QueryField> {
-    All(Vec<Condition<F>>),
-    Any(Vec<Condition<F>>),
-    Not(Box<Condition<F>>),
-    Term(F, Match),
-    Test(Predicate<F::Record>),
+enum Condition {
+    All(Vec<Condition>),
+    Any(Vec<Condition>),
+    Not(Box<Condition>),
+    Term(Field, Match),
+    Test(Predicate),
 }
 
-impl<F: QueryField> Condition<F> {
-    fn matches(&self, record: &F::Record) -> bool {
+impl Condition {
+    fn matches(&self, record: View<'_>) -> bool {
         match self {
             Condition::All(terms) => terms.iter().all(|t| t.matches(record)),
             Condition::Any(terms) => terms.iter().any(|t| t.matches(record)),
             Condition::Not(term) => !term.matches(record),
-            Condition::Term(field, matcher) => matcher.test(field.of(record).as_deref()),
-            Condition::Test(check) => (check.0)(record),
+            Condition::Term(field, matcher) => matcher.test(record.value(*field).as_deref()),
+            Condition::Test(check) => check.test(record),
         }
     }
 
-    /// A closure names no field, so it answers `false`. That is what makes
-    /// `default_status` apply to one.
-    fn mentions(&self, field: F) -> bool {
+    /// A closure names no field, so it answers `false`. That is what makes a
+    /// result finder's default task status apply to one.
+    fn mentions(&self, field: Field) -> bool {
         match self {
             Condition::All(terms) | Condition::Any(terms) => {
                 terms.iter().any(|t| t.mentions(field))
@@ -217,33 +459,53 @@ impl<F: QueryField> Condition<F> {
 /// A caller's closure as one condition. Its own type so `Condition` keeps its
 /// derives: `Arc<dyn Fn>` carries no `Debug`, and a derived `Clone` would
 /// demand one of the record.
-struct Predicate<R>(Arc<dyn Fn(&R) -> bool + Send + Sync>);
+enum Predicate {
+    Task(Arc<dyn Fn(&Task) -> bool + Send + Sync>),
+    Event(Arc<dyn Fn(&Event) -> bool + Send + Sync>),
+}
 
-impl<R> Clone for Predicate<R> {
-    fn clone(&self) -> Self {
-        Predicate(Arc::clone(&self.0))
+impl Predicate {
+    fn test(&self, record: View<'_>) -> bool {
+        match (self, record) {
+            (Predicate::Task(check), View::Task(task)) => check(task),
+            (Predicate::Event(check), View::Event(event)) => check(event),
+            _ => false,
+        }
     }
 }
 
-impl<R> fmt::Debug for Predicate<R> {
+impl Clone for Predicate {
+    fn clone(&self) -> Self {
+        match self {
+            Predicate::Task(check) => Predicate::Task(Arc::clone(check)),
+            Predicate::Event(check) => Predicate::Event(Arc::clone(check)),
+        }
+    }
+}
+
+impl fmt::Debug for Predicate {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("<predicate>")
     }
 }
 
-/// A compiled query over one field set. [`Query`] is its one named face,
-/// and everything a query does with a parsed condition it does here.
+/// A parsed query and its inferred origin, behind [`Query`].
 #[derive(Debug, Clone)]
-struct Compiled<F: QueryField> {
-    root: Condition<F>,
-    /// What `ORDER BY` named, or `None` for the order the field set defaults to.
-    order: Option<Sort<F>>,
+struct Compiled {
+    root: Condition,
+    /// What `ORDER BY` named, or `None` for the source origin's default order.
+    order: Option<Sort>,
+    origin: Option<Origin>,
 }
 
-impl<F: QueryField> Compiled<F> {
+impl Compiled {
     fn new(query: &str) -> Result<Self, QueryError> {
-        let (root, order) = parse_query(query)?;
-        Ok(Self { root, order })
+        let (root, order, origin) = parse_query(query)?;
+        Ok(Self {
+            root,
+            order,
+            origin: Some(origin),
+        })
     }
 
     /// Every record, which AQL cannot spell beyond a bare `ORDER BY`.
@@ -251,32 +513,43 @@ impl<F: QueryField> Compiled<F> {
         Self::rooted(Condition::All(Vec::new()))
     }
 
-    fn test(check: impl Fn(&F::Record) -> bool + Send + Sync + 'static) -> Self {
-        Self::rooted(Condition::Test(Predicate(Arc::new(check))))
+    fn test(check: Predicate) -> Self {
+        Self::rooted(Condition::Test(check))
     }
 
-    fn term(field: F, matcher: Match) -> Self {
-        Self::rooted(Condition::Term(field, matcher))
+    fn term(field: Field, matcher: Match) -> Self {
+        Self {
+            root: Condition::Term(field, matcher),
+            order: None,
+            origin: Some(field.origin()),
+        }
     }
 
-    fn rooted(root: Condition<F>) -> Self {
-        Self { root, order: None }
+    fn rooted(root: Condition) -> Self {
+        Self {
+            root,
+            order: None,
+            origin: None,
+        }
     }
 
     /// Both conditions. The order is this query's, since `other` is the term a
     /// caller never wrote and so never ordered by.
     fn and(self, other: Self) -> Self {
+        let origin = merge_origins(self.origin, other.origin)
+            .expect("internally combined queries must have one origin");
         Self {
             root: Condition::All(vec![self.root, other.root]),
             order: self.order.or(other.order),
+            origin,
         }
     }
 
-    fn matches(&self, record: &F::Record) -> bool {
+    fn matches(&self, record: View<'_>) -> bool {
         self.root.matches(record)
     }
 
-    fn mentions(&self, field: F) -> bool {
+    fn mentions(&self, field: Field) -> bool {
         self.root.mentions(field)
     }
 
@@ -286,140 +559,122 @@ impl<F: QueryField> Compiled<F> {
 
     /// Takes both the borrowed records a store hands out and the owned ones a
     /// log read produces, so neither caller copies to be sorted.
-    fn sort<T: Borrow<F::Record>>(&self, records: &mut [T]) {
+    fn sort_tasks<T: Borrow<Task>>(&self, records: &mut [T]) {
         match &self.order {
-            Some(order) => {
-                records.sort_by(|left, right| order.compare(left.borrow(), right.borrow()))
-            }
-            None => F::sort_unordered(records),
+            Some(order) => records.sort_by(|left, right| {
+                order.compare(View::Task(left.borrow()), View::Task(right.borrow()))
+            }),
+            None => records.sort_by_key(|task| {
+                let task = task.borrow();
+                (task.created_at, numeric_id(&task.id))
+            }),
+        }
+    }
+
+    fn sort_events<T: Borrow<Event>>(&self, records: &mut [T]) {
+        if let Some(order) = &self.order {
+            records.sort_by(|left, right| {
+                order.compare(View::Event(left.borrow()), View::Event(right.borrow()))
+            });
+        }
+    }
+
+    fn expects(&self, expected: Origin) -> Result<(), QueryError> {
+        match self.origin {
+            Some(actual) if actual != expected => Err(QueryError::OriginMismatch {
+                expected: expected.name(),
+                actual: actual.name(),
+            }),
+            _ => Ok(()),
+        }
+    }
+
+    fn bind(&mut self, expected: Origin) {
+        self.expects(expected)
+            .unwrap_or_else(|error| panic!("invalid query target: {error}"));
+        self.origin = Some(expected);
+    }
+
+    fn bind_if_originless(&mut self, origin: Origin) {
+        if self.origin.is_none() {
+            self.origin = Some(origin);
         }
     }
 }
 
-/// One set of fields AQL names, which is all that separates the task grammar
-/// from the event one. The tokenizer, the parser, [`Condition`], and
-/// [`Compiled`] are shared.
-trait QueryField: Copy + PartialEq + fmt::Debug + Sized + 'static {
-    /// What the fields are read off. Bounded so `Condition` keeps its derives
-    /// with a closure over it.
-    type Record: fmt::Debug + Clone;
-
-    /// Every spelling, in the order an unknown field is answered with.
-    const FIELDS: &'static [(&'static str, Self)];
-
-    /// What the record holds for this field, or `None` where it holds nothing.
-    fn of(self, record: &Self::Record) -> Option<Cow<'_, str>>;
-
-    fn kind(self) -> Kind;
-
-    /// Whether the field is one a record can be missing, and so one `IS EMPTY`
-    /// reads.
-    fn is_optional(self) -> bool;
-
-    /// A lone word, read as the thing this field set names most often.
-    fn shorthand(word: String) -> Condition<Self>;
-
-    /// The field a lone quoted word names, which is how a label carrying spaces
-    /// is written.
-    fn label() -> Self;
-
-    /// What breaks a tie in `ORDER BY`, so one query answers one list.
-    fn tie_break(record: &Self::Record) -> (u64, u32);
-
-    /// How records lie when no `ORDER BY` names an order. A log already holds
-    /// one; a store that is a map does not.
-    fn sort_unordered<T: Borrow<Self::Record>>(records: &mut [T]) {
-        let _ = records;
-    }
-
-    /// The value in the one spelling the record stores, rejecting a spelling
-    /// no value of this field takes. Left as written unless a field overrides.
-    fn canonical(self, value: String) -> Result<String, QueryError> {
-        Ok(value)
-    }
-
-    /// A quoted value, which fields read like an unquoted one unless quoting
-    /// deliberately escapes their canonical spelling.
-    fn literal(self, value: String) -> Result<String, QueryError> {
-        self.canonical(value)
-    }
-
-    /// A time by the millisecond `of` wrote, everything else as text unless
-    /// the field set says otherwise.
-    fn compare(self, left: &str, right: &str) -> Ordering {
-        match self.kind() {
-            Kind::Time => millis(left).cmp(&millis(right)),
-            _ => left.cmp(right),
-        }
-    }
-
-    fn named(name: &str) -> Option<Self> {
-        Self::FIELDS
-            .iter()
-            .find(|(spelling, _)| *spelling == name)
-            .map(|(_, field)| *field)
-    }
-
-    fn name(self) -> &'static str {
-        Self::FIELDS
-            .iter()
-            .find(|(_, field)| *field == self)
-            .map(|(spelling, _)| *spelling)
-            .expect("every field has a spelling")
-    }
-
-    /// Every spelling as one list, for the message an unknown field answers
-    /// with.
-    fn spellings() -> String {
-        Self::FIELDS
-            .iter()
-            .map(|(spelling, _)| *spelling)
-            .collect::<Vec<&str>>()
-            .join(", ")
-    }
-
-    fn allows(self, matcher: &Match) -> bool {
-        match matcher {
-            Match::Contains(_) | Match::Omits(_) => self.kind() == Kind::Text,
-            Match::Empty | Match::NotEmpty => self.is_optional(),
-            Match::After(_) | Match::NotBefore(_) | Match::Before(_) | Match::NotAfter(_) => {
-                self.kind() == Kind::Time
-            }
-            _ => self.kind() == Kind::Value,
-        }
-    }
-
-    /// The operators this field takes, for the message a rejected one answers
-    /// with.
-    fn operators(self) -> &'static str {
-        match (self.kind(), self.is_optional()) {
-            (Kind::Text, true) => "~, !~, IS EMPTY, IS NOT EMPTY",
-            (Kind::Text, false) => "~ and !~",
-            (Kind::Time, true) => ">, >=, <, <=, IS EMPTY, IS NOT EMPTY, and ORDER BY",
-            (Kind::Time, false) => ">, >=, <, <=, and ORDER BY",
-            (Kind::Value, true) => "=, !=, IN, NOT IN, IS EMPTY, IS NOT EMPTY",
-            (Kind::Value, false) => "=, !=, IN, NOT IN",
-        }
-    }
-}
-
-/// A task field AQL names.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum TaskField {
-    Id,
-    Label,
-    Status,
-    Pending,
-    Cancelled,
-    Agent,
-    Parent,
+enum Origin {
     Task,
-    Result,
-    Errors,
-    Created,
-    Started,
-    Finished,
-    Failed,
+    Event,
+}
+
+impl Origin {
+    fn name(self) -> &'static str {
+        match self {
+            Origin::Task => "task",
+            Origin::Event => "event",
+        }
+    }
+}
+
+fn merge_origins(
+    left: Option<Origin>,
+    right: Option<Origin>,
+) -> Result<Option<Origin>, QueryError> {
+    match (left, right) {
+        (Some(left), Some(right)) if left != right => Err(QueryError::OriginsMixed {
+            first: left.name(),
+            second: right.name(),
+        }),
+        (Some(origin), _) | (_, Some(origin)) => Ok(Some(origin)),
+        (None, None) => Ok(None),
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum View<'a> {
+    Task(&'a Task),
+    Event(&'a Event),
+}
+
+impl<'a> View<'a> {
+    fn value(self, field: Field) -> Option<Cow<'a, str>> {
+        match self {
+            View::Task(task) => field.of_task(task),
+            View::Event(event) => field.of_event(event),
+        }
+    }
+
+    fn tie_break(self) -> (u64, u32) {
+        match self {
+            View::Task(task) => (task.created_at, numeric_id(&task.id)),
+            View::Event(event) => (event.created_at, 0),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Field {
+    TaskId,
+    TaskLabel,
+    TaskStatus,
+    TaskPending,
+    TaskCancelled,
+    TaskAssignee,
+    TaskParentId,
+    TaskInput,
+    TaskResult,
+    TaskErrors,
+    TaskCreated,
+    TaskStarted,
+    TaskFinished,
+    TaskFailed,
+    EventName,
+    EventAgentId,
+    EventTaskId,
+    EventLabel,
+    EventCreated,
+    EventData,
 }
 
 /// What a field holds, which decides the operators it takes.
@@ -433,208 +688,199 @@ enum Kind {
     Time,
 }
 
-impl QueryField for TaskField {
-    type Record = Task;
-
-    const FIELDS: &'static [(&'static str, TaskField)] = &[
-        ("id", TaskField::Id),
-        ("label", TaskField::Label),
-        ("status", TaskField::Status),
-        ("pending", TaskField::Pending),
-        ("cancelled", TaskField::Cancelled),
-        ("agent", TaskField::Agent),
-        ("parent", TaskField::Parent),
-        ("task", TaskField::Task),
-        ("result", TaskField::Result),
-        ("errors", TaskField::Errors),
-        ("created", TaskField::Created),
-        ("started", TaskField::Started),
-        ("finished", TaskField::Finished),
-        ("failed", TaskField::Failed),
+impl Field {
+    const FIELDS: &'static [(&'static str, Field)] = &[
+        ("task.id", Field::TaskId),
+        ("task.label", Field::TaskLabel),
+        ("task.status", Field::TaskStatus),
+        ("task.pending", Field::TaskPending),
+        ("task.cancelled", Field::TaskCancelled),
+        ("task.assignee", Field::TaskAssignee),
+        ("task.parent_id", Field::TaskParentId),
+        ("task.input", Field::TaskInput),
+        ("task.result", Field::TaskResult),
+        ("task.errors", Field::TaskErrors),
+        ("task.created", Field::TaskCreated),
+        ("task.started", Field::TaskStarted),
+        ("task.finished", Field::TaskFinished),
+        ("task.failed", Field::TaskFailed),
+        ("event.name", Field::EventName),
+        ("event.agent_id", Field::EventAgentId),
+        ("event.task_id", Field::EventTaskId),
+        ("event.label", Field::EventLabel),
+        ("event.created", Field::EventCreated),
+        ("event.data", Field::EventData),
     ];
 
-    fn of(self, task: &Task) -> Option<Cow<'_, str>> {
+    fn named(name: &str) -> Option<Self> {
+        Self::FIELDS
+            .iter()
+            .find_map(|(spelling, field)| (*spelling == name).then_some(*field))
+    }
+
+    fn spellings() -> String {
+        Self::FIELDS
+            .iter()
+            .map(|(name, _)| *name)
+            .collect::<Vec<_>>()
+            .join(", ")
+    }
+
+    fn name(self) -> &'static str {
+        Self::FIELDS
+            .iter()
+            .find_map(|(name, field)| (*field == self).then_some(*name))
+            .expect("every field has one spelling")
+    }
+
+    fn origin(self) -> Origin {
         match self {
-            TaskField::Id => Some(Cow::Borrowed(task.id.as_str())),
-            TaskField::Label => task.label.as_deref().map(Cow::Borrowed),
-            TaskField::Status => Some(Cow::Owned(task.status.to_string())),
-            TaskField::Pending => Some(Cow::Borrowed(bool_text(task.is_pending()))),
-            TaskField::Cancelled => Some(Cow::Borrowed(bool_text(task.is_cancelled()))),
-            TaskField::Agent => task.assignee.as_deref().map(Cow::Borrowed),
-            TaskField::Parent => task.parent.as_deref().map(Cow::Borrowed),
-            TaskField::Task => Some(as_text(&task.task)),
-            TaskField::Result => task.result.as_ref().map(as_text),
-            // The serialized events, so `~` reaches both the kind
-            // (`"event":"tool_call_failed"`) and the message.
-            TaskField::Errors => (!task.errors.is_empty())
-                .then(|| Cow::Owned(serde_json::to_string(&task.errors).unwrap_or_default())),
-            TaskField::Created => Some(Cow::Owned(task.created_at.to_string())),
-            TaskField::Started => task.started_at.map(millis_text),
-            TaskField::Finished => task.finished_at.map(millis_text),
-            TaskField::Failed => task.failed_at.map(millis_text),
+            Self::TaskId
+            | Self::TaskLabel
+            | Self::TaskStatus
+            | Self::TaskPending
+            | Self::TaskCancelled
+            | Self::TaskAssignee
+            | Self::TaskParentId
+            | Self::TaskInput
+            | Self::TaskResult
+            | Self::TaskErrors
+            | Self::TaskCreated
+            | Self::TaskStarted
+            | Self::TaskFinished
+            | Self::TaskFailed => Origin::Task,
+            Self::EventName
+            | Self::EventAgentId
+            | Self::EventTaskId
+            | Self::EventLabel
+            | Self::EventCreated
+            | Self::EventData => Origin::Event,
+        }
+    }
+
+    fn kind(self) -> Kind {
+        match self {
+            Self::TaskInput | Self::TaskResult | Self::TaskErrors | Self::EventData => Kind::Text,
+            Self::TaskCreated
+            | Self::TaskStarted
+            | Self::TaskFinished
+            | Self::TaskFailed
+            | Self::EventCreated => Kind::Time,
+            _ => Kind::Value,
         }
     }
 
     fn is_optional(self) -> bool {
         matches!(
             self,
-            TaskField::Label
-                | TaskField::Agent
-                | TaskField::Parent
-                | TaskField::Result
-                | TaskField::Errors
-                | TaskField::Started
-                | TaskField::Finished
-                | TaskField::Failed
+            Self::TaskLabel
+                | Self::TaskAssignee
+                | Self::TaskParentId
+                | Self::TaskResult
+                | Self::TaskErrors
+                | Self::TaskStarted
+                | Self::TaskFinished
+                | Self::TaskFailed
+                | Self::EventAgentId
+                | Self::EventTaskId
+                | Self::EventLabel
         )
     }
 
-    fn kind(self) -> Kind {
-        match self {
-            TaskField::Task | TaskField::Result | TaskField::Errors => Kind::Text,
-            TaskField::Created | TaskField::Started | TaskField::Finished | TaskField::Failed => {
-                Kind::Time
+    fn allows(self, matcher: &Match) -> bool {
+        match matcher {
+            Match::Empty | Match::NotEmpty => self.is_optional(),
+            Match::Contains(_) | Match::Omits(_) => self.kind() == Kind::Text,
+            Match::After(_) | Match::NotBefore(_) | Match::Before(_) | Match::NotAfter(_) => {
+                self.kind() == Kind::Time
             }
-            _ => Kind::Value,
+            _ => self.kind() == Kind::Value,
         }
     }
 
-    /// The task it names by ID where it is spelled like one, and the label
-    /// otherwise.
-    fn shorthand(word: String) -> Condition<TaskField> {
-        match is_task_id(&word) {
-            true => Condition::Term(TaskField::Id, Match::Is(word)),
-            false => Condition::Term(TaskField::Label, Match::Is(word)),
+    fn operators(self) -> &'static str {
+        match (self.kind(), self.is_optional()) {
+            (Kind::Value, false) => "=, !=, IN, or NOT IN",
+            (Kind::Value, true) => "=, !=, IN, NOT IN, IS EMPTY, or IS NOT EMPTY",
+            (Kind::Text, false) => "~ or !~",
+            (Kind::Text, true) => "~, !~, IS EMPTY, or IS NOT EMPTY",
+            (Kind::Time, false) => ">, >=, <, or <=",
+            (Kind::Time, true) => ">, >=, <, <=, IS EMPTY, or IS NOT EMPTY",
         }
     }
 
-    fn label() -> TaskField {
-        TaskField::Label
-    }
-
-    fn tie_break(task: &Task) -> (u64, u32) {
-        (task.created_at, numeric_id(&task.id))
-    }
-
-    fn sort_unordered<T: Borrow<Task>>(tasks: &mut [T]) {
-        tasks.sort_by_key(|t| Self::tie_break(t.borrow()));
-    }
-
-    /// A status in the one spelling `Status::Display` writes.
     fn canonical(self, value: String) -> Result<String, QueryError> {
-        if self != TaskField::Status {
-            return Ok(value);
-        }
-        for status in STATUSES {
-            let spelling = status.to_string();
-            if value.eq_ignore_ascii_case(&spelling) {
-                return Ok(spelling);
+        if self == Self::TaskStatus {
+            for status in STATUSES {
+                let spelling = status.to_string();
+                if value.eq_ignore_ascii_case(&spelling) {
+                    return Ok(spelling);
+                }
             }
+            return Err(QueryError::StatusUnrecognized { value });
         }
-        Err(QueryError::StatusUnrecognized { value })
-    }
-
-    /// `id` by its number, so t-2 comes before t-10, and `status`
-    /// along the lifecycle.
-    fn compare(self, left: &str, right: &str) -> Ordering {
-        match self {
-            TaskField::Id => numeric_id(left).cmp(&numeric_id(right)),
-            TaskField::Status => status_rank(left).cmp(&status_rank(right)),
-            TaskField::Created | TaskField::Started | TaskField::Finished | TaskField::Failed => {
-                millis(left).cmp(&millis(right))
-            }
-            _ => left.cmp(right),
+        if self == Self::EventName {
+            return Ok(event_named(&value).map_or(value, str::to_string));
         }
-    }
-}
-
-/// An event field AQL names.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum EventField {
-    Event,
-    Agent,
-    Task,
-    Label,
-    Created,
-    Payload,
-}
-
-impl QueryField for EventField {
-    type Record = Event;
-
-    const FIELDS: &'static [(&'static str, EventField)] = &[
-        ("event", EventField::Event),
-        ("agent", EventField::Agent),
-        ("task", EventField::Task),
-        ("label", EventField::Label),
-        ("created", EventField::Created),
-        ("payload", EventField::Payload),
-    ];
-
-    fn of(self, event: &Event) -> Option<Cow<'_, str>> {
-        match self {
-            EventField::Event => Some(Cow::Borrowed(&event.name)),
-            EventField::Agent => carried(&event.agent_id),
-            EventField::Task => carried(&event.task_id),
-            EventField::Label => event.label.as_deref().map(Cow::Borrowed),
-            EventField::Created => Some(Cow::Owned(event.created_at.to_string())),
-            EventField::Payload => serde_json::to_string(&serde_json::json!({
-                "name": event.name,
-                "data": event.data,
-            }))
-            .ok()
-            .map(Cow::Owned),
-        }
-    }
-
-    fn is_optional(self) -> bool {
-        matches!(
-            self,
-            EventField::Agent | EventField::Task | EventField::Label
-        )
-    }
-
-    fn kind(self) -> Kind {
-        match self {
-            EventField::Payload => Kind::Text,
-            EventField::Created => Kind::Time,
-            _ => Kind::Value,
-        }
-    }
-
-    /// The event it names where the word is one, the task where it is spelled
-    /// like an ID, and the label otherwise.
-    fn shorthand(word: String) -> Condition<EventField> {
-        if is_task_id(&word) {
-            return Condition::Term(EventField::Task, Match::Is(word));
-        }
-        match event_named(&word) {
-            Some(name) => Condition::Term(EventField::Event, Match::Is(name.to_string())),
-            None => Condition::Term(EventField::Label, Match::Is(word)),
-        }
-    }
-
-    fn label() -> EventField {
-        EventField::Label
-    }
-
-    /// Events arrive in the order they were logged, which is what a tie keeps.
-    fn tie_break(event: &Event) -> (u64, u32) {
-        (event.created_at, 0)
-    }
-
-    /// A built-in event in the one snake_case spelling the log writes.
-    /// Application event names are matched exactly.
-    fn canonical(self, value: String) -> Result<String, QueryError> {
-        if self != EventField::Event {
-            return Ok(value);
-        }
-        Ok(event_named(&value).map_or(value, str::to_string))
+        Ok(value)
     }
 
     fn literal(self, value: String) -> Result<String, QueryError> {
-        Ok(value)
+        match self {
+            Self::EventName => Ok(value),
+            _ => self.canonical(value),
+        }
     }
+
+    fn compare(self, left: &str, right: &str) -> Ordering {
+        match self {
+            Self::TaskId => numeric_id(left).cmp(&numeric_id(right)),
+            Self::TaskStatus => status_rank(left).cmp(&status_rank(right)),
+            Self::TaskCreated
+            | Self::TaskStarted
+            | Self::TaskFinished
+            | Self::TaskFailed
+            | Self::EventCreated => millis(left).cmp(&millis(right)),
+            _ => left.cmp(right),
+        }
+    }
+
+    fn of_task(self, task: &Task) -> Option<Cow<'_, str>> {
+        match self {
+            Self::TaskId => Some(Cow::Borrowed(task.id.as_str())),
+            Self::TaskLabel => task.label.as_deref().map(Cow::Borrowed),
+            Self::TaskStatus => Some(Cow::Owned(task.status.to_string())),
+            Self::TaskPending => Some(Cow::Borrowed(bool_text(task.is_pending()))),
+            Self::TaskCancelled => Some(Cow::Borrowed(bool_text(task.is_cancelled()))),
+            Self::TaskAssignee => task.assignee.as_deref().map(Cow::Borrowed),
+            Self::TaskParentId => task.parent.as_deref().map(Cow::Borrowed),
+            Self::TaskInput => Some(as_text(&task.task)),
+            Self::TaskResult => task.result.as_ref().map(as_text),
+            Self::TaskErrors => serialized_errors(task),
+            Self::TaskCreated => Some(millis_text(task.created_at)),
+            Self::TaskStarted => task.started_at.map(millis_text),
+            Self::TaskFinished => task.finished_at.map(millis_text),
+            Self::TaskFailed => task.failed_at.map(millis_text),
+            _ => None,
+        }
+    }
+
+    fn of_event(self, event: &Event) -> Option<Cow<'_, str>> {
+        match self {
+            Self::EventName => Some(Cow::Borrowed(&event.name)),
+            Self::EventAgentId => carried(&event.agent_id),
+            Self::EventTaskId => carried(&event.task_id),
+            Self::EventLabel => event.label.as_deref().map(Cow::Borrowed),
+            Self::EventCreated => Some(millis_text(event.created_at)),
+            Self::EventData => serde_json::to_string(&event.data).ok().map(Cow::Owned),
+            _ => None,
+        }
+    }
+}
+
+fn serialized_errors(task: &Task) -> Option<Cow<'_, str>> {
+    (!task.errors.is_empty())
+        .then(|| Cow::Owned(serde_json::to_string(&task.errors).unwrap_or_default()))
 }
 
 fn is_task_id(word: &str) -> bool {
@@ -665,14 +911,14 @@ fn as_text(value: &serde_json::Value) -> Cow<'_, str> {
 
 /// The one key an `ORDER BY` clause names.
 #[derive(Debug, Clone, Copy)]
-struct Sort<F: QueryField> {
-    field: F,
+struct Sort {
+    field: Field,
     descending: bool,
 }
 
-impl<F: QueryField> Sort<F> {
-    fn compare(&self, left: &F::Record, right: &F::Record) -> Ordering {
-        let placed = match (self.field.of(left), self.field.of(right)) {
+impl Sort {
+    fn compare(&self, left: View<'_>, right: View<'_>) -> Ordering {
+        let placed = match (left.value(self.field), right.value(self.field)) {
             (Some(l), Some(r)) => self.field.compare(&l, &r),
             // A record the field is absent from has no value to place, so it
             // sorts last whichever way the rest is ordered.
@@ -685,7 +931,7 @@ impl<F: QueryField> Sort<F> {
             false => placed,
         };
         // Ties keep the record order, so one query always answers one list.
-        placed.then_with(|| F::tie_break(left).cmp(&F::tie_break(right)))
+        placed.then_with(|| left.tie_break().cmp(&right.tie_break()))
     }
 }
 
@@ -720,7 +966,7 @@ fn millis(value: &str) -> u64 {
 ///
 /// An offset is resolved here rather than at match time, so one compiled query
 /// answers one set however long it is held.
-fn time_value<F: QueryField>(field: F, value: &str) -> Result<u64, QueryError> {
+fn time_value(field: Field, value: &str) -> Result<u64, QueryError> {
     let resolved = match value.strip_prefix('-') {
         Some(offset) => ago(offset),
         None => match value.chars().all(|c| c.is_ascii_digit()) {
@@ -824,13 +1070,26 @@ impl Match {
 pub enum QueryError {
     /// The query carried no terms at all.
     TermsMissing,
-    /// No field is named this. `known` is the field set the query was compiled
-    /// against, which is the task one or the event one.
+    /// No field is named this. `known` lists every task and event field.
     FieldUnrecognized {
         /// Field supplied by the query.
         name: String,
         /// Valid fields for this record type.
         known: String,
+    },
+    /// Fields from two record origins appeared in one query.
+    OriginsMixed {
+        /// Property inferred before the conflict.
+        first: &'static str,
+        /// Conflicting property.
+        second: &'static str,
+    },
+    /// A compiled query was supplied to an operation requiring another origin.
+    OriginMismatch {
+        /// Origin required by the receiving finder.
+        expected: &'static str,
+        /// Origin inferred when the query was compiled.
+        actual: &'static str,
     },
     /// No status is spelled this way.
     StatusUnrecognized {
@@ -870,10 +1129,21 @@ impl fmt::Display for QueryError {
         match self {
             Self::TermsMissing => write!(
                 f,
-                "A query cannot be blank. Name a label, a task ID, or a field."
+                "A query cannot be blank. Name an origin-qualified field or a task ID."
             ),
             Self::FieldUnrecognized { name, known } => {
                 write!(f, "No field named `{name}`. Use one of {known}.")
+            }
+            Self::OriginsMixed { first, second } => write!(
+                f,
+                "A query must use one record origin, but `{first}` conflicts with `{second}`."
+            ),
+            Self::OriginMismatch { expected, actual } => {
+                let article = if *expected == "event" { "an" } else { "a" };
+                write!(
+                    f,
+                    "This operation requires {article} {expected} query, but the query has {actual} origin."
+                )
             }
             Self::StatusUnrecognized { value } => write!(
                 f,
@@ -890,7 +1160,7 @@ impl fmt::Display for QueryError {
             }
             Self::FieldRepeated { field } => write!(
                 f,
-                "`{field}` holds one value per task; use `{field} IN (a, b)` to match either."
+                "`{field}` holds one value per record; use `{field} IN (a, b)` to match either."
             ),
             Self::TokenRejected { token } => write!(f, "Unexpected `{token}` in the query."),
             Self::TermUnfinished => write!(f, "The query ends in the middle of a term."),
@@ -1000,7 +1270,7 @@ fn tokenize(query: &str) -> Result<Vec<Token>, QueryError> {
     Ok(tokens)
 }
 
-fn parse_query<F: QueryField>(query: &str) -> Result<(Condition<F>, Option<Sort<F>>), QueryError> {
+fn parse_query(query: &str) -> Result<(Condition, Option<Sort>, Origin), QueryError> {
     let tokens = tokenize(query)?;
     if tokens.is_empty() {
         return Err(QueryError::TermsMissing);
@@ -1008,7 +1278,7 @@ fn parse_query<F: QueryField>(query: &str) -> Result<(Condition<F>, Option<Sort<
     let mut parser = Parser {
         tokens,
         at: 0,
-        field: std::marker::PhantomData,
+        origin_field: None,
     };
     // A query naming nothing but an order selects every record, which is how
     // the tasks tool asks for the newest without narrowing first.
@@ -1021,17 +1291,24 @@ fn parse_query<F: QueryField>(query: &str) -> Result<(Condition<F>, Option<Sort<
         Some(token) => Err(QueryError::TokenRejected {
             token: token.spelling(),
         }),
-        None => Ok((condition, order)),
+        None => Ok((
+            condition,
+            order,
+            parser
+                .origin_field
+                .expect("a nonblank query names an origin")
+                .origin(),
+        )),
     }
 }
 
-struct Parser<F: QueryField> {
+struct Parser {
     tokens: Vec<Token>,
     at: usize,
-    field: std::marker::PhantomData<F>,
+    origin_field: Option<Field>,
 }
 
-impl<F: QueryField> Parser<F> {
+impl Parser {
     fn peek(&self) -> Option<&Token> {
         self.tokens.get(self.at)
     }
@@ -1061,7 +1338,7 @@ impl<F: QueryField> Parser<F> {
 
     /// `ORDER BY field (ASC | DESC)?`, or nothing where the query names no
     /// order.
-    fn order_by(&mut self) -> Result<Option<Sort<F>>, QueryError> {
+    fn order_by(&mut self) -> Result<Option<Sort>, QueryError> {
         if !self.at_order_by() {
             return Ok(None);
         }
@@ -1075,10 +1352,7 @@ impl<F: QueryField> Parser<F> {
             }
             None => return Err(QueryError::TermUnfinished),
         };
-        let field = F::named(&name).ok_or_else(|| QueryError::FieldUnrecognized {
-            name,
-            known: F::spellings(),
-        })?;
+        let field = self.field(name)?;
         let descending = self.take_keyword("desc");
         if !descending {
             self.take_keyword("asc");
@@ -1087,7 +1361,7 @@ impl<F: QueryField> Parser<F> {
     }
 
     /// `and (OR and)*`
-    fn any(&mut self) -> Result<Condition<F>, QueryError> {
+    fn any(&mut self) -> Result<Condition, QueryError> {
         let mut terms = vec![self.all()?];
         while self.take_keyword("or") {
             terms.push(self.all()?);
@@ -1097,7 +1371,7 @@ impl<F: QueryField> Parser<F> {
 
     /// `unary (AND unary)*`, where the collected terms may not name one
     /// single-valued field twice.
-    fn all(&mut self) -> Result<Condition<F>, QueryError> {
+    fn all(&mut self) -> Result<Condition, QueryError> {
         let mut terms = vec![self.unary()?];
         while self.take_keyword("and") {
             terms.push(self.unary()?);
@@ -1107,7 +1381,7 @@ impl<F: QueryField> Parser<F> {
     }
 
     /// `NOT unary | '(' any ')' | term`
-    fn unary(&mut self) -> Result<Condition<F>, QueryError> {
+    fn unary(&mut self) -> Result<Condition, QueryError> {
         if self.take_keyword("not") {
             return Ok(Condition::Not(Box::new(self.unary()?)));
         }
@@ -1125,13 +1399,16 @@ impl<F: QueryField> Parser<F> {
         self.term()
     }
 
-    /// `field operator value?`, or a lone word standing for the record it
-    /// names, which each field set reads its own way.
-    fn term(&mut self) -> Result<Condition<F>, QueryError> {
+    /// `field operator value?`, or a bare task ID.
+    fn term(&mut self) -> Result<Condition, QueryError> {
         let token = self.next().ok_or(QueryError::TermUnfinished)?;
         let word = match token {
             Token::Word(word) => word,
-            Token::Quoted(text) => return Ok(Condition::Term(F::label(), Match::Is(text))),
+            Token::Quoted(text) => {
+                return Err(QueryError::TokenRejected {
+                    token: format!("\"{text}\""),
+                })
+            }
             other => {
                 return Err(QueryError::TokenRejected {
                     token: other.spelling(),
@@ -1139,15 +1416,17 @@ impl<F: QueryField> Parser<F> {
             }
         };
 
-        // An operator after the word makes it a field reference, so a word
-        // naming no field is a mistake rather than the shorthand.
         if !self.at_operator() {
-            return Ok(F::shorthand(word));
+            if is_task_id(&word) {
+                self.record_field(Field::TaskId)?;
+                return Ok(Condition::Term(Field::TaskId, Match::Is(word)));
+            }
+            return Err(QueryError::FieldUnrecognized {
+                name: word,
+                known: Field::spellings(),
+            });
         }
-        let field = F::named(&word).ok_or_else(|| QueryError::FieldUnrecognized {
-            name: word,
-            known: F::spellings(),
-        })?;
+        let field = self.field(word)?;
         let matcher = self.operator(field)?;
         if !field.allows(&matcher) {
             return Err(QueryError::OperatorNotAllowed {
@@ -1180,7 +1459,7 @@ impl<F: QueryField> Parser<F> {
         }
     }
 
-    fn operator(&mut self, field: F) -> Result<Match, QueryError> {
+    fn operator(&mut self, field: Field) -> Result<Match, QueryError> {
         match self.next().ok_or(QueryError::TermUnfinished)? {
             Token::Equals => Ok(Match::Is(self.value(field)?)),
             Token::NotEquals => Ok(Match::IsNot(self.value(field)?)),
@@ -1221,7 +1500,7 @@ impl<F: QueryField> Parser<F> {
         }
     }
 
-    fn value(&mut self, field: F) -> Result<String, QueryError> {
+    fn value(&mut self, field: Field) -> Result<String, QueryError> {
         match self.next().ok_or(QueryError::TermUnfinished)? {
             Token::Word(word) => field.canonical(word),
             Token::Quoted(text) => field.literal(text),
@@ -1234,7 +1513,7 @@ impl<F: QueryField> Parser<F> {
     /// The moment a comparison names. Read before the field is checked against
     /// the operator, so `label > x` answers that `label` takes no `>` rather
     /// than complaining about `x`.
-    fn time(&mut self, field: F) -> Result<u64, QueryError> {
+    fn time(&mut self, field: Field) -> Result<u64, QueryError> {
         match self.next().ok_or(QueryError::TermUnfinished)? {
             Token::Word(word) | Token::Quoted(word) => match field.kind() {
                 Kind::Time => time_value(field, &word),
@@ -1247,7 +1526,7 @@ impl<F: QueryField> Parser<F> {
     }
 
     /// `'(' value (',' value)* ')'`, which an empty list does not satisfy.
-    fn values(&mut self, field: F) -> Result<Vec<String>, QueryError> {
+    fn values(&mut self, field: Field) -> Result<Vec<String>, QueryError> {
         match self.next() {
             Some(Token::Open) => {}
             Some(token) => {
@@ -1271,12 +1550,32 @@ impl<F: QueryField> Parser<F> {
             }
         }
     }
+
+    fn field(&mut self, name: String) -> Result<Field, QueryError> {
+        let field = Field::named(&name).ok_or_else(|| QueryError::FieldUnrecognized {
+            name,
+            known: Field::spellings(),
+        })?;
+        self.record_field(field)?;
+        Ok(field)
+    }
+
+    fn record_field(&mut self, field: Field) -> Result<(), QueryError> {
+        if let Some(first) = self.origin_field {
+            if first.origin() != field.origin() {
+                return Err(QueryError::OriginsMixed {
+                    first: first.name(),
+                    second: field.name(),
+                });
+            }
+        } else {
+            self.origin_field = Some(field);
+        }
+        Ok(())
+    }
 }
 
-fn one_or<F: QueryField>(
-    group: fn(Vec<Condition<F>>) -> Condition<F>,
-    mut terms: Vec<Condition<F>>,
-) -> Condition<F> {
+fn one_or(group: fn(Vec<Condition>) -> Condition, mut terms: Vec<Condition>) -> Condition {
     if terms.len() == 1 {
         return terms.pop().expect("one term");
     }
@@ -1286,8 +1585,8 @@ fn one_or<F: QueryField>(
 /// Two equalities on one single-valued field match no record, so they are a
 /// mistake rather than a query. `OR` is left alone: that is the shape the
 /// message points at.
-fn reject_repeated_field<F: QueryField>(terms: &[Condition<F>]) -> Result<(), QueryError> {
-    let mut seen: Vec<F> = Vec::new();
+fn reject_repeated_field(terms: &[Condition]) -> Result<(), QueryError> {
+    let mut seen: Vec<Field> = Vec::new();
     for term in terms {
         let Condition::Term(field, Match::Is(_)) = term else {
             continue;
@@ -1300,1031 +1599,4 @@ fn reject_repeated_field<F: QueryField>(terms: &[Condition<F>]) -> Result<(), Qu
         seen.push(*field);
     }
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use serde_json::json;
-
-    fn task(id: &str) -> Task {
-        let mut task = Task::new("task");
-        task.id = id.to_string();
-        task
-    }
-
-    /// The fields the Werk writes as a task is worked, which `Task`'s own
-    /// chainable methods do not set.
-    trait Fixture {
-        fn agent(self, agent: &str) -> Task;
-        fn status(self, status: Status) -> Task;
-        fn task(self, task: serde_json::Value) -> Task;
-        fn finished(self, result: serde_json::Value) -> Task;
-        fn cancelled(self) -> Task;
-        fn errored(self, event: crate::event::Event) -> Task;
-        fn created_at(self, millis: u64) -> Task;
-        fn finished_at(self, millis: u64) -> Task;
-    }
-
-    impl Fixture for Task {
-        fn agent(mut self, agent: &str) -> Task {
-            self.assignee = Some(agent.to_string());
-            self
-        }
-
-        fn errored(mut self, event: crate::event::Event) -> Task {
-            let id = self.id.clone();
-            self.errors.push(event.task_id(id).agent_id("agent"));
-            self
-        }
-
-        fn created_at(mut self, millis: u64) -> Task {
-            self.created_at = millis;
-            self
-        }
-
-        fn finished_at(mut self, millis: u64) -> Task {
-            self.status = Status::Finished;
-            self.finished_at = Some(millis);
-            self
-        }
-
-        fn status(mut self, status: Status) -> Task {
-            self.status = status;
-            self
-        }
-
-        fn task(mut self, task: serde_json::Value) -> Task {
-            self.task = task;
-            self
-        }
-
-        fn finished(mut self, result: serde_json::Value) -> Task {
-            self.status = Status::Finished;
-            self.result = Some(result);
-            self
-        }
-
-        fn cancelled(mut self) -> Task {
-            self.cancelled = true;
-            self
-        }
-    }
-
-    fn parse(query: &str) -> Query {
-        Query::new(query).expect("query must parse")
-    }
-
-    fn error(query: &str) -> QueryError {
-        Query::<Task>::new(query).expect_err("query must be rejected")
-    }
-
-    /// The IDs the query selects, in the order it puts them in.
-    fn ordered(query: &str, tasks: &[Task]) -> Vec<String> {
-        let query = parse(query);
-        let mut matching: Vec<&Task> = tasks.iter().filter(|t| query.matches(t)).collect();
-        query.sort(&mut matching);
-        matching.into_iter().map(|t| t.id.clone()).collect()
-    }
-
-    #[test]
-    fn multiple_fields_and_together() {
-        let q = parse("label = scan AND agent = scanner-1");
-        assert!(q.matches(&task("t-1").label("scan").agent("scanner-1")));
-        assert!(!q.matches(&task("t-2").label("scan").agent("scanner-2")));
-        assert!(!q.matches(&task("t-3").label("report").agent("scanner-1")));
-    }
-
-    #[test]
-    fn default_status_applies_to_a_query_that_leaves_status_unset() {
-        let q = parse("label = scan").default_status(Status::Finished);
-        assert!(q.matches(&task("t-1").label("scan").finished(json!("ok"))));
-        assert!(!q.matches(&task("t-2").label("scan")));
-    }
-
-    #[test]
-    fn default_status_leaves_a_query_that_sets_status_alone() {
-        let q = parse("status = todo").default_status(Status::Finished);
-        assert!(q.matches(&task("t-1")));
-    }
-
-    #[test]
-    fn default_status_finds_a_status_nested_in_a_group() {
-        let q = parse("label = scan AND NOT (status = failed)").default_status(Status::Finished);
-        assert!(q.matches(&task("t-1").label("scan")));
-    }
-
-    #[test]
-    fn default_status_applies_to_a_closure_which_names_no_field() {
-        let q = (|t: &Task| t.label.as_deref() == Some("scan"))
-            .into_query()
-            .default_status(Status::Finished);
-        assert!(q.matches(&task("t-1").label("scan").finished(json!("ok"))));
-        assert!(!q.matches(&task("t-2").label("scan")));
-    }
-
-    #[test]
-    fn and_status_applies_to_a_query_that_sets_status_of_its_own() {
-        let q = parse("status = todo").and_status(Status::Finished);
-        assert!(!q.matches(&task("t-1")));
-        assert!(!q.matches(&task("t-2").finished(json!("ok"))));
-    }
-
-    #[test]
-    fn a_closure_selects_the_tasks_it_accepts() {
-        let q = (|t: &Task| t.label.as_deref() == Some("scan")).into_query();
-        assert!(q.matches(&task("t-1").label("scan")));
-        assert!(!q.matches(&task("t-2").label("report")));
-    }
-
-    #[test]
-    fn every_way_of_naming_a_label_selects_the_same_tasks() {
-        let spellings = [
-            ("Query::from", Query::from("scan")),
-            ("&str", Matcher::<Task>::into_query("scan")),
-            ("String", Matcher::<Task>::into_query("scan".to_string())),
-        ];
-        for (spelling, q) in spellings {
-            assert!(q.matches(&task("t-1").label("scan")), "{spelling}");
-            assert!(!q.matches(&task("t-2").label("report")), "{spelling}");
-            assert!(!q.matches(&task("t-3")), "{spelling}");
-        }
-    }
-
-    #[test]
-    fn equals_selects_the_named_value() {
-        let q = parse("agent = scanner-1");
-        assert!(q.matches(&task("t-1").agent("scanner-1")));
-        assert!(!q.matches(&task("t-2").agent("scanner-2")));
-    }
-
-    #[test]
-    fn not_equals_excludes_the_named_value() {
-        let q = parse("label != scan");
-        assert!(q.matches(&task("t-1").label("report")));
-        assert!(!q.matches(&task("t-2").label("scan")));
-    }
-
-    #[test]
-    fn an_absent_field_fails_every_comparison() {
-        let unlabelled = task("t-1");
-        for query in [
-            "label = scan",
-            "label != scan",
-            "label IN (scan, report)",
-            "label NOT IN (scan, report)",
-        ] {
-            assert!(!parse(query).matches(&unlabelled), "{query}");
-        }
-    }
-
-    #[test]
-    fn in_matches_any_listed_value() {
-        let q = parse("label IN (scan, report)");
-        assert!(q.matches(&task("t-1").label("scan")));
-        assert!(q.matches(&task("t-2").label("report")));
-        assert!(!q.matches(&task("t-3").label("review")));
-    }
-
-    #[test]
-    fn not_in_excludes_every_listed_value() {
-        let q = parse("status NOT IN (Finished, Failed)");
-        assert!(q.matches(&task("t-1").status(Status::Todo)));
-        assert!(!q.matches(&task("t-2").status(Status::Failed)));
-    }
-
-    #[test]
-    fn pending_selects_unfinished_uncancelled_tasks() {
-        let pending = parse("pending = true");
-        let not_pending = parse("pending = false");
-        let tasks = [
-            task("t-1"),
-            task("t-2").status(Status::InProgress),
-            task("t-3").status(Status::Finished),
-            task("t-4").status(Status::Failed),
-            task("t-5").cancelled(),
-        ];
-
-        assert_eq!(ordered("pending = true", &tasks), ["t-1", "t-2"]);
-        assert_eq!(ordered("pending = false", &tasks), ["t-3", "t-4", "t-5"]);
-        assert!(pending.matches(&tasks[0]));
-        assert!(not_pending.matches(&tasks[4]));
-    }
-
-    #[test]
-    fn cancelled_selects_only_tasks_cancelled_in_this_run() {
-        let cancelled = parse("cancelled = true");
-        let active = parse("cancelled = false");
-
-        assert!(cancelled.matches(&task("t-1").cancelled()));
-        assert!(!cancelled.matches(&task("t-2")));
-        assert!(active.matches(&task("t-3")));
-    }
-
-    #[test]
-    fn id_takes_in_like_any_other_field() {
-        let q = parse("id IN (t-1, t-2)");
-        assert!(q.matches(&task("t-1")));
-        assert!(!q.matches(&task("t-3")));
-    }
-
-    #[test]
-    fn parent_selects_the_task_a_handover_came_from() {
-        let q = parse("parent = t-1");
-        assert!(q.matches(&task("t-2").parent("t-1")));
-        assert!(!q.matches(&task("t-3")));
-    }
-
-    #[test]
-    fn an_empty_in_list_is_rejected() {
-        assert!(matches!(
-            error("label IN ()"),
-            QueryError::TokenRejected { .. }
-        ));
-    }
-
-    #[test]
-    fn is_empty_matches_a_task_without_a_label() {
-        let q = parse("label IS EMPTY");
-        assert!(q.matches(&task("t-1")));
-        assert!(!q.matches(&task("t-2").label("scan")));
-    }
-
-    #[test]
-    fn is_not_empty_matches_a_task_carrying_one() {
-        let q = parse("label IS NOT EMPTY");
-        assert!(q.matches(&task("t-1").label("scan")));
-        assert!(!q.matches(&task("t-2")));
-    }
-
-    #[test]
-    fn result_is_empty_matches_a_task_carrying_no_result() {
-        let q = parse("result IS EMPTY");
-        assert!(q.matches(&task("t-1")));
-        assert!(!q.matches(&task("t-2").finished(json!("done"))));
-    }
-
-    #[test]
-    fn contains_matches_the_task_body_case_insensitively() {
-        let q = parse("task ~ \"Retry Budget\"");
-        assert!(q.matches(&task("t-1").task(json!("check the retry budget"))));
-        assert!(!q.matches(&task("t-2").task(json!("check the upload path"))));
-    }
-
-    #[test]
-    fn contains_matches_a_structured_task_by_its_json_text() {
-        let q = parse("task ~ db.rs");
-        assert!(q.matches(&task("t-1").task(json!({"file": "src/db.rs"}))));
-    }
-
-    #[test]
-    fn omits_excludes_a_matching_task() {
-        let q = parse("task !~ draft");
-        assert!(q.matches(&task("t-1").task(json!("final report"))));
-        assert!(!q.matches(&task("t-2").task(json!("draft report"))));
-    }
-
-    #[test]
-    fn contains_matches_the_stored_result() {
-        let q = parse("result ~ zip");
-        assert!(q.matches(&task("t-1").finished(json!({"finding": "zip slip"}))));
-        assert!(!q.matches(&task("t-2").finished(json!({"finding": "clean"}))));
-    }
-
-    fn tool_failed(message: &str) -> crate::event::Event {
-        crate::event::Event::new(crate::event::Event::TOOL_CALL_FAILED).data(json!({
-            "tool_name": "grep",
-            "call_id": "c1",
-            "kind": "execution_failed",
-            "message": message,
-        }))
-    }
-
-    #[test]
-    fn errors_is_empty_matches_a_task_without_failures() {
-        let q = parse("errors IS EMPTY");
-        assert!(q.matches(&task("t-1")));
-        assert!(!q.matches(&task("t-2").errored(tool_failed("boom"))));
-    }
-
-    #[test]
-    fn errors_is_not_empty_matches_a_task_that_failed() {
-        let q = parse("errors IS NOT EMPTY");
-        assert!(q.matches(&task("t-1").errored(tool_failed("boom"))));
-        assert!(!q.matches(&task("t-2")));
-    }
-
-    #[test]
-    fn contains_matches_a_failure_by_kind() {
-        let request_failed =
-            crate::event::Event::new(crate::event::Event::REQUEST_FAILED).data(json!({
-                "model": "mock",
-                "kind": crate::providers::RequestErrorKind::ConnectionFailed,
-                "message": "boom",
-            }));
-        let q = parse("errors ~ tool_call_failed");
-        assert!(q.matches(&task("t-1").errored(tool_failed("boom"))));
-        // A different kind is excluded: the search selects by kind, not presence.
-        assert!(!q.matches(&task("t-2").errored(request_failed)));
-    }
-
-    #[test]
-    fn contains_matches_a_failure_message() {
-        let q = parse("errors ~ timeout");
-        assert!(q.matches(&task("t-1").errored(tool_failed("connection timeout"))));
-        assert!(!q.matches(&task("t-2").errored(tool_failed("no such file"))));
-    }
-
-    #[test]
-    fn omits_excludes_a_matching_failure() {
-        let q = parse("errors !~ timeout");
-        assert!(q.matches(&task("t-1").errored(tool_failed("no such file"))));
-        assert!(!q.matches(&task("t-2").errored(tool_failed("connection timeout"))));
-    }
-
-    #[test]
-    fn omits_does_not_match_a_task_without_failures() {
-        // An optional field the task does not carry fails every comparison,
-        // so `!~` excludes a clean task rather than including it.
-        let q = parse("errors !~ timeout");
-        assert!(!q.matches(&task("t-1")));
-        assert!(q.matches(&task("t-2").errored(tool_failed("no such file"))));
-    }
-
-    #[test]
-    fn contains_searches_every_recorded_failure() {
-        // A task accumulates many failures; the search reads the whole log,
-        // so a needle in the second failure still matches.
-        let q = parse("errors ~ timeout");
-        let task = task("t-1")
-            .errored(tool_failed("no such file"))
-            .errored(tool_failed("connection timeout"));
-        assert!(q.matches(&task));
-    }
-
-    #[test]
-    fn and_binds_tighter_than_or() {
-        let q = parse("label = scan AND status = todo OR label = report");
-        assert!(q.matches(&task("t-1").label("scan").status(Status::Todo)));
-        assert!(!q.matches(&task("t-2").label("scan").status(Status::Failed)));
-        assert!(q.matches(&task("t-3").label("report").status(Status::Failed)));
-    }
-
-    #[test]
-    fn parentheses_override_precedence() {
-        let q = parse("(label = scan OR label = report) AND status = todo");
-        assert!(q.matches(&task("t-1").label("report").status(Status::Todo)));
-        assert!(!q.matches(&task("t-2").label("report").status(Status::Failed)));
-    }
-
-    #[test]
-    fn not_inverts_a_group() {
-        let q = parse("NOT (label = scan OR label = report)");
-        assert!(q.matches(&task("t-1").label("review")));
-        assert!(!q.matches(&task("t-2").label("scan")));
-    }
-
-    #[test]
-    fn a_quoted_value_keeps_its_spaces() {
-        let q = parse("label = \"needs review\"");
-        assert!(q.matches(&task("t-1").label("needs review")));
-        assert!(!q.matches(&task("t-2").label("needs")));
-    }
-
-    #[test]
-    fn keywords_parse_in_any_case() {
-        let q = parse("label in (scan, report) and agent is not empty order by id desc");
-        assert!(q.matches(&task("t-1").label("scan").agent("scanner-1")));
-        assert!(!q.matches(&task("t-2").label("scan")));
-    }
-
-    #[test]
-    fn a_status_parses_in_its_canonical_spelling() {
-        let in_progress = task("t-1").status(Status::InProgress);
-        assert!(parse("status = in_progress").matches(&in_progress));
-    }
-
-    #[test]
-    fn a_value_comparison_is_case_sensitive() {
-        let q = parse("label = Scan");
-        assert!(!q.matches(&task("t-1").label("scan")));
-    }
-
-    #[test]
-    fn a_bare_word_selects_the_label() {
-        let q = parse("scan");
-        assert!(q.matches(&task("t-1").label("scan")));
-        assert!(!q.matches(&task("t-2").label("report")));
-    }
-
-    #[test]
-    fn a_task_id_selects_that_one_task() {
-        let q = parse("t-3");
-        assert!(q.matches(&task("t-3").label("scan")));
-        assert!(!q.matches(&task("t-4").label("scan")));
-    }
-
-    #[test]
-    fn a_bare_word_inside_a_group_selects_the_label() {
-        let q = parse("(scan OR report) AND status = todo");
-        assert!(q.matches(&task("t-1").label("report").status(Status::Todo)));
-        assert!(!q.matches(&task("t-2").label("review").status(Status::Todo)));
-    }
-
-    #[test]
-    fn a_label_named_like_an_id_needs_the_field() {
-        let odd = task("t-1").label("t-3");
-        assert!(!parse("t-3").matches(&odd));
-        assert!(parse("label = t-3").matches(&odd));
-    }
-
-    #[test]
-    fn a_quoted_word_alone_selects_a_label_carrying_spaces() {
-        let q = parse("\"needs review\"");
-        assert!(q.matches(&task("t-1").label("needs review")));
-    }
-
-    #[test]
-    fn order_by_sorts_ascending_by_default() {
-        let tasks = [
-            task("t-1").agent("scanner-2"),
-            task("t-2").agent("scanner-1"),
-        ];
-        assert_eq!(ordered("ORDER BY agent", &tasks), ["t-2", "t-1"]);
-    }
-
-    #[test]
-    fn a_filter_and_an_order_compose() {
-        let tasks = [
-            task("t-1").label("scan"),
-            task("t-2").label("scan"),
-            task("t-3").label("report"),
-        ];
-        assert_eq!(
-            ordered("label = scan ORDER BY id DESC", &tasks),
-            ["t-2", "t-1"]
-        );
-    }
-
-    #[test]
-    fn a_query_that_is_only_an_order_by_matches_every_task() {
-        let q = parse("ORDER BY id");
-        assert!(q.matches(&task("t-1")));
-        assert!(q.matches(&task("t-2").label("scan")));
-    }
-
-    #[test]
-    fn order_by_status_follows_the_lifecycle() {
-        let tasks = [
-            task("t-1").status(Status::Failed),
-            task("t-2").status(Status::Todo),
-            task("t-3").status(Status::Finished),
-        ];
-        assert_eq!(ordered("ORDER BY status", &tasks), ["t-2", "t-3", "t-1"]);
-    }
-
-    #[test]
-    fn order_by_id_sorts_numerically_not_as_text() {
-        let tasks = [task("t-10"), task("t-2")];
-        assert_eq!(ordered("ORDER BY id", &tasks), ["t-2", "t-10"]);
-    }
-
-    #[test]
-    fn a_task_missing_the_sort_field_sorts_last_in_both_directions() {
-        let tasks = [task("t-1"), task("t-2").agent("scanner-1")];
-        assert_eq!(ordered("ORDER BY agent", &tasks), ["t-2", "t-1"]);
-        assert_eq!(ordered("ORDER BY agent DESC", &tasks), ["t-2", "t-1"]);
-    }
-
-    #[test]
-    fn equal_sort_values_keep_creation_order() {
-        // The IDs disagree with the creation times, so the assertion holds
-        // only while creation order is what breaks the tie.
-        let tasks = [
-            task("t-1").label("scan").created_at(2),
-            task("t-2").label("scan").created_at(1),
-        ];
-        assert_eq!(ordered("ORDER BY label", &tasks), ["t-2", "t-1"]);
-    }
-
-    #[test]
-    fn a_query_without_an_order_by_answers_in_creation_order() {
-        let tasks = [
-            task("t-1").label("scan").created_at(2),
-            task("t-2").label("scan").created_at(1),
-        ];
-        assert_eq!(ordered("label = scan", &tasks), ["t-2", "t-1"]);
-    }
-
-    #[test]
-    fn order_by_asc_is_the_default_spelled_out() {
-        let tasks = [task("t-2"), task("t-1")];
-        assert_eq!(
-            ordered("ORDER BY id ASC", &tasks),
-            ordered("ORDER BY id", &tasks)
-        );
-        assert_eq!(ordered("ORDER BY id ASC", &tasks), ["t-1", "t-2"]);
-    }
-
-    #[test]
-    fn order_by_finished_answers_the_most_recent_first() {
-        let tasks = [
-            task("t-1").finished_at(100),
-            task("t-2").finished_at(300),
-            task("t-3").finished_at(200),
-        ];
-        assert_eq!(
-            ordered("ORDER BY finished DESC", &tasks),
-            ["t-2", "t-3", "t-1"]
-        );
-    }
-
-    #[test]
-    fn order_by_finished_sorts_numerically_not_as_text() {
-        let tasks = [task("t-1").finished_at(1000), task("t-2").finished_at(900)];
-        assert_eq!(ordered("ORDER BY finished", &tasks), ["t-2", "t-1"]);
-    }
-
-    #[test]
-    fn a_task_still_running_sorts_last_by_finished() {
-        let tasks = [task("t-1"), task("t-2").finished_at(100)];
-        assert_eq!(ordered("ORDER BY finished DESC", &tasks), ["t-2", "t-1"]);
-    }
-
-    #[test]
-    fn finished_is_empty_matches_a_task_that_has_not_finished() {
-        let q = parse("finished IS EMPTY");
-        assert!(q.matches(&task("t-1")));
-        assert!(!q.matches(&task("t-2").finished_at(100)));
-    }
-
-    #[test]
-    fn a_time_field_takes_no_equality() {
-        let message = error("finished = 3").to_string();
-        assert!(message.contains("finished"), "{message}");
-        assert!(message.contains("ORDER BY"), "{message}");
-    }
-
-    #[test]
-    fn created_is_never_empty() {
-        assert_eq!(
-            error("created IS EMPTY"),
-            QueryError::OperatorNotAllowed {
-                field: "created",
-                operators: ">, >=, <, <=, and ORDER BY",
-            }
-        );
-    }
-
-    #[test]
-    fn after_selects_the_tasks_finished_since_the_moment() {
-        let q = parse("finished > 200");
-        assert!(q.matches(&task("t-1").finished_at(300)));
-        assert!(!q.matches(&task("t-2").finished_at(200)));
-        assert!(!q.matches(&task("t-3").finished_at(100)));
-    }
-
-    #[test]
-    fn not_before_includes_the_moment_itself() {
-        let q = parse("finished >= 200");
-        assert!(q.matches(&task("t-1").finished_at(200)));
-        assert!(!q.matches(&task("t-2").finished_at(199)));
-    }
-
-    #[test]
-    fn before_selects_the_tasks_finished_up_to_the_moment() {
-        let q = parse("finished < 200");
-        assert!(q.matches(&task("t-1").finished_at(100)));
-        assert!(!q.matches(&task("t-2").finished_at(200)));
-    }
-
-    #[test]
-    fn not_after_includes_the_moment_itself() {
-        let q = parse("finished <= 200");
-        assert!(q.matches(&task("t-1").finished_at(200)));
-        assert!(!q.matches(&task("t-2").finished_at(201)));
-    }
-
-    #[test]
-    fn two_comparisons_on_one_time_are_a_window() {
-        // `reject_repeated_field` names one field twice a mistake, and this is
-        // the shape that must survive it.
-        let q = parse("finished >= 200 AND finished < 400");
-        assert!(q.matches(&task("t-1").finished_at(300)));
-        assert!(!q.matches(&task("t-2").finished_at(400)));
-        assert!(!q.matches(&task("t-3").finished_at(100)));
-    }
-
-    #[test]
-    fn an_offset_selects_what_happened_inside_it() {
-        let now = crate::agents::tasks::now_millis();
-        let q = parse("created > -1h");
-        assert!(q.matches(&task("t-1").created_at(now)));
-        assert!(!q.matches(&task("t-2").created_at(now - 7_200_000)));
-    }
-
-    #[test]
-    fn every_offset_unit_reaches_further_back() {
-        let now = crate::agents::tasks::now_millis();
-        let a_day_ago = task("t-1").created_at(now - 86_400_000);
-        assert!(!parse("created > -1h").matches(&a_day_ago));
-        assert!(!parse("created > -30m").matches(&a_day_ago));
-        assert!(parse("created > -2d").matches(&a_day_ago));
-        assert!(parse("created > -1w").matches(&a_day_ago));
-    }
-
-    #[test]
-    fn a_date_is_read_as_midnight_utc() {
-        // 2026-08-24T00:00:00Z, the moment the date names.
-        let q = parse("created >= 2026-08-24");
-        assert!(q.matches(&task("t-1").created_at(1_787_529_600_000)));
-        assert!(!q.matches(&task("t-2").created_at(1_787_529_599_999)));
-    }
-
-    #[test]
-    fn a_date_may_be_quoted() {
-        let q = parse("created >= \"2026-08-24\"");
-        assert!(q.matches(&task("t-1").created_at(1_787_529_600_000)));
-    }
-
-    #[test]
-    fn an_absent_time_fails_every_comparison() {
-        // The same rule an absent label follows: `IS EMPTY` is what reads it.
-        let running = task("t-1");
-        assert!(!parse("finished > 0").matches(&running));
-        assert!(!parse("finished < 999").matches(&running));
-        assert!(parse("finished IS EMPTY").matches(&running));
-    }
-
-    #[test]
-    fn a_time_that_is_in_no_spelling_names_the_three() {
-        let message = error("created > yesterday").to_string();
-        assert!(message.contains("yesterday"), "{message}");
-        assert!(message.contains("2026-08-24"), "{message}");
-        assert!(message.contains("-30m"), "{message}");
-    }
-
-    #[test]
-    fn an_offset_in_no_unit_is_rejected() {
-        assert!(matches!(
-            error("created > -5y"),
-            QueryError::TimeMalformed { .. }
-        ));
-    }
-
-    #[test]
-    fn a_comparison_on_a_field_that_is_not_a_time_lists_the_operators() {
-        let message = error("label > scan").to_string();
-        assert!(message.contains("label"), "{message}");
-        assert!(message.contains("IN"), "{message}");
-    }
-
-    #[test]
-    fn a_comparison_needs_no_spaces_around_it() {
-        let q = parse("finished>=200");
-        assert!(q.matches(&task("t-1").finished_at(200)));
-    }
-
-    #[test]
-    fn an_unknown_sort_field_lists_the_fields_that_exist() {
-        let message = error("ORDER BY assignee").to_string();
-        assert!(message.contains("assignee"), "{message}");
-        assert!(message.contains("agent"), "{message}");
-    }
-
-    #[test]
-    fn an_order_by_without_a_field_is_rejected() {
-        assert_eq!(error("scan ORDER BY"), QueryError::TermUnfinished);
-    }
-
-    #[test]
-    fn an_order_without_by_is_rejected() {
-        assert!(matches!(
-            error("ORDER id"),
-            QueryError::TokenRejected { .. }
-        ));
-    }
-
-    #[test]
-    fn two_equalities_on_one_label_are_rejected() {
-        let message = error("label = scan AND label = report").to_string();
-        assert!(message.contains("label"), "{message}");
-        assert!(message.contains("IN"), "{message}");
-    }
-
-    #[test]
-    fn two_equalities_on_one_label_are_allowed_under_or() {
-        let q = parse("label = scan OR label = report");
-        assert!(q.matches(&task("t-1").label("scan")));
-        assert!(q.matches(&task("t-2").label("report")));
-    }
-
-    #[test]
-    fn an_unknown_field_lists_the_fields_that_exist() {
-        let message = error("assignee = alice").to_string();
-        assert!(message.contains("assignee"), "{message}");
-        assert!(message.contains("agent"), "{message}");
-    }
-
-    #[test]
-    fn key_is_not_an_alias_for_id() {
-        assert!(matches!(
-            error("key = t-1"),
-            QueryError::FieldUnrecognized { name, .. } if name == "key"
-        ));
-    }
-
-    #[test]
-    fn an_unknown_status_lists_the_four() {
-        let message = error("status = Started").to_string();
-        assert!(message.contains("in_progress"), "{message}");
-    }
-
-    #[test]
-    fn an_operator_the_field_rejects_lists_the_ones_it_takes() {
-        let message = error("task = anything").to_string();
-        assert!(message.contains("task"), "{message}");
-        assert!(message.contains('~'), "{message}");
-    }
-
-    #[test]
-    fn a_text_operator_on_a_value_field_lists_the_ones_it_takes() {
-        let message = error("label ~ scan").to_string();
-        assert!(message.contains("label"), "{message}");
-        assert!(message.contains("IN"), "{message}");
-    }
-
-    #[test]
-    fn is_empty_on_a_field_every_task_carries_is_rejected() {
-        assert_eq!(
-            error("id IS EMPTY"),
-            QueryError::OperatorNotAllowed {
-                field: "id",
-                operators: "=, !=, IN, NOT IN",
-            }
-        );
-    }
-
-    #[test]
-    fn an_unclosed_group_is_rejected() {
-        assert_eq!(error("(label = scan"), QueryError::TermUnfinished);
-    }
-
-    #[test]
-    fn an_unterminated_quote_is_rejected() {
-        assert_eq!(error("label = \"needs review"), QueryError::TermUnfinished);
-    }
-
-    #[test]
-    fn a_lone_bang_is_rejected() {
-        assert!(matches!(
-            error("label ! scan"),
-            QueryError::TokenRejected { .. }
-        ));
-    }
-
-    #[test]
-    fn a_blank_query_is_rejected() {
-        assert_eq!(error("   "), QueryError::TermsMissing);
-    }
-
-    #[test]
-    #[should_panic(expected = "invalid query")]
-    fn a_malformed_query_string_panics_naming_the_input() {
-        Matcher::<Task>::into_query("label = ");
-    }
-}
-
-/// The same grammar over the event field set.
-#[cfg(test)]
-mod event_tests {
-    use super::*;
-
-    fn event(event: Event) -> Event {
-        event.task_id("t-1").agent_id("scout-1")
-    }
-
-    fn tool_failed(message: &str) -> Event {
-        Event::new(Event::TOOL_CALL_FAILED).data(serde_json::json!({
-            "tool_name": "grep",
-            "call_id": "c1",
-            "kind": "execution_failed",
-            "message": message,
-        }))
-    }
-
-    /// Pins the stamp, which `Event::new` would set to now.
-    fn at(created_at: u64, value: Event) -> Event {
-        Event {
-            created_at,
-            ..event(value)
-        }
-    }
-
-    fn parse(query: &str) -> Query<Event> {
-        Query::new(query).expect("query must parse")
-    }
-
-    fn error(query: &str) -> QueryError {
-        Query::<Event>::new(query).expect_err("query must be rejected")
-    }
-
-    /// The events the query selects, in the order it puts them in.
-    fn ordered(query: &str, events: &[Event]) -> Vec<u64> {
-        let query = parse(query);
-        let mut matching: Vec<Event> = events
-            .iter()
-            .filter(|e| query.matches(e))
-            .cloned()
-            .collect();
-        query.sort(&mut matching);
-        matching.iter().map(|e| e.created_at).collect()
-    }
-
-    #[test]
-    fn an_event_is_selected_by_its_name() {
-        let q = parse("event = tool_call_failed");
-        assert!(q.matches(&event(tool_failed("boom"))));
-        assert!(!q.matches(&event(Event::new(Event::TURN_STARTED))));
-    }
-
-    #[test]
-    fn a_builtin_event_name_uses_only_its_canonical_spelling() {
-        let failed = event(tool_failed("boom"));
-        assert!(parse("event = tool_call_failed").matches(&failed));
-        assert!(!parse("event = ToolCallFailed").matches(&failed));
-    }
-
-    #[test]
-    fn an_event_takes_in_like_any_other_field() {
-        let q = parse("event IN (request_failed, tool_call_failed)");
-        assert!(q.matches(&event(tool_failed("boom"))));
-        assert!(!q.matches(&event(Event::new(Event::TURN_STARTED))));
-    }
-
-    #[test]
-    fn an_application_event_name_is_never_reinterpreted_as_a_builtin() {
-        let event = Event::new("TaskFinished");
-        assert!(parse(r#"event = "TaskFinished""#).matches(&event));
-        assert!(parse("event = TaskFinished").matches(&event));
-        assert!(!parse("event = task_finished").matches(&event));
-    }
-
-    #[test]
-    fn the_task_field_selects_the_events_of_one_task() {
-        let q = parse("task = t-1");
-        assert!(q.matches(&event(Event::new(Event::TURN_STARTED))));
-        assert!(!q.matches(
-            &Event::new(Event::TURN_STARTED)
-                .task_id("t-2")
-                .agent_id("scout-1")
-        ));
-    }
-
-    #[test]
-    fn an_event_no_task_owns_reads_as_empty() {
-        // `RunStarted` and `RunFinished` carry no task ID.
-        let run = Event::new(Event::RUN_STARTED);
-        assert!(parse("task IS EMPTY").matches(&run));
-        assert!(parse("agent IS EMPTY").matches(&run));
-        assert!(!parse("task IS NOT EMPTY").matches(&run));
-    }
-
-    #[test]
-    fn the_agent_field_selects_who_emitted_it() {
-        let q = parse("agent = scout-1");
-        assert!(q.matches(&event(Event::new(Event::TURN_STARTED))));
-        assert!(!q.matches(
-            &Event::new(Event::TURN_STARTED)
-                .task_id("t-1")
-                .agent_id("sniper-1")
-        ));
-    }
-
-    #[test]
-    fn the_label_field_selects_the_pool_the_task_belongs_to() {
-        let labelled = Event {
-            label: Some("scan".into()),
-            ..Event::new(Event::TURN_STARTED)
-                .task_id("t-1")
-                .agent_id("scout-1")
-        };
-        assert!(parse("label = scan").matches(&labelled));
-        assert!(parse("label IS EMPTY").matches(&event(Event::new(Event::TURN_STARTED))));
-    }
-
-    #[test]
-    fn payload_searches_the_message_the_kind_carries() {
-        let q = parse("payload ~ timeout");
-        assert!(q.matches(&event(tool_failed("connection timeout"))));
-        assert!(!q.matches(&event(tool_failed("no such file"))));
-    }
-
-    #[test]
-    fn payload_reaches_the_name_as_well_as_the_body() {
-        assert!(parse("payload ~ tool_call_failed").matches(&event(tool_failed("boom"))));
-    }
-
-    #[test]
-    fn a_lone_word_naming_an_event_selects_it() {
-        let q = parse("tool_call_failed");
-        assert!(q.matches(&event(tool_failed("boom"))));
-        assert!(!q.matches(&event(Event::new(Event::TURN_STARTED))));
-    }
-
-    #[test]
-    fn a_lone_word_naming_no_event_selects_the_label() {
-        let labelled = Event {
-            label: Some("scan".into()),
-            ..Event::new(Event::TURN_STARTED)
-                .task_id("t-1")
-                .agent_id("scout-1")
-        };
-        let q = parse("scan");
-        assert!(q.matches(&labelled));
-        assert!(!q.matches(&event(Event::new(Event::TURN_STARTED))));
-    }
-
-    #[test]
-    fn a_lone_task_id_selects_that_task_s_events() {
-        let q = parse("t-1");
-        assert!(q.matches(&event(Event::new(Event::TURN_STARTED))));
-        assert!(!q.matches(
-            &Event::new(Event::TURN_STARTED)
-                .task_id("t-2")
-                .agent_id("scout-1")
-        ));
-    }
-
-    #[test]
-    fn created_takes_the_same_comparisons_tasks_take() {
-        let q = parse("created > 200");
-        assert!(q.matches(&at(300, Event::new(Event::TURN_STARTED))));
-        assert!(!q.matches(&at(100, Event::new(Event::TURN_STARTED))));
-    }
-
-    #[test]
-    fn terms_combine_the_way_they_do_over_tasks() {
-        let q = parse("agent = scout-1 AND (tool_call_failed OR turn_started)");
-        assert!(q.matches(&event(Event::new(Event::TURN_STARTED))));
-        assert!(!q.matches(&event(Event::new(Event::RUN_STARTED))));
-    }
-
-    #[test]
-    fn order_by_created_desc_answers_the_newest_first() {
-        let events = [
-            at(100, Event::new(Event::TURN_STARTED)),
-            at(300, Event::new(Event::TURN_STARTED)),
-            at(200, Event::new(Event::TURN_STARTED)),
-        ];
-        assert_eq!(
-            ordered("turn_started ORDER BY created DESC", &events),
-            [300, 200, 100]
-        );
-    }
-
-    #[test]
-    fn a_query_without_an_order_keeps_the_order_the_log_holds() {
-        let events = [
-            at(300, Event::new(Event::TURN_STARTED)),
-            at(100, Event::new(Event::TURN_STARTED)),
-        ];
-        assert_eq!(ordered("turn_started", &events), [300, 100]);
-    }
-
-    #[test]
-    fn an_unknown_field_lists_the_event_fields() {
-        let message = error("status = finished").to_string();
-        assert!(message.contains("status"), "{message}");
-        assert!(message.contains("payload"), "{message}");
-        // The task fields are a different set, and the message says so.
-        assert!(!message.contains("parent"), "{message}");
-    }
-
-    #[test]
-    fn an_operator_the_field_rejects_lists_the_ones_it_takes() {
-        let message = error("event ~ tool_call_failed").to_string();
-        assert!(message.contains("event"), "{message}");
-        assert!(message.contains("IN"), "{message}");
-    }
-
-    #[test]
-    fn a_closure_selects_the_events_it_accepts() {
-        let q = (|e: &Event| e.get_name() == Event::TOOL_CALL_FAILED).into_query();
-        assert!(q.matches(&event(tool_failed("boom"))));
-        assert!(!q.matches(&event(Event::new(Event::TURN_STARTED))));
-    }
-
-    #[test]
-    fn a_string_says_the_same_query_a_compiled_one_does() {
-        let q = Matcher::<Event>::into_query("tool_call_failed");
-        assert!(q.matches(&event(tool_failed("boom"))));
-        assert!(!q.matches(&event(Event::new(Event::TURN_STARTED))));
-    }
-
-    #[test]
-    #[should_panic(expected = "invalid query")]
-    fn a_malformed_query_string_panics_naming_the_input() {
-        Matcher::<Event>::into_query("event = ");
-    }
 }

--- a/crates/agentwerk/src/agents/tasks/store.rs
+++ b/crates/agentwerk/src/agents/tasks/store.rs
@@ -52,7 +52,7 @@ impl Werk {
             .lock()
             .unwrap()
             .iter()
-            .any(|query| query.matches(&task));
+            .any(|query| query.matches_task(&task));
         let mut store = self.tasks.lock().unwrap();
         let id = task.id.clone();
         let reporter = task.reporter.clone();
@@ -97,8 +97,11 @@ impl Werk {
         let now = now_millis();
         let id = {
             let mut store = self.tasks.lock().unwrap();
-            let mut candidates: Vec<&Task> = store.values().filter(|t| query.matches(t)).collect();
-            query.sort(&mut candidates);
+            let mut candidates: Vec<&Task> = store
+                .values()
+                .filter(|task| query.matches_task(task))
+                .collect();
+            query.sort_tasks(&mut candidates);
             let id = candidates.first()?.id.clone();
             let task = store.get_mut(&id)?;
             if task.status != Status::Todo {
@@ -553,7 +556,9 @@ mod tests {
     fn claim_transitions_todo_to_in_progress_and_sets_the_assignee() {
         let (werk, _tmp) = test_werk();
         werk.add_task("hello");
-        let id = werk.claim(&Query::from("status = todo"), "alice").unwrap();
+        let id = werk
+            .claim(&Query::from("task.status = todo"), "alice")
+            .unwrap();
         assert_eq!(id, "t-1");
         let t = werk.get_task(&id).unwrap();
         assert_eq!(t.status, Status::InProgress);
@@ -565,7 +570,9 @@ mod tests {
     fn claim_leaves_the_label_the_task_was_filed_with() {
         let (werk, _tmp) = test_werk();
         werk.add_task(Task::new("hello").label("analysis"));
-        let id = werk.claim(&Query::from("analysis"), "alice").unwrap();
+        let id = werk
+            .claim(&Query::from("task.label = analysis"), "alice")
+            .unwrap();
         assert_eq!(
             werk.get_task(&id).unwrap().label.as_deref(),
             Some("analysis")
@@ -576,7 +583,9 @@ mod tests {
     fn claim_returns_none_when_no_task_matches() {
         let (werk, _tmp) = test_werk();
         werk.add_task("hello");
-        assert!(werk.claim(&Query::from("nonexistent"), "alice").is_none());
+        assert!(werk
+            .claim(&Query::from("task.label = nonexistent"), "alice")
+            .is_none());
     }
 
     #[test]
@@ -596,7 +605,9 @@ mod tests {
         werk.add_task("a");
         werk.add_task("b");
         werk.add_task("c");
-        let id = werk.claim(&Query::from("status = todo"), "alice").unwrap();
+        let id = werk
+            .claim(&Query::from("task.status = todo"), "alice")
+            .unwrap();
         assert_eq!(id, "t-1");
     }
 
@@ -604,7 +615,7 @@ mod tests {
     fn claim_logs_the_task_starting() {
         let (werk, dir) = test_werk();
         werk.add_task("hello");
-        werk.claim(&Query::from("status = todo"), "alice");
+        werk.claim(&Query::from("task.status = todo"), "alice");
         let lines = read_events_log(dir.path());
         assert_eq!(lines.len(), 2);
         assert_eq!(lines[0]["name"], "task_created");
@@ -617,7 +628,7 @@ mod tests {
     fn set_finished_transitions_to_finished() {
         let (werk, _tmp) = test_werk();
         let id = werk.add_task("hello");
-        werk.claim(&Query::from("status = todo"), "alice");
+        werk.claim(&Query::from("task.status = todo"), "alice");
         werk.set_finished_by(&id, "alice").unwrap();
         let t = werk.get_task(&id).unwrap();
         assert_eq!(t.status, Status::Finished);
@@ -667,7 +678,7 @@ mod tests {
         drop(werk);
 
         let resumed = Werk::load(dir.path()).unwrap();
-        let event = resumed.find_event(Event::TASK_FINISHED).unwrap();
+        let event = resumed.find_event("event.name = task_finished").unwrap();
         assert_eq!(event.get_data()["result"], "done");
         assert_eq!(resumed.get_results(), vec![serde_json::json!("done")]);
     }
@@ -676,7 +687,7 @@ mod tests {
     fn set_failed_transitions_to_failed() {
         let (werk, _tmp) = test_werk();
         let id = werk.add_task("hello");
-        werk.claim(&Query::from("status = todo"), "alice");
+        werk.claim(&Query::from("task.status = todo"), "alice");
         werk.set_task_failed(&id).unwrap();
         let t = werk.get_task(&id).unwrap();
         assert_eq!(t.status, Status::Failed);
@@ -687,7 +698,7 @@ mod tests {
     fn a_finished_task_is_not_reopened_by_a_later_failure() {
         let (werk, _tmp) = test_werk();
         let id = werk.add_task("hello");
-        werk.claim(&Query::from("status = todo"), "alice");
+        werk.claim(&Query::from("task.status = todo"), "alice");
         werk.set_task_finished(&id, "host result").unwrap();
 
         // Alice was still turning the task and gives up after the host
@@ -709,7 +720,7 @@ mod tests {
     fn a_failed_task_is_not_reopened_by_a_later_finish() {
         let (werk, _tmp) = test_werk();
         let id = werk.add_task("hello");
-        werk.claim(&Query::from("status = todo"), "alice");
+        werk.claim(&Query::from("task.status = todo"), "alice");
         werk.set_failed_by(&id, "alice").unwrap();
 
         werk.set_task_finished(&id, "late result").unwrap();
@@ -913,7 +924,7 @@ mod tests {
         original.set_dir(dir.path().to_path_buf());
         original.add_task("mid flight");
         original
-            .claim(&Query::from("status = todo"), "alice")
+            .claim(&Query::from("task.status = todo"), "alice")
             .unwrap();
         drop(original);
 
@@ -1071,7 +1082,7 @@ mod tests {
         let werk = Werk::new();
         werk.set_dir(dir.path().to_path_buf());
         let id = werk.add_task(Task::new("hello").label("scan"));
-        werk.cancel_tasks("label = scan");
+        werk.cancel_tasks("task.label = scan");
         werk.set_task_failed(&id).unwrap();
 
         let stored =
@@ -1080,8 +1091,8 @@ mod tests {
         assert!(record.get("cancelled").is_none());
 
         let resumed = Werk::load(dir.path()).unwrap();
-        assert!(resumed.find_tasks("cancelled = true").is_empty());
-        assert_eq!(resumed.find_tasks("cancelled = false").len(), 1);
+        assert!(resumed.find_tasks("task.cancelled = true").is_empty());
+        assert_eq!(resumed.find_tasks("task.cancelled = false").len(), 1);
     }
 
     #[test]
@@ -1127,12 +1138,13 @@ mod tests {
     fn task_lifecycle_writes_its_events_to_the_log() {
         let (werk, _dir) = test_werk();
         werk.add_task("seed");
-        werk.claim(&Query::from("status = todo"), "alice").unwrap();
+        werk.claim(&Query::from("task.status = todo"), "alice")
+            .unwrap();
         werk.set_result("t-1", serde_json::Value::Null).unwrap();
         werk.set_finished_by("t-1", "agent").unwrap();
 
-        assert_eq!(werk.find_events("task_created").len(), 1);
-        assert_eq!(werk.find_events("task_finished").len(), 1);
+        assert_eq!(werk.find_events("event.name = task_created").len(), 1);
+        assert_eq!(werk.find_events("event.name = task_finished").len(), 1);
     }
 
     #[test]

--- a/crates/agentwerk/src/agents/tasks/store.rs
+++ b/crates/agentwerk/src/agents/tasks/store.rs
@@ -7,7 +7,7 @@ use crate::event::Event;
 use crate::persistence::Persist;
 use crate::schemas::SchemaViolations;
 
-use super::super::query::Query;
+use super::super::query::{Origin, Query};
 use super::error::TaskError;
 use super::reply::Reply;
 use super::task::{Status, Task};
@@ -52,7 +52,7 @@ impl Werk {
             .lock()
             .unwrap()
             .iter()
-            .any(|query| query.matches_task(&task));
+            .any(|filter| filter.matches(&task));
         let mut store = self.tasks.lock().unwrap();
         let id = task.id.clone();
         let reporter = task.reporter.clone();
@@ -94,15 +94,26 @@ impl Werk {
     /// The earliest candidate must itself be `todo`, so a query naming no
     /// status never reaches past a task already claimed.
     pub(crate) fn claim(&self, query: &Query, agent_id: &str) -> Option<String> {
+        let projected = match query.origin() {
+            Origin::Task => None,
+            Origin::Event | Origin::Joined => {
+                Some(self.tasks_selected_by(query).into_iter().next()?.id)
+            }
+        };
         let now = now_millis();
         let id = {
             let mut store = self.tasks.lock().unwrap();
-            let mut candidates: Vec<&Task> = store
-                .values()
-                .filter(|task| query.matches_task(task))
-                .collect();
-            query.sort_tasks(&mut candidates);
-            let id = candidates.first()?.id.clone();
+            let id = match projected {
+                Some(id) => id,
+                None => {
+                    let mut candidates: Vec<&Task> = store
+                        .values()
+                        .filter(|task| query.matches_task(task))
+                        .collect();
+                    query.sort_tasks(&mut candidates);
+                    candidates.first()?.id.clone()
+                }
+            };
             let task = store.get_mut(&id)?;
             if task.status != Status::Todo {
                 return None;

--- a/crates/agentwerk/src/agents/tasks/werk.rs
+++ b/crates/agentwerk/src/agents/tasks/werk.rs
@@ -876,52 +876,83 @@ impl Werk {
 
     /// Get every task in creation order.
     pub fn get_tasks(&self) -> Vec<Task> {
-        self.matching_tasks(&Query::all())
+        self.matching_tasks(&Query::all().task())
     }
 
-    /// Get every task matching a condition, in creation order unless the
-    /// query names another with `ORDER BY`.
+    /// Get every task selected by a task query or referenced by an event query.
+    /// The query's source order determines the returned order.
     ///
     /// Your condition MUST NOT call another `Werk` method that reads
     /// the task store, or the call deadlocks.
     pub fn find_tasks(&self, predicate: impl Matcher<Task>) -> Vec<Task> {
-        self.matching_tasks(&predicate.into_query())
+        let query = predicate.into_query().task_if_originless();
+        self.tasks_selected_by(&query)
     }
 
-    /// Get the first task matching a condition, the earliest one unless the
-    /// query names another order.
+    /// Get the first task selected by a task query or referenced by an event
+    /// query.
     ///
     /// Your condition MUST NOT call another `Werk` method that reads
     /// the task store, or the call deadlocks.
     pub fn find_task(&self, predicate: impl Matcher<Task>) -> Option<Task> {
-        self.first_matching_task(&predicate.into_query())
+        let query = predicate.into_query().task_if_originless();
+        match query.is_event() {
+            true => self.tasks_referenced_by(&query).into_iter().next(),
+            false => self.first_matching_task(&query),
+        }
+    }
+
+    fn tasks_selected_by(&self, query: &Query) -> Vec<Task> {
+        match query.is_event() {
+            true => self.tasks_referenced_by(query),
+            false => self.matching_tasks(query),
+        }
     }
 
     fn matching_tasks(&self, query: &Query) -> Vec<Task> {
         let store = self.tasks.lock().unwrap();
-        let mut matching: Vec<&Task> = store.values().filter(|t| query.matches(t)).collect();
-        query.sort(&mut matching);
+        let mut matching: Vec<&Task> = store
+            .values()
+            .filter(|task| query.matches_task(task))
+            .collect();
+        query.sort_tasks(&mut matching);
         matching.into_iter().cloned().collect()
     }
 
     /// The first of those, and the only task copied.
     fn first_matching_task(&self, query: &Query) -> Option<Task> {
         let store = self.tasks.lock().unwrap();
-        let mut matching: Vec<&Task> = store.values().filter(|t| query.matches(t)).collect();
-        query.sort(&mut matching);
+        let mut matching: Vec<&Task> = store
+            .values()
+            .filter(|task| query.matches_task(task))
+            .collect();
+        query.sort_tasks(&mut matching);
         matching.into_iter().next().cloned()
     }
 
-    /// Get every recorded event matching a condition, oldest first, or in the
-    /// order an `ORDER BY` names.
+    fn tasks_referenced_by(&self, query: &Query) -> Vec<Task> {
+        let events = self.matching_events(query);
+        let store = self.tasks.lock().unwrap();
+        let mut seen = HashSet::new();
+        events
+            .into_iter()
+            .filter_map(|event| {
+                let task = store.get(&event.task_id)?;
+                seen.insert(event.task_id).then(|| task.clone())
+            })
+            .collect()
+    }
+
+    /// Get every event selected by an event query or attached to tasks selected
+    /// by a task query, in source-query order.
     ///
-    /// The condition is an AQL string, a [`Query<Event>`](crate::Query), or a
+    /// The condition is an AQL string, a [`Query`](crate::Query), or a
     /// closure, the way [`Self::find_tasks`] takes any of the three.
     ///
     /// ```no_run
     /// # use agentwerk::Werk;
     /// let werk = Werk::new();
-    /// werk.find_events("tool_call_failed AND created > -1h");
+    /// werk.find_events("event.name = tool_call_failed AND event.created > -1h");
     /// ```
     ///
     /// Read from the session's `events.jsonl`, so this answers for a run that
@@ -930,16 +961,20 @@ impl Werk {
     /// finds nothing, and `TextChunkReceived` is never recorded, so a condition
     /// naming it never matches.
     pub fn find_events(&self, matcher: impl Matcher<Event>) -> Vec<Event> {
-        let query = matcher.into_query();
-        let mut out = self.collect_events(&query, usize::MAX);
-        query.sort(&mut out);
-        out
+        let query = matcher.into_query().event_if_originless();
+        match query.is_event() {
+            true => self.matching_events(&query),
+            false => self.events_referencing_tasks(&query),
+        }
     }
 
-    /// Get the earliest recorded event matching a condition, or the first in
-    /// the order an `ORDER BY` names.
+    /// Get the first event selected by an event query or attached to a task
+    /// selected by a task query.
     pub fn find_event(&self, matcher: impl Matcher<Event>) -> Option<Event> {
-        let query = matcher.into_query();
+        let query = matcher.into_query().event_if_originless();
+        if !query.is_event() {
+            return self.events_referencing_tasks(&query).into_iter().next();
+        }
         // Without an order the log's own is the answer, so one match ends the
         // read instead of the whole log being copied to be sorted.
         let wanted = match query.is_ordered() {
@@ -947,15 +982,37 @@ impl Werk {
             false => 1,
         };
         let mut found = self.collect_events(&query, wanted);
-        query.sort(&mut found);
+        query.sort_events(&mut found);
         found.into_iter().next()
     }
 
+    fn matching_events(&self, query: &Query) -> Vec<Event> {
+        let mut events = self.collect_events(query, usize::MAX);
+        query.sort_events(&mut events);
+        events
+    }
+
+    fn events_referencing_tasks(&self, query: &Query) -> Vec<Event> {
+        let tasks = self.matching_tasks(query);
+        let positions: HashMap<&str, usize> = tasks
+            .iter()
+            .enumerate()
+            .map(|(position, task)| (task.id.as_str(), position))
+            .collect();
+        let mut grouped = vec![Vec::new(); tasks.len()];
+        let _ = Stats::for_each_event(&self.get_dir(), |event| {
+            if let Some(position) = positions.get(event.task_id.as_str()) {
+                grouped[*position].push(event.clone());
+            }
+        });
+        grouped.into_iter().flatten().collect()
+    }
+
     /// In log order: the caller sorts if its query named one.
-    fn collect_events(&self, query: &Query<Event>, wanted: usize) -> Vec<Event> {
+    fn collect_events(&self, query: &Query, wanted: usize) -> Vec<Event> {
         let mut out = Vec::new();
         let _ = Stats::for_each_event(&self.get_dir(), |event| {
-            if out.len() < wanted && query.matches(event) {
+            if out.len() < wanted && query.matches_event(event) {
                 out.push(event.clone());
             }
         });
@@ -975,13 +1032,13 @@ impl Werk {
     /// ```no_run
     /// # use agentwerk::Werk;
     /// let werk = Werk::new();
-    /// werk.cancel_tasks("scan");
+    /// werk.cancel_tasks("task.label = scan");
     /// ```
     pub fn cancel_tasks(&self, matches: impl Matcher<Task>) -> &Self {
-        let query = matches.into_query();
+        let query = matches.into_query().task();
         self.cancel_filters.lock().unwrap().push(query.clone());
         for task in self.tasks.lock().unwrap().values_mut() {
-            if query.matches(task) {
+            if query.matches_task(task) {
                 task.cancelled = true;
             }
         }
@@ -993,7 +1050,7 @@ impl Werk {
     /// [`Self::finish_all_tasks`] then reports `FinishReason::Cancelled`. Like
     /// [`Self::cancel_tasks`], nothing waits, so a ctrl-c handler can call it.
     pub fn cancel_all_tasks(&self) -> &Self {
-        self.cancel_tasks(Query::all())
+        self.cancel_tasks(Query::all().task())
     }
 
     /// True while any matching task still has work for an agent.
@@ -1011,7 +1068,7 @@ impl Werk {
         let interactive = self.interactive_agents();
         let tasks = self.tasks.lock().unwrap();
         tasks.values().any(|t| {
-            matches.matches(t)
+            matches.matches_task(t)
                 && t.is_pending()
                 && !(t.is_paused()
                     && t.assignee
@@ -1174,13 +1231,13 @@ impl Werk {
     /// # use agentwerk::Werk;
     /// # async fn run() {
     /// let werk = Werk::new();
-    /// for finding in werk.finish_tasks("research").await {
+    /// for finding in werk.finish_tasks("task.label = research").await {
     ///     println!("{finding}");
     /// }
     /// # }
     /// ```
     pub async fn finish_tasks(&self, matches: impl Matcher<Task>) -> Vec<serde_json::Value> {
-        let query = matches.into_query();
+        let query = matches.into_query().task();
         if self.join_handle.lock().unwrap().is_none()
             && (!self.run.is_finished() || self.anything_claimable())
         {
@@ -1208,8 +1265,8 @@ impl Werk {
             self.join_handle.lock().unwrap().take();
         }
         // `and_status`, not the `find_results` default: a caller who waited on
-        // `status = todo` receives finished results, not the matching unfinished tasks.
-        self.matching_tasks(&query.and_status(Status::Finished))
+        // `task.status = todo` receives finished results, not the matching unfinished tasks.
+        self.matching_tasks(&query.and_task_status(Status::Finished))
             .into_iter()
             .filter_map(|t| t.result)
             .collect()
@@ -1230,7 +1287,7 @@ impl Werk {
     /// # }
     /// ```
     pub async fn finish_all_tasks(&self) -> Vec<serde_json::Value> {
-        self.finish_tasks(Query::all()).await
+        self.finish_tasks(Query::all().task()).await
     }
 
     /// Wait for the matching tasks to be done, then get the first available
@@ -1243,7 +1300,7 @@ impl Werk {
     /// # use agentwerk::Werk;
     /// # async fn run() {
     /// let werk = Werk::new();
-    /// if let Some(answer) = werk.finish_task("ORDER BY created DESC").await {
+    /// if let Some(answer) = werk.finish_task("ORDER BY task.created DESC").await {
     ///     println!("{answer}");
     /// }
     /// # }
@@ -1281,48 +1338,54 @@ impl Werk {
     /// still running, or finished without a result, contributes nothing, so
     /// this is shorter than [`Self::get_tasks`] rather than aligned with it.
     pub fn get_results(&self) -> Vec<serde_json::Value> {
-        self.find_results(Query::all())
+        self.find_results(Query::all().task())
     }
 
-    /// Get every result whose task matches the query, in query order, or
-    /// creation order when the query names none.
+    /// Get every result whose task is selected directly or through a matching
+    /// event, in source-query order.
     ///
-    /// Status defaults to `finished` when the filter names none, which is
-    /// every closure and any query that leaves it unset. A caller that sets
-    /// `.status(Status::Failed)` keeps that filter. A task contributes a
-    /// result only when it has one, so this is shorter than the set the
-    /// filter named.
+    /// A task query defaults status to `finished` when it names none. Event
+    /// queries always project only finished tasks. A task contributes a result
+    /// only when it has one, so this is shorter than the set the filter named.
     ///
     /// ```no_run
     /// # use agentwerk::Werk;
     /// let werk = Werk::new();
-    /// let scans = werk.find_results("scan");
+    /// let scans = werk.find_results("task.label = scan");
     /// ```
     pub fn find_results(&self, matches: impl Matcher<Task>) -> Vec<serde_json::Value> {
-        self.matching_tasks(&results_of(matches))
+        self.result_tasks(matches)
             .into_iter()
-            .filter_map(|t| t.result)
+            .filter_map(|task| task.result)
             .collect()
     }
 
-    /// Get the first result whose task matches the query.
+    /// Get the first result selected through a matching task or event.
     ///
     /// Status defaults to `finished` as in [`Self::find_results`], and the
     /// order is that method's too.
     pub fn find_result(&self, matches: impl Matcher<Task>) -> Option<serde_json::Value> {
-        self.first_matching_task(&results_of(matches))
-            .and_then(|t| t.result)
+        self.result_tasks(matches)
+            .into_iter()
+            .next()
+            .and_then(|task| task.result)
     }
-}
 
-/// The tasks that contribute to `find_results`. The result term is why
-/// `find_result` answers with the first match carrying one, not the first
-/// match.
-fn results_of(matches: impl Matcher<Task>) -> Query {
-    matches
-        .into_query()
-        .default_status(Status::Finished)
-        .and_result()
+    fn result_tasks(&self, matches: impl Matcher<Task>) -> Vec<Task> {
+        let query = matches.into_query().task_if_originless();
+        if query.is_event() {
+            return self
+                .tasks_referenced_by(&query)
+                .into_iter()
+                .filter(|task| task.status == Status::Finished && task.result.is_some())
+                .collect();
+        }
+        self.matching_tasks(
+            &query
+                .default_task_status(Status::Finished)
+                .and_task_result(),
+        )
+    }
 }
 
 #[cfg(test)]
@@ -1396,7 +1459,7 @@ mod tests {
         werk.add_task("b");
         werk.add_task("c");
         let ids: Vec<String> = werk
-            .find_tasks("status = todo")
+            .find_tasks("task.status = todo")
             .into_iter()
             .map(|t| t.id)
             .collect();
@@ -1408,8 +1471,8 @@ mod tests {
         let (werk, _tmp) = test_werk();
         werk.add_task("a");
         werk.add_task("b");
-        werk.cancel_tasks("ORDER BY id DESC");
-        assert_eq!(werk.find_tasks("cancelled = true").len(), 2);
+        werk.cancel_tasks("ORDER BY task.id DESC");
+        assert_eq!(werk.find_tasks("task.cancelled = true").len(), 2);
     }
 
     #[test]
@@ -1419,7 +1482,7 @@ mod tests {
         werk.add_task("b");
         werk.add_task("c");
         let ids: Vec<String> = werk
-            .find_tasks("ORDER BY id DESC")
+            .find_tasks("ORDER BY task.id DESC")
             .into_iter()
             .map(|t| t.id)
             .collect();
@@ -1431,7 +1494,7 @@ mod tests {
         let (werk, _tmp) = test_werk();
         werk.add_task("a");
         werk.add_task("b");
-        let found = werk.find_task("ORDER BY id DESC").expect("a task");
+        let found = werk.find_task("ORDER BY task.id DESC").expect("a task");
         assert_eq!(found.id, "t-2");
     }
 
@@ -1443,8 +1506,75 @@ mod tests {
         attach_done_result(&werk, "t-1", "first");
         attach_done_result(&werk, "t-2", "second");
         assert_eq!(
-            werk.find_results("ORDER BY id DESC"),
+            werk.find_results("ORDER BY task.id DESC"),
             vec![serde_json::json!("second"), serde_json::json!("first")]
+        );
+    }
+
+    #[test]
+    fn one_task_query_can_select_tasks_and_their_results() {
+        let (werk, _tmp) = test_werk();
+        werk.add_task(Task::labeled("scan", "a"));
+        werk.add_task(Task::labeled("scan", "b"));
+        werk.add_task(Task::labeled("report", "c"));
+        attach_done_result(&werk, "t-1", "clean one");
+        attach_done_result(&werk, "t-2", "clean two");
+        attach_done_result(&werk, "t-3", "reported");
+        let query =
+            Query::new("task.label = scan AND task.result ~ clean ORDER BY task.id DESC").unwrap();
+
+        let ids = werk
+            .find_tasks(query.clone())
+            .into_iter()
+            .map(|task| task.id)
+            .collect::<Vec<_>>();
+        assert_eq!(ids, ["t-2", "t-1"]);
+        assert_eq!(
+            werk.find_results(query),
+            [
+                serde_json::json!("clean two"),
+                serde_json::json!("clean one")
+            ]
+        );
+    }
+
+    #[test]
+    fn compiled_queries_work_with_singular_and_plural_finders() {
+        let (werk, _tmp) = test_werk();
+        werk.add_task(Task::labeled("scan", "a"));
+        attach_done_result(&werk, "t-1", "clean");
+
+        let tasks = Query::new("task.label = scan").unwrap();
+        assert_eq!(werk.find_task(tasks.clone()).unwrap().id, "t-1");
+        assert_eq!(werk.find_tasks(tasks.clone()).len(), 1);
+        assert_eq!(
+            werk.find_result(tasks.clone()),
+            Some(serde_json::json!("clean"))
+        );
+        assert_eq!(werk.find_results(tasks), [serde_json::json!("clean")]);
+        assert_eq!(
+            werk.find_result(|task: &Task| task.label.as_deref() == Some("scan")),
+            Some(serde_json::json!("clean"))
+        );
+
+        let events = Query::new("event.name = task_created").unwrap();
+        assert_eq!(werk.find_event(events.clone()).unwrap().task_id, "t-1");
+        assert_eq!(werk.find_events(events).len(), 1);
+    }
+
+    #[test]
+    fn find_result_accepts_a_bare_task_id_and_skips_tasks_without_results() {
+        let (werk, _tmp) = test_werk();
+        werk.add_task("no result");
+        werk.add_task("has result");
+        werk.set_finished_by("t-1", "agent").unwrap();
+        attach_done_result(&werk, "t-2", "answer");
+
+        assert_eq!(werk.find_result("t-1"), None);
+        assert_eq!(werk.find_result("t-2"), Some(serde_json::json!("answer")));
+        assert_eq!(
+            werk.find_result("task.status = finished"),
+            Some(serde_json::json!("answer"))
         );
     }
 
@@ -1489,14 +1619,14 @@ mod tests {
     }
 
     #[test]
-    fn find_results_takes_a_label_in_place_of_a_query() {
+    fn find_results_selects_by_task_label() {
         let (werk, _tmp) = test_werk();
         werk.add_task(Task::labeled("scan", "a"));
         werk.add_task(Task::labeled("report", "b"));
         attach_done_result(&werk, "t-1", "scanned");
         attach_done_result(&werk, "t-2", "reported");
         assert_eq!(
-            werk.find_results("scan"),
+            werk.find_results("task.label = scan"),
             vec![serde_json::json!("scanned")]
         );
     }
@@ -1508,7 +1638,7 @@ mod tests {
         werk.add_task(Task::labeled("scan", "b"));
         attach_done_result(&werk, "t-1", "scanned");
         assert_eq!(
-            werk.find_results("scan"),
+            werk.find_results("task.label = scan"),
             vec![serde_json::json!("scanned")]
         );
     }
@@ -1517,10 +1647,12 @@ mod tests {
     fn find_results_keeps_the_status_the_query_names() {
         let (werk, _tmp) = test_werk();
         werk.add_task(Task::labeled("scan", "a"));
-        attach_done_result(&werk, "t-1", "scanned");
-        assert!(werk
-            .find_results("label = scan AND status = todo")
-            .is_empty());
+        werk.set_result("t-1", serde_json::json!("mid-flight"))
+            .unwrap();
+        assert_eq!(
+            werk.find_results("task.label = scan AND task.status = todo"),
+            vec![serde_json::json!("mid-flight")]
+        );
     }
 
     #[test]
@@ -1531,7 +1663,7 @@ mod tests {
         attach_done_result(&werk, "t-1", "scanned");
         attach_done_result(&werk, "t-2", "reported");
         assert_eq!(
-            werk.find_results("label = scan"),
+            werk.find_results(|task: &Task| task.label.as_deref() == Some("scan")),
             vec![serde_json::json!("scanned")]
         );
     }
@@ -1544,7 +1676,118 @@ mod tests {
         // leaves out because a closure names no status of its own.
         werk.set_result("t-1", serde_json::json!("mid-flight"))
             .unwrap();
-        assert!(werk.find_results("label = scan").is_empty());
+        assert!(werk
+            .find_results(|task: &Task| task.label.as_deref() == Some("scan"))
+            .is_empty());
+    }
+
+    #[test]
+    fn event_queries_project_ordered_unique_referenced_tasks() {
+        let (werk, tmp) = test_werk();
+        werk.add_task("first");
+        werk.add_task("second");
+        for (task_id, created_at) in [
+            ("t-2", 100),
+            ("", 150),
+            ("t-404", 175),
+            ("t-1", 200),
+            ("t-2", 300),
+        ] {
+            let event = Event {
+                created_at,
+                ..Event::new("selected").task_id(task_id)
+            };
+            Stats::append(tmp.path(), &event).unwrap();
+        }
+        let query = Query::new("event.name = selected ORDER BY event.created").unwrap();
+
+        let ids = werk
+            .find_tasks(query.clone())
+            .into_iter()
+            .map(|task| task.id)
+            .collect::<Vec<_>>();
+        assert_eq!(ids, ["t-2", "t-1"]);
+        assert_eq!(
+            werk.find_task("event.name = selected ORDER BY event.created")
+                .unwrap()
+                .id,
+            "t-2"
+        );
+    }
+
+    #[test]
+    fn task_queries_project_events_grouped_in_task_order() {
+        let (werk, tmp) = test_werk();
+        werk.add_task(Task::labeled("scan", "first"));
+        werk.add_task(Task::labeled("scan", "second"));
+        werk.add_task(Task::labeled("report", "third"));
+        Stats::append(tmp.path(), &Event::new("noted").task_id("t-2")).unwrap();
+        Stats::append(tmp.path(), &Event::new("noted").task_id("t-1")).unwrap();
+        let query = Query::new("task.label = scan ORDER BY task.id DESC").unwrap();
+
+        let events = werk.find_events(query.clone());
+        let identified = events
+            .iter()
+            .map(|event| (event.task_id.as_str(), event.name.as_str()))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            identified,
+            [
+                ("t-2", Event::TASK_CREATED),
+                ("t-2", "noted"),
+                ("t-1", Event::TASK_CREATED),
+                ("t-1", "noted"),
+            ]
+        );
+        assert_eq!(
+            werk.find_event("task.label = scan ORDER BY task.id DESC")
+                .unwrap()
+                .task_id,
+            "t-2"
+        );
+    }
+
+    #[test]
+    fn event_queries_project_finished_results_in_event_order() {
+        let (werk, tmp) = test_werk();
+        for task in ["first", "mid-flight", "empty", "fourth"] {
+            werk.add_task(task);
+        }
+        attach_done_result(&werk, "t-1", "first");
+        werk.set_result("t-2", serde_json::json!("mid-flight"))
+            .unwrap();
+        werk.set_finished_by("t-3", "agent").unwrap();
+        attach_done_result(&werk, "t-4", "fourth");
+        for (task_id, created_at) in [
+            ("t-4", 100),
+            ("t-3", 200),
+            ("t-2", 300),
+            ("t-1", 400),
+            ("t-4", 500),
+        ] {
+            let event = Event {
+                created_at,
+                ..Event::new("selected").task_id(task_id)
+            };
+            Stats::append(tmp.path(), &event).unwrap();
+        }
+        let query = Query::new("event.name = selected ORDER BY event.created").unwrap();
+
+        assert_eq!(
+            werk.find_results(query.clone()),
+            [serde_json::json!("fourth"), serde_json::json!("first")]
+        );
+        assert_eq!(
+            werk.find_result("event.name = selected ORDER BY event.created"),
+            Some(serde_json::json!("fourth"))
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "requires a task query")]
+    fn lifecycle_operations_still_reject_event_queries() {
+        let (werk, _tmp) = test_werk();
+        werk.cancel_tasks(Query::new("event.name = task_created").unwrap());
     }
 
     #[test]
@@ -1552,7 +1795,7 @@ mod tests {
         let (werk, _tmp) = test_werk();
         werk.add_task(Task::labeled("scan", "a"));
         werk.add_task(Task::labeled("report", "b"));
-        let found = werk.find_tasks("label = report AND status = todo");
+        let found = werk.find_tasks("task.label = report AND task.status = todo");
         assert_eq!(found.len(), 1);
         assert_eq!(found[0].task, serde_json::json!("b"));
     }
@@ -1568,15 +1811,16 @@ mod tests {
     fn pending_only_for_the_matching_tasks() {
         let (werk, _tmp) = test_werk();
         werk.add_task(Task::new("a").label("research"));
-        assert!(werk.pending(&Query::from("research")));
-        assert!(!werk.pending(&Query::from("report")));
+        assert!(werk.pending(&Query::from("task.label = research")));
+        assert!(!werk.pending(&Query::from("task.label = report")));
     }
 
     #[test]
     fn pending_while_a_claimed_task_awaits_the_model() {
         let (werk, _tmp) = test_werk();
         werk.add_task("x");
-        werk.claim(&Query::from("status = todo"), "agent").unwrap();
+        werk.claim(&Query::from("task.status = todo"), "agent")
+            .unwrap();
         assert!(werk.pending(&Query::all()));
     }
 
@@ -1584,7 +1828,9 @@ mod tests {
     fn pending_when_a_text_only_reply_pauses_a_non_interactive_agent() {
         let (werk, _tmp) = test_werk();
         werk.add_task("x");
-        let id = werk.claim(&Query::from("status = todo"), "agent").unwrap();
+        let id = werk
+            .claim(&Query::from("task.status = todo"), "agent")
+            .unwrap();
         werk.append_reply(
             &id,
             Reply::assistant(&[crate::providers::ContentBlock::Text {
@@ -1611,7 +1857,7 @@ mod tests {
     fn not_pending_on_a_cancelled_task() {
         let (werk, _tmp) = test_werk();
         werk.add_task(Task::new("a").label("research"));
-        werk.cancel_tasks("label = research");
+        werk.cancel_tasks("task.label = research");
         assert!(!werk.pending(&Query::all()));
     }
 
@@ -1699,17 +1945,17 @@ mod tests {
     }
 
     #[test]
-    fn find_events_takes_the_same_syntax_a_task_query_is_written_in() {
+    fn find_events_accepts_namespaced_event_fields() {
         let (werk, _tmp) = test_werk();
         werk.add_task(Task::new("scan").label("scout"));
         werk.add_task("b");
         werk.claim(&Query::from("t-1"), "scout-1");
 
-        assert_eq!(werk.find_events("task_created").len(), 2);
-        assert_eq!(werk.find_events("t-1").len(), 2);
-        assert_eq!(werk.find_events("event = task_started").len(), 1);
-        assert_eq!(werk.find_events("agent = scout-1").len(), 1);
-        assert!(werk.find_events("run_finished").is_empty());
+        assert_eq!(werk.find_events("event.name = task_created").len(), 2);
+        assert_eq!(werk.find_events("event.task_id = t-1").len(), 2);
+        assert_eq!(werk.find_events("event.name = task_started").len(), 1);
+        assert_eq!(werk.find_events("event.agent_id = scout-1").len(), 1);
+        assert!(werk.find_events("event.name = run_finished").is_empty());
     }
 
     #[test]
@@ -1776,7 +2022,9 @@ mod tests {
         drop(werk);
 
         let resumed = Werk::load(dir.path()).unwrap();
-        let found = resumed.find_event(r#"event = "Document Indexed""#).unwrap();
+        let found = resumed
+            .find_event(r#"event.name = "Document Indexed""#)
+            .unwrap();
         assert_eq!(found.get_name(), "Document Indexed");
         assert_eq!(found.get_data(), &serde_json::json!({ "documents": 42 }));
     }
@@ -1832,7 +2080,7 @@ mod tests {
         werk.emit_event(Event::new(Event::TASK_FINISHED).task_id(&id));
 
         assert_eq!(werk.get_task(&id).unwrap().status, Status::Todo);
-        assert_eq!(werk.find_events("event = task_finished").len(), 1);
+        assert_eq!(werk.find_events("event.name = task_finished").len(), 1);
         assert_eq!(task_calls.load(Ordering::Relaxed), 2);
     }
 
@@ -1847,9 +2095,9 @@ mod tests {
             Stats::append(tmp.path(), &event).unwrap();
         }
 
-        let newest = werk.find_event("task_created ORDER BY created DESC");
+        let newest = werk.find_event("event.name = task_created ORDER BY event.created DESC");
         assert_eq!(newest.unwrap().task_id, "t-2");
-        let oldest = werk.find_event("task_created");
+        let oldest = werk.find_event("event.name = task_created");
         assert_eq!(oldest.unwrap().task_id, "t-1");
     }
 
@@ -1859,7 +2107,7 @@ mod tests {
         // crate keeping one.
         let (werk, _tmp) = test_werk();
         werk.add_task(Task::new("scan").label("scout"));
-        werk.claim(&Query::from("scout"), "scout-1");
+        werk.claim(&Query::from("task.label = scout"), "scout-1");
 
         assert_eq!(
             werk.find_events(|e: &Event| e.label.as_deref() == Some("scout"))
@@ -1928,7 +2176,7 @@ mod tests {
         assert_eq!(werk.stats.event_count(Event::REQUEST_FINISHED), 1);
         assert_eq!(werk.get_input_tokens(), 0);
         assert_eq!(werk.get_output_tokens(), 0);
-        assert_eq!(werk.find_events("event = request_finished").len(), 1);
+        assert_eq!(werk.find_events("event.name = request_finished").len(), 1);
     }
 
     #[test]
@@ -1943,9 +2191,9 @@ mod tests {
         let research = werk.add_task(Task::new("x").label("research"));
         werk.add_task(Task::new("x").label("analysis"));
         werk.add_task(Task::new("x"));
-        werk.cancel_tasks("label = research");
+        werk.cancel_tasks("task.label = research");
 
-        let cancelled = werk.find_tasks("cancelled = true");
+        let cancelled = werk.find_tasks("task.cancelled = true");
         assert_eq!(cancelled.len(), 1);
         assert_eq!(cancelled[0].id, research);
     }
@@ -1953,29 +2201,29 @@ mod tests {
     #[test]
     fn cancel_applies_to_matching_tasks_inserted_later() {
         let (werk, _tmp) = test_werk();
-        werk.cancel_tasks("label = research");
+        werk.cancel_tasks("task.label = research");
         let research = werk.add_task(Task::new("x").label("research"));
         werk.add_task(Task::new("x").label("analysis"));
 
         assert_eq!(
-            werk.find_task("cancelled = true").map(|task| task.id),
+            werk.find_task("task.cancelled = true").map(|task| task.id),
             Some(research),
         );
-        assert_eq!(werk.find_tasks("cancelled = false").len(), 1);
+        assert_eq!(werk.find_tasks("task.cancelled = false").len(), 1);
     }
 
     #[tokio::test]
     async fn start_clears_cancellation_flags_and_filters() {
         let (werk, _tmp) = test_werk();
         werk.add_task(Task::new("first").label("research"));
-        werk.cancel_tasks("label = research");
-        assert_eq!(werk.find_tasks("cancelled = true").len(), 1);
+        werk.cancel_tasks("task.label = research");
+        assert_eq!(werk.find_tasks("task.cancelled = true").len(), 1);
 
         werk.start();
         werk.add_task(Task::new("second").label("research"));
 
-        assert!(werk.find_tasks("cancelled = true").is_empty());
-        assert_eq!(werk.find_tasks("pending = true").len(), 2);
+        assert!(werk.find_tasks("task.cancelled = true").is_empty());
+        assert_eq!(werk.find_tasks("task.pending = true").len(), 2);
         werk.cancel_all_tasks();
         werk.finish_all_tasks().await;
     }
@@ -1985,15 +2233,15 @@ mod tests {
         let (werk, _tmp) = test_werk();
         werk.add_task(Task::new("work").label("research"));
         werk.start();
-        werk.cancel_tasks("pending = true AND label = research");
+        werk.cancel_tasks("task.pending = true AND task.label = research");
         werk.finish_all_tasks().await;
 
-        assert_eq!(werk.find_events("event = run_started").len(), 1);
-        werk.finish_tasks("label = research").await;
-        assert_eq!(werk.find_events("event = run_started").len(), 1);
+        assert_eq!(werk.find_events("event.name = run_started").len(), 1);
+        werk.finish_tasks("task.label = research").await;
+        assert_eq!(werk.find_events("event.name = run_started").len(), 1);
 
         werk.start();
-        assert_eq!(werk.find_events("event = run_started").len(), 2);
+        assert_eq!(werk.find_events("event.name = run_started").len(), 2);
         werk.cancel_all_tasks();
         werk.finish_all_tasks().await;
     }
@@ -2034,7 +2282,9 @@ mod tests {
             }
         });
         werk.add_task(Task::new("a").label("scan"));
-        let id = werk.claim(&Query::from("scan"), "scout").unwrap();
+        let id = werk
+            .claim(&Query::from("task.label = scan"), "scout")
+            .unwrap();
         werk.set_result(&id, serde_json::json!("done")).unwrap();
         werk.set_finished_by(&id, "scout").unwrap();
 
@@ -2107,7 +2357,7 @@ mod tests {
                 .push((task.id.clone(), result.clone()))
         });
         werk.add_task(Task::new("x").label("L"));
-        let id = werk.claim(&Query::from("L"), "agent").unwrap();
+        let id = werk.claim(&Query::from("task.label = L"), "agent").unwrap();
 
         attach_done_result(&werk, &id, "lead");
 
@@ -2255,7 +2505,7 @@ mod tests {
 
         werk.set_task_failed(&id).unwrap();
 
-        let retry = werk.find_task(format!("parent = {id}")).unwrap();
+        let retry = werk.find_task(format!("task.parent_id = {id}")).unwrap();
         assert_eq!(retry.task, serde_json::json!("work"));
     }
 
@@ -2271,21 +2521,23 @@ mod tests {
 
         emit_event(&werk, &id, "agent", Event::new(Event::TURN_STARTED));
 
-        assert_eq!(werk.find_tasks("label = report").len(), 1);
+        assert_eq!(werk.find_tasks("task.label = report").len(), 1);
     }
 
     #[test]
     fn on_result_links_a_follow_up_to_the_finished_parent() {
         let (werk, _tmp) = test_werk();
         werk.add_task(Task::new("scout").label("scout"));
-        let id = werk.claim(&Query::from("scout"), "agent").unwrap();
+        let id = werk
+            .claim(&Query::from("task.label = scout"), "agent")
+            .unwrap();
         werk.set_result(&id, serde_json::json!("lead")).unwrap();
         werk.set_finished_by(&id, "agent").unwrap();
         werk.on_result(|werk, done, _| {
             werk.add_task(Task::new("hunt").label("sniper").parent(&done.id));
         });
         emit_event(&werk, &id, "agent", Event::new(Event::TASK_FINISHED));
-        let spawned = werk.find_task("label = sniper").unwrap();
+        let spawned = werk.find_task("task.label = sniper").unwrap();
         assert_eq!(spawned.parent, Some(id));
     }
 
@@ -2306,7 +2558,10 @@ mod tests {
         let counts = Arc::new(Mutex::new(Vec::new()));
         let record = Arc::clone(&counts);
         werk.on_result(move |werk, _, _| {
-            record.lock().unwrap().push(werk.find_results("scan").len());
+            record
+                .lock()
+                .unwrap()
+                .push(werk.find_results("task.label = scan").len());
         });
         for id in scans(&werk, 2) {
             werk.set_task_finished(&id, "clean").unwrap();
@@ -2549,7 +2804,7 @@ mod tests {
 
         werk.finish_all_tasks().await;
 
-        let spawned = werk.find_task("label = sniper").unwrap();
+        let spawned = werk.find_task("task.label = sniper").unwrap();
         assert_eq!(spawned.parent, Some(id));
     }
 
@@ -2592,17 +2847,17 @@ mod tests {
     fn a_hook_waits_for_the_results_it_needs_before_filing_the_next_step() {
         let (werk, _tmp) = test_werk();
         werk.on_result(|werk, _, _| {
-            if werk.find_results("scan").len() == 2 {
+            if werk.find_results("task.label = scan").len() == 2 {
                 werk.add_task(Task::new("write the report").label("report"));
             }
         });
         let scans = scans(&werk, 2);
 
         werk.set_task_finished(&scans[0], "clean").unwrap();
-        assert!(werk.find_tasks("label = report").is_empty());
+        assert!(werk.find_tasks("task.label = report").is_empty());
 
         werk.set_task_finished(&scans[1], "clean").unwrap();
-        assert_eq!(werk.find_tasks("label = report").len(), 1);
+        assert_eq!(werk.find_tasks("task.label = report").len(), 1);
     }
 
     #[test]
@@ -2614,7 +2869,9 @@ mod tests {
             }
         });
         werk.add_task(Task::new("scout").label("scout"));
-        let id = werk.claim(&Query::from("scout"), "agent").unwrap();
+        let id = werk
+            .claim(&Query::from("task.label = scout"), "agent")
+            .unwrap();
         werk.set_result(&id, serde_json::json!("lead")).unwrap();
         werk.set_finished_by(&id, "agent").unwrap();
         // The handler ran inside `set_finished_by`, so the Werk is never
@@ -2638,7 +2895,9 @@ mod tests {
             }
         });
         werk.add_task(Task::new("scan").label("scan"));
-        let id = werk.claim(&Query::from("scan"), "analyst").unwrap();
+        let id = werk
+            .claim(&Query::from("task.label = scan"), "analyst")
+            .unwrap();
         werk.append_reply(&id, Reply::user_text("hello"));
         werk.set_result(&id, serde_json::json!("done")).unwrap();
         werk.set_finished_by(&id, "analyst").unwrap();
@@ -2662,7 +2921,9 @@ mod tests {
         let seen = Arc::new(Mutex::new(Vec::new()));
         let record = Arc::clone(&seen);
         werk.add_task(Task::new("scan").label("scan"));
-        let id = werk.claim(&Query::from("scan"), "analyst").unwrap();
+        let id = werk
+            .claim(&Query::from("task.label = scan"), "analyst")
+            .unwrap();
         // Installed after the claim, so only the turn is in the handler's view.
         werk.on_task(move |_, _, task| record.lock().unwrap().push(task.id.clone()));
         emit_event(&werk, &id, "analyst", Event::new(Event::TURN_STARTED));
@@ -2690,7 +2951,9 @@ mod tests {
         werk.on_task(move |_, _, task| record.lock().unwrap().push(task.id.clone()));
         werk.add_task(Task::new("scan").label("scan"));
         // The claim is the lifecycle event; no second publication is needed.
-        let id = werk.claim(&Query::from("scan"), "analyst").unwrap();
+        let id = werk
+            .claim(&Query::from("task.label = scan"), "analyst")
+            .unwrap();
 
         assert_eq!(*seen.lock().unwrap(), vec![id]);
         assert!(logged.lock().unwrap().contains(&"task_started".to_string()));
@@ -2758,7 +3021,7 @@ mod tests {
         attach_done_result(&werk, "t-2", "reported");
 
         assert_eq!(
-            werk.finish_tasks("label = scan").await,
+            werk.finish_tasks("task.label = scan").await,
             vec![serde_json::json!("scanned")]
         );
     }
@@ -2787,7 +3050,7 @@ mod tests {
         attach_done_result(&werk, "t-1", "scanned");
 
         assert_eq!(
-            werk.finish_task("ORDER BY id DESC").await,
+            werk.finish_task("ORDER BY task.id DESC").await,
             Some(serde_json::json!("reported"))
         );
     }
@@ -2796,7 +3059,7 @@ mod tests {
     async fn finish_task_is_none_when_nothing_finished() {
         let (werk, _tmp) = test_werk();
 
-        assert_eq!(werk.finish_task("status = finished").await, None);
+        assert_eq!(werk.finish_task("task.status = finished").await, None);
     }
 
     #[tokio::test]

--- a/crates/agentwerk/src/agents/tasks/werk.rs
+++ b/crates/agentwerk/src/agents/tasks/werk.rs
@@ -14,7 +14,7 @@ use tokio::task::JoinHandle;
 
 use super::super::agent::Agent;
 use super::super::policy::Policy;
-use super::super::query::{Matcher, Query};
+use super::super::query::{Matcher, Origin, Query};
 use super::super::r#loop::run_main_loop;
 use super::super::stats::Stats;
 use super::task::{Status, Task};
@@ -57,6 +57,20 @@ type EventHandler = dyn Fn(&Arc<Werk>, &Event) + Send + Sync;
 /// missing them. `TextChunkReceived` fires once per streaming delta and sets
 /// the volume this has to absorb.
 const EVENT_STREAM_CAPACITY: usize = 1024;
+
+pub(crate) enum CancelFilter {
+    Live(Query),
+    Snapshot(HashSet<String>),
+}
+
+impl CancelFilter {
+    pub(super) fn matches(&self, task: &Task) -> bool {
+        match self {
+            Self::Live(query) => query.matches_task(task),
+            Self::Snapshot(ids) => ids.contains(&task.id),
+        }
+    }
+}
 
 /// One shape for every awaited hook: the task is `None` for the kinds no
 /// task-shaped hook accepts, and the wrapper each `on_*_async` installs picks
@@ -277,7 +291,7 @@ pub struct Werk {
     /// What `cancel` has taken off the Werk. A matching task is neither
     /// claimed nor resumed, and an agent already holding one is taken off it,
     /// while the rest of the run continues.
-    pub(crate) cancel_filters: Mutex<Vec<Query>>,
+    pub(crate) cancel_filters: Mutex<Vec<CancelFilter>>,
     /// How many terminal status transitions are between their status change and
     /// the return of their event handlers. `pending` counts a non-zero value as
     /// pending work, so a handler creating a follow-up task always beats the drain.
@@ -879,8 +893,8 @@ impl Werk {
         self.matching_tasks(&Query::all().task())
     }
 
-    /// Get every task selected by a task query or referenced by an event query.
-    /// The query's source order determines the returned order.
+    /// Get every task selected directly, through matching events, or through
+    /// joined task-event rows. The query's source order determines the result.
     ///
     /// Your condition MUST NOT call another `Werk` method that reads
     /// the task store, or the call deadlocks.
@@ -889,23 +903,30 @@ impl Werk {
         self.tasks_selected_by(&query)
     }
 
-    /// Get the first task selected by a task query or referenced by an event
-    /// query.
+    /// Get the first task selected directly, through a matching event, or
+    /// through a joined task-event row.
     ///
     /// Your condition MUST NOT call another `Werk` method that reads
     /// the task store, or the call deadlocks.
     pub fn find_task(&self, predicate: impl Matcher<Task>) -> Option<Task> {
         let query = predicate.into_query().task_if_originless();
-        match query.is_event() {
-            true => self.tasks_referenced_by(&query).into_iter().next(),
-            false => self.first_matching_task(&query),
+        match query.origin() {
+            Origin::Task => self.first_matching_task(&query),
+            Origin::Event | Origin::Joined => self.tasks_selected_by(&query).into_iter().next(),
         }
     }
 
-    fn tasks_selected_by(&self, query: &Query) -> Vec<Task> {
-        match query.is_event() {
-            true => self.tasks_referenced_by(query),
-            false => self.matching_tasks(query),
+    pub(super) fn tasks_selected_by(&self, query: &Query) -> Vec<Task> {
+        match query.origin() {
+            Origin::Task => self.matching_tasks(query),
+            Origin::Event => self.tasks_referenced_by(query),
+            Origin::Joined => {
+                let mut seen = HashSet::new();
+                self.matching_task_events(query)
+                    .into_iter()
+                    .filter_map(|(task, _)| seen.insert(task.id.clone()).then_some(task))
+                    .collect()
+            }
         }
     }
 
@@ -943,8 +964,26 @@ impl Werk {
             .collect()
     }
 
-    /// Get every event selected by an event query or attached to tasks selected
-    /// by a task query, in source-query order.
+    fn matching_task_events(&self, query: &Query) -> Vec<(Task, Event)> {
+        let mut events = Vec::new();
+        let _ = Stats::for_each_event(&self.get_dir(), |event| events.push(event.clone()));
+        let store = self.tasks.lock().unwrap();
+        let mut pairs: Vec<(Task, Event)> = events
+            .into_iter()
+            .filter_map(|event| {
+                let task = store.get(&event.task_id)?;
+                query
+                    .matches_joined(task, &event)
+                    .then(|| (task.clone(), event))
+            })
+            .collect();
+        drop(store);
+        query.sort_joined(&mut pairs);
+        pairs
+    }
+
+    /// Get every event selected directly, attached to matching tasks, or from
+    /// matching joined task-event rows, in source-query order.
     ///
     /// The condition is an AQL string, a [`Query`](crate::Query), or a
     /// closure, the way [`Self::find_tasks`] takes any of the three.
@@ -962,18 +1001,15 @@ impl Werk {
     /// naming it never matches.
     pub fn find_events(&self, matcher: impl Matcher<Event>) -> Vec<Event> {
         let query = matcher.into_query().event_if_originless();
-        match query.is_event() {
-            true => self.matching_events(&query),
-            false => self.events_referencing_tasks(&query),
-        }
+        self.events_selected_by(&query)
     }
 
-    /// Get the first event selected by an event query or attached to a task
-    /// selected by a task query.
+    /// Get the first event selected directly, through a matching task, or from
+    /// a matching joined task-event row.
     pub fn find_event(&self, matcher: impl Matcher<Event>) -> Option<Event> {
         let query = matcher.into_query().event_if_originless();
-        if !query.is_event() {
-            return self.events_referencing_tasks(&query).into_iter().next();
+        if query.origin() != Origin::Event {
+            return self.events_selected_by(&query).into_iter().next();
         }
         // Without an order the log's own is the answer, so one match ends the
         // read instead of the whole log being copied to be sorted.
@@ -984,6 +1020,18 @@ impl Werk {
         let mut found = self.collect_events(&query, wanted);
         query.sort_events(&mut found);
         found.into_iter().next()
+    }
+
+    fn events_selected_by(&self, query: &Query) -> Vec<Event> {
+        match query.origin() {
+            Origin::Task => self.events_referencing_tasks(query),
+            Origin::Event => self.matching_events(query),
+            Origin::Joined => self
+                .matching_task_events(query)
+                .into_iter()
+                .map(|(_, event)| event)
+                .collect(),
+        }
     }
 
     fn matching_events(&self, query: &Query) -> Vec<Event> {
@@ -1025,6 +1073,8 @@ impl Werk {
     /// is taken off it; the task stays `in_progress`. Nothing waits: this is
     /// not async, so it can be called from a ctrl-c handler, a drop guard, or
     /// anywhere else. Use [`Self::cancel_all_tasks`] to stop the whole run.
+    /// Task-only queries remain live for tasks added later. Event and joined
+    /// queries snapshot the task IDs they currently select.
     ///
     /// Your filter MUST NOT call another `Werk` method that reads the
     /// task store, or the claim path deadlocks.
@@ -1032,14 +1082,37 @@ impl Werk {
     /// ```no_run
     /// # use agentwerk::Werk;
     /// let werk = Werk::new();
-    /// werk.cancel_tasks("task.label = scan");
+    /// werk.cancel_tasks("scan");
     /// ```
     pub fn cancel_tasks(&self, matches: impl Matcher<Task>) -> &Self {
-        let query = matches.into_query().task();
-        self.cancel_filters.lock().unwrap().push(query.clone());
-        for task in self.tasks.lock().unwrap().values_mut() {
-            if query.matches_task(task) {
-                task.cancelled = true;
+        let query = matches.into_query().task_if_originless();
+        match query.origin() {
+            Origin::Task => {
+                self.cancel_filters
+                    .lock()
+                    .unwrap()
+                    .push(CancelFilter::Live(query.clone()));
+                for task in self.tasks.lock().unwrap().values_mut() {
+                    if query.matches_task(task) {
+                        task.cancelled = true;
+                    }
+                }
+            }
+            Origin::Event | Origin::Joined => {
+                let ids: HashSet<String> = self
+                    .tasks_selected_by(&query)
+                    .into_iter()
+                    .map(|task| task.id)
+                    .collect();
+                for task in self.tasks.lock().unwrap().values_mut() {
+                    if ids.contains(&task.id) {
+                        task.cancelled = true;
+                    }
+                }
+                self.cancel_filters
+                    .lock()
+                    .unwrap()
+                    .push(CancelFilter::Snapshot(ids));
             }
         }
         self
@@ -1060,21 +1133,53 @@ impl Werk {
     /// subset. A task is pending while it is todo or in progress,
     /// uncancelled, and not paused for a caller reply.
     pub(crate) fn pending(&self, matches: &Query) -> bool {
-        // A terminal transition mid-flight may still add a follow-up task
-        // from a handler, so it counts as work whatever the store says.
+        match matches.origin() {
+            Origin::Task => {
+                // A terminal transition mid-flight may still add a follow-up task
+                // from a handler, so it counts as work whatever the store says.
+                if self.terminal_transitions_in_flight.load(Ordering::SeqCst) > 0 {
+                    return true;
+                }
+                let interactive = self.interactive_agents();
+                let tasks = self.tasks.lock().unwrap();
+                tasks.values().any(|task| {
+                    matches.matches_task(task) && Self::task_is_pending(task, &interactive)
+                })
+            }
+            Origin::Event | Origin::Joined => {
+                let ids: Vec<String> = self
+                    .tasks_selected_by(matches)
+                    .into_iter()
+                    .map(|task| task.id)
+                    .collect();
+                self.pending_ids(&ids)
+            }
+        }
+    }
+
+    fn pending_ids(&self, ids: &[String]) -> bool {
+        if ids.is_empty() {
+            return false;
+        }
         if self.terminal_transitions_in_flight.load(Ordering::SeqCst) > 0 {
             return true;
         }
         let interactive = self.interactive_agents();
         let tasks = self.tasks.lock().unwrap();
-        tasks.values().any(|t| {
-            matches.matches_task(t)
-                && t.is_pending()
-                && !(t.is_paused()
-                    && t.assignee
-                        .as_deref()
-                        .is_some_and(|a| interactive.contains(a)))
+        ids.iter().any(|id| {
+            tasks
+                .get(id)
+                .is_some_and(|task| Self::task_is_pending(task, &interactive))
         })
+    }
+
+    fn task_is_pending(task: &Task, interactive: &HashSet<String>) -> bool {
+        task.is_pending()
+            && !(task.is_paused()
+                && task
+                    .assignee
+                    .as_deref()
+                    .is_some_and(|agent| interactive.contains(agent)))
     }
 
     /// Why the run is over, or `None` while it should keep going.
@@ -1211,7 +1316,7 @@ impl Werk {
     /// Wait for the matching tasks to be done, then get their results in
     /// query order, or creation order when the query names none.
     ///
-    /// Name a label to wait for one pool, or an ID to wait for one task;
+    /// Name task state, recorded events, or both to select what to wait for;
     /// [`Self::finish_all_tasks`] waits for the whole run. The wait ends once no
     /// matching task has work left for an agent, which covers one that
     /// finished, failed, was cancelled, or is paused awaiting your reply.
@@ -1231,20 +1336,35 @@ impl Werk {
     /// # use agentwerk::Werk;
     /// # async fn run() {
     /// let werk = Werk::new();
-    /// for finding in werk.finish_tasks("task.label = research").await {
+    /// for finding in werk.finish_tasks("research").await {
     ///     println!("{finding}");
     /// }
     /// # }
     /// ```
     pub async fn finish_tasks(&self, matches: impl Matcher<Task>) -> Vec<serde_json::Value> {
-        let query = matches.into_query().task();
+        let query = matches.into_query().task_if_originless();
+        let snapshot = match query.origin() {
+            Origin::Task => None,
+            Origin::Event | Origin::Joined => Some(
+                self.tasks_selected_by(&query)
+                    .into_iter()
+                    .map(|task| task.id)
+                    .collect::<Vec<_>>(),
+            ),
+        };
+        if snapshot.as_ref().is_some_and(Vec::is_empty) {
+            return Vec::new();
+        }
         if self.join_handle.lock().unwrap().is_none()
             && (!self.run.is_finished() || self.anything_claimable())
         {
             self.start();
         }
         let mut stream = self.event_stream.subscribe();
-        while self.pending(&query) {
+        while snapshot
+            .as_ref()
+            .map_or_else(|| self.pending(&query), |ids| self.pending_ids(ids))
+        {
             let ended = self.next_event_or_end(&mut stream).await;
             self.await_handlers().await;
             if ended {
@@ -1264,12 +1384,24 @@ impl Werk {
         if self.run.is_finished() {
             self.join_handle.lock().unwrap().take();
         }
-        // `and_status`, not the `find_results` default: a caller who waited on
-        // `task.status = todo` receives finished results, not the matching unfinished tasks.
-        self.matching_tasks(&query.and_task_status(Status::Finished))
-            .into_iter()
-            .filter_map(|t| t.result)
-            .collect()
+        match snapshot {
+            Some(ids) => {
+                let tasks = self.tasks.lock().unwrap();
+                ids.into_iter()
+                    .filter_map(|id| tasks.get(&id))
+                    .filter(|task| task.status == Status::Finished)
+                    .filter_map(|task| task.result.clone())
+                    .collect()
+            }
+            None => {
+                // `and_status`, not the `find_results` default: a caller who waited on
+                // `task.status = todo` receives finished results, not the matching unfinished tasks.
+                self.matching_tasks(&query.and_task_status(Status::Finished))
+                    .into_iter()
+                    .filter_map(|task| task.result)
+                    .collect()
+            }
+        }
     }
 
     /// Wait for every task to be done, then get every result in creation
@@ -1341,17 +1473,17 @@ impl Werk {
         self.find_results(Query::all().task())
     }
 
-    /// Get every result whose task is selected directly or through a matching
-    /// event, in source-query order.
+    /// Get every result whose task is selected directly, through a matching
+    /// event, or through a joined task-event row, in source-query order.
     ///
-    /// A task query defaults status to `finished` when it names none. Event
-    /// queries always project only finished tasks. A task contributes a result
-    /// only when it has one, so this is shorter than the set the filter named.
+    /// Status defaults to `finished` when the query names none. A task
+    /// contributes a result only when it has one, so this is shorter than the
+    /// set the filter named.
     ///
     /// ```no_run
     /// # use agentwerk::Werk;
     /// let werk = Werk::new();
-    /// let scans = werk.find_results("task.label = scan");
+    /// let scans = werk.find_results("scan");
     /// ```
     pub fn find_results(&self, matches: impl Matcher<Task>) -> Vec<serde_json::Value> {
         self.result_tasks(matches)
@@ -1372,19 +1504,12 @@ impl Werk {
     }
 
     fn result_tasks(&self, matches: impl Matcher<Task>) -> Vec<Task> {
-        let query = matches.into_query().task_if_originless();
-        if query.is_event() {
-            return self
-                .tasks_referenced_by(&query)
-                .into_iter()
-                .filter(|task| task.status == Status::Finished && task.result.is_some())
-                .collect();
-        }
-        self.matching_tasks(
-            &query
-                .default_task_status(Status::Finished)
-                .and_task_result(),
-        )
+        let query = matches
+            .into_query()
+            .task_if_originless()
+            .default_task_status(Status::Finished)
+            .and_task_result();
+        self.tasks_selected_by(&query)
     }
 }
 
@@ -1539,14 +1664,19 @@ mod tests {
     }
 
     #[test]
-    fn compiled_queries_work_with_singular_and_plural_finders() {
+    fn compiled_label_shorthand_works_with_all_finders() {
         let (werk, _tmp) = test_werk();
         werk.add_task(Task::labeled("scan", "a"));
         attach_done_result(&werk, "t-1", "clean");
 
-        let tasks = Query::new("task.label = scan").unwrap();
+        let tasks = Query::new("scan").unwrap();
         assert_eq!(werk.find_task(tasks.clone()).unwrap().id, "t-1");
         assert_eq!(werk.find_tasks(tasks.clone()).len(), 1);
+        assert_eq!(werk.find_event(tasks.clone()).unwrap().task_id, "t-1");
+        assert!(werk
+            .find_events(tasks.clone())
+            .iter()
+            .all(|event| event.task_id == "t-1"));
         assert_eq!(
             werk.find_result(tasks.clone()),
             Some(serde_json::json!("clean"))
@@ -1784,10 +1914,184 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "requires a task query")]
-    fn lifecycle_operations_still_reject_event_queries() {
+    fn event_cancellation_snapshots_current_task_references() {
         let (werk, _tmp) = test_werk();
+        werk.add_task("already present");
         werk.cancel_tasks(Query::new("event.name = task_created").unwrap());
+        werk.add_task("added after the snapshot");
+
+        assert!(werk.get_task("t-1").unwrap().cancelled);
+        assert!(!werk.get_task("t-2").unwrap().cancelled);
+    }
+
+    #[test]
+    fn joined_lifecycle_queries_select_current_tasks() {
+        let (werk, _tmp) = test_werk();
+        werk.add_task(Task::labeled("scan", "first"));
+        werk.add_task(Task::labeled("report", "second"));
+        let joined = Query::new("scan AND event.name = task_created").unwrap();
+
+        assert!(werk.pending(&joined));
+        assert_eq!(werk.claim(&joined, "agent"), Some("t-1".into()));
+        werk.cancel_tasks(joined);
+        assert!(werk.get_task("t-1").unwrap().cancelled);
+        assert!(!werk.get_task("t-2").unwrap().cancelled);
+    }
+
+    #[tokio::test]
+    async fn event_finish_uses_a_snapshot_that_future_events_do_not_expand() {
+        let (werk, tmp) = test_werk();
+        let results = werk.finish_tasks("event.name = selected").await;
+        werk.add_task("later");
+        attach_done_result(&werk, "t-1", "late");
+        Stats::append(tmp.path(), &Event::new("selected").task_id("t-1")).unwrap();
+
+        assert!(results.is_empty());
+    }
+
+    #[tokio::test]
+    async fn joined_finish_returns_results_in_join_order() {
+        let (werk, tmp) = test_werk();
+        werk.add_task(Task::labeled("scan", "first"));
+        werk.add_task(Task::labeled("scan", "second"));
+        attach_done_result(&werk, "t-1", "one");
+        attach_done_result(&werk, "t-2", "two");
+        Stats::append(
+            tmp.path(),
+            &Event {
+                created_at: 200,
+                ..Event::new("selected").task_id("t-2")
+            },
+        )
+        .unwrap();
+        Stats::append(
+            tmp.path(),
+            &Event {
+                created_at: 100,
+                ..Event::new("selected").task_id("t-1")
+            },
+        )
+        .unwrap();
+
+        let results = werk
+            .finish_tasks("task.label = scan AND event.name = selected ORDER BY event.created DESC")
+            .await;
+        assert_eq!(
+            results,
+            [serde_json::json!("two"), serde_json::json!("one")]
+        );
+    }
+
+    #[test]
+    fn mixed_queries_project_joined_rows_through_all_read_finders() {
+        let (werk, tmp) = test_werk();
+        werk.add_task(Task::labeled("scan", "first"));
+        werk.add_task(Task::labeled("scan", "second"));
+        werk.add_task(Task::labeled("report", "third"));
+        attach_done_result(&werk, "t-1", "one");
+        attach_done_result(&werk, "t-2", "two");
+        attach_done_result(&werk, "t-3", "three");
+        for (task_id, created_at) in [("t-1", 100), ("t-2", 200), ("t-1", 300)] {
+            Stats::append(
+                tmp.path(),
+                &Event {
+                    created_at,
+                    ..Event::new("selected").task_id(task_id)
+                },
+            )
+            .unwrap();
+        }
+        let query =
+            Query::new("scan AND event.name = selected ORDER BY event.created DESC").unwrap();
+
+        assert_eq!(
+            werk.find_tasks(query.clone())
+                .into_iter()
+                .map(|task| task.id)
+                .collect::<Vec<_>>(),
+            ["t-1", "t-2"]
+        );
+        assert_eq!(werk.find_task(query.clone()).unwrap().id, "t-1");
+        assert_eq!(
+            werk.find_events(query.clone())
+                .into_iter()
+                .map(|event| event.task_id)
+                .collect::<Vec<_>>(),
+            ["t-1", "t-2", "t-1"]
+        );
+        assert_eq!(werk.find_event(query.clone()).unwrap().task_id, "t-1");
+        assert_eq!(
+            werk.find_results(query.clone()),
+            [serde_json::json!("one"), serde_json::json!("two")]
+        );
+        assert_eq!(werk.find_result(query), Some(serde_json::json!("one")));
+    }
+
+    #[test]
+    fn mixed_queries_use_pair_level_boolean_and_inner_join_semantics() {
+        let (werk, tmp) = test_werk();
+        werk.add_task(Task::labeled("scan", "first"));
+        werk.add_task(Task::labeled("report", "second"));
+        for event in [
+            Event::new("ordinary").task_id("t-1"),
+            Event::new("selected").task_id("t-2"),
+            Event::new("selected"),
+            Event::new("selected").task_id("t-404"),
+        ] {
+            Stats::append(tmp.path(), &event).unwrap();
+        }
+
+        let events = werk.find_events("task.label = scan OR event.name = selected");
+        assert!(events.iter().any(|event| event.name == "ordinary"));
+        assert!(events
+            .iter()
+            .any(|event| event.name == "selected" && event.task_id == "t-2"));
+        assert!(events.iter().all(|event| !event.task_id.is_empty()));
+        assert!(events.iter().all(|event| event.task_id != "t-404"));
+
+        assert!(werk
+            .find_events("task.label = scan AND NOT event.name = ordinary")
+            .iter()
+            .all(|event| event.task_id == "t-1" && event.name != "ordinary"));
+    }
+
+    #[test]
+    fn joined_ordering_can_use_task_fields_and_keeps_each_tasks_log_order() {
+        let (werk, tmp) = test_werk();
+        werk.add_task("first");
+        werk.add_task("second");
+        for (name, task_id) in [
+            ("second-a", "t-2"),
+            ("first-a", "t-1"),
+            ("second-b", "t-2"),
+            ("first-b", "t-1"),
+        ] {
+            Stats::append(tmp.path(), &Event::new(name).task_id(task_id)).unwrap();
+        }
+
+        let names = werk
+            .find_events(
+                "task.id IN (t-1, t-2) AND event.name IN (second-a, first-a, second-b, first-b) ORDER BY task.id",
+            )
+            .into_iter()
+            .map(|event| event.name)
+            .collect::<Vec<_>>();
+        assert_eq!(names, ["first-a", "first-b", "second-a", "second-b"]);
+    }
+
+    #[test]
+    fn joined_result_queries_honor_an_explicit_unfinished_status() {
+        let (werk, _tmp) = test_werk();
+        werk.add_task(Task::labeled("scan", "work"));
+        werk.set_result("t-1", serde_json::json!("mid-flight"))
+            .unwrap();
+
+        assert_eq!(
+            werk.find_results(
+                "task.status = todo AND event.name = task_created ORDER BY event.created"
+            ),
+            [serde_json::json!("mid-flight")]
+        );
     }
 
     #[test]
@@ -1798,6 +2102,23 @@ mod tests {
         let found = werk.find_tasks("task.label = report AND task.status = todo");
         assert_eq!(found.len(), 1);
         assert_eq!(found[0].task, serde_json::json!("b"));
+    }
+
+    #[test]
+    fn a_bare_event_name_selects_a_task_label() {
+        let (werk, tmp) = test_werk();
+        werk.add_task(Task::labeled(Event::TOOL_CALL_FAILED, "label match"));
+        werk.add_task(Task::labeled("other", "event match"));
+        Stats::append(
+            tmp.path(),
+            &Event::new(Event::TOOL_CALL_FAILED).task_id("t-2"),
+        )
+        .unwrap();
+
+        assert_eq!(
+            werk.find_task("tool_call_failed").unwrap().task,
+            serde_json::json!("label match")
+        );
     }
 
     #[test]
@@ -1857,7 +2178,7 @@ mod tests {
     fn not_pending_on_a_cancelled_task() {
         let (werk, _tmp) = test_werk();
         werk.add_task(Task::new("a").label("research"));
-        werk.cancel_tasks("task.label = research");
+        werk.cancel_tasks("research");
         assert!(!werk.pending(&Query::all()));
     }
 
@@ -3021,7 +3342,7 @@ mod tests {
         attach_done_result(&werk, "t-2", "reported");
 
         assert_eq!(
-            werk.finish_tasks("task.label = scan").await,
+            werk.finish_tasks("scan").await,
             vec![serde_json::json!("scanned")]
         );
     }

--- a/crates/agentwerk/src/lib.rs
+++ b/crates/agentwerk/src/lib.rs
@@ -68,7 +68,7 @@
 //! - [`Agent`]: picks up tasks and produces results.
 //! - [`Werk`]: stores tasks and runs agents.
 //! - [`Task`]: defines work with an optional label and schema.
-//! - [`Query`]: a reusable origin-aware AQL selection over tasks or events.
+//! - [`Query`]: a reusable AQL selection over tasks, events, or joined task-event pairs.
 //! - [`Knowledge`]: durable memory the agent shares across tasks and other agents.
 //! - [`Event`]: records requests, tool usage, failures, and other activity.
 //! - [`tools`]: the built-in tools agents call, for files, search, commands, web, knowledge, and tasks.

--- a/crates/agentwerk/src/lib.rs
+++ b/crates/agentwerk/src/lib.rs
@@ -21,7 +21,7 @@
 //!
 //! agent.add_task("Find every `pub trait` defined under src/ and explain each in one sentence.");
 //! let werk = agent.start();
-//! let result = werk.finish_task("ORDER BY created DESC").await.unwrap();
+//! let result = werk.finish_task("ORDER BY task.created DESC").await.unwrap();
 //!
 //! println!("{}", result.as_str().unwrap_or_default());
 //! # }
@@ -68,7 +68,7 @@
 //! - [`Agent`]: picks up tasks and produces results.
 //! - [`Werk`]: stores tasks and runs agents.
 //! - [`Task`]: defines work with an optional label and schema.
-//! - [`Query`]: a reusable AQL task selection.
+//! - [`Query`]: a reusable origin-aware AQL selection over tasks or events.
 //! - [`Knowledge`]: durable memory the agent shares across tasks and other agents.
 //! - [`Event`]: records requests, tool usage, failures, and other activity.
 //! - [`tools`]: the built-in tools agents call, for files, search, commands, web, knowledge, and tasks.

--- a/crates/agentwerk/src/tools/event.rs
+++ b/crates/agentwerk/src/tools/event.rs
@@ -387,7 +387,7 @@ mod tests {
         werk.set_dir(path.clone());
         werk.insert(Task::new("work").label("alice"), "tester".into());
         let id = werk
-            .claim(&Query::from("status = todo"), "alice")
+            .claim(&Query::from("task.status = todo"), "alice")
             .expect("claim must succeed");
         let ctx = ToolContext::new(path)
             .werk(Arc::clone(&werk))
@@ -427,7 +427,7 @@ mod tests {
         assert_eq!(event.get_data()["line"], 42);
         assert_eq!(werk.stats.event_count("candidate_found"), 1);
         let persisted = werk
-            .find_event(r#"event = "candidate_found""#)
+            .find_event(r#"event.name = "candidate_found""#)
             .expect("event persisted to the session log");
         assert_eq!(persisted.get_task_id(), id);
         assert_eq!(persisted.get_data()["path"], "src/auth.rs");
@@ -466,7 +466,7 @@ mod tests {
         assert!(outcome.get_content().contains("\"path\":\"src/auth.rs\""));
         assert!(outcome.get_content().contains("\"data\":\"shadow\""));
         assert_eq!(
-            werk.find_event(r#"event = "candidate_found""#)
+            werk.find_event(r#"event.name = "candidate_found""#)
                 .unwrap()
                 .get_directive(),
             Some("candidate_found"),
@@ -501,7 +501,9 @@ mod tests {
 
         assert!(werk.get_task(&id).unwrap().is_in_progress());
         assert_eq!(
-            werk.find_event(Event::TASK_FAILED).unwrap().get_data()["reason"],
+            werk.find_event("event.name = task_failed")
+                .unwrap()
+                .get_data()["reason"],
             "reported"
         );
     }
@@ -544,7 +546,7 @@ mod tests {
             werk.get_task(&id).unwrap().get_result(),
             Some(&serde_json::json!({ "verdict": "safe" }))
         );
-        assert_eq!(werk.find_events(Event::TASK_FINISHED).len(), 1);
+        assert_eq!(werk.find_events("event.name = task_finished").len(), 1);
     }
 
     #[tokio::test]
@@ -650,7 +652,7 @@ mod tests {
             "tester".into(),
         );
         let id = werk
-            .claim(&Query::from("status = todo"), "alice")
+            .claim(&Query::from("task.status = todo"), "alice")
             .expect("claim must succeed");
         let ctx = ToolContext::new(dir.path().to_path_buf())
             .werk(Arc::clone(&werk))

--- a/crates/agentwerk/src/tools/task/finish.rs
+++ b/crates/agentwerk/src/tools/task/finish.rs
@@ -155,7 +155,7 @@ mod tests {
         werk.set_dir(shared_test_dir().to_path_buf());
         werk.insert(Task::new("body").label(agent), "tester".into());
         let id = werk
-            .claim(&Query::from("status = todo"), agent)
+            .claim(&Query::from("task.status = todo"), agent)
             .expect("claim must succeed");
         (werk, id)
     }
@@ -195,7 +195,7 @@ mod tests {
             Task::new("body").schema(line_schema()).label("alice"),
             "tester".into(),
         );
-        werk.claim(&Query::from("status = todo"), "alice")
+        werk.claim(&Query::from("task.status = todo"), "alice")
             .expect("claim must succeed");
         werk
     }
@@ -300,7 +300,7 @@ mod tests {
         let dir = crate::test_util::TempDir::new().unwrap();
         let werk = line_task(dir.path());
         let id = werk
-            .find_task("status = in_progress")
+            .find_task("task.status = in_progress")
             .unwrap()
             .get_id()
             .to_string();
@@ -357,7 +357,9 @@ mod tests {
             Some(&serde_json::Value::Null)
         );
         assert_eq!(
-            werk.find_event(Event::TASK_FINISHED).unwrap().get_data()["result"],
+            werk.find_event("event.name = task_finished")
+                .unwrap()
+                .get_data()["result"],
             serde_json::Value::Null
         );
     }
@@ -383,7 +385,7 @@ mod tests {
             "tester".into(),
         );
         let id = werk
-            .claim(&Query::from("status = todo"), "alice")
+            .claim(&Query::from("task.status = todo"), "alice")
             .expect("claim must succeed");
         let ctx = ctx_with(Arc::clone(&werk), "alice", dir.path().to_path_buf());
 
@@ -458,7 +460,7 @@ mod tests {
             t.result.as_ref().and_then(|v| v.as_str()),
             Some("the answer")
         );
-        let event = werk.find_event(Event::TASK_FINISHED).unwrap();
+        let event = werk.find_event("event.name = task_finished").unwrap();
         assert_eq!(event.get_data()["result"], "the answer");
 
         assert_eq!(read_result(dir.path(), &id), Some("the answer".into()));
@@ -568,7 +570,7 @@ mod tests {
             "tester".into(),
         );
         let id = werk
-            .claim(&Query::from("status = todo"), "alice")
+            .claim(&Query::from("task.status = todo"), "alice")
             .expect("claim must succeed");
         let ctx = ctx_with(Arc::clone(&werk), "alice", dir.path().to_path_buf());
 
@@ -607,7 +609,7 @@ mod tests {
             "tester".into(),
         );
         let id = werk
-            .claim(&Query::from("status = todo"), "alice")
+            .claim(&Query::from("task.status = todo"), "alice")
             .expect("claim must succeed");
         let ctx = ctx_with(Arc::clone(&werk), "alice", dir.path().to_path_buf());
 
@@ -637,7 +639,7 @@ mod tests {
             "tester".into(),
         );
         let id = werk
-            .claim(&Query::from("status = todo"), "alice")
+            .claim(&Query::from("task.status = todo"), "alice")
             .expect("claim must succeed");
         let ctx = ctx_with(Arc::clone(&werk), "alice", dir.path().to_path_buf());
 
@@ -713,7 +715,7 @@ mod tests {
             );
             let id = werk
                 .claim(
-                    &Query::from(format!("status = todo AND label = {agent}")),
+                    &Query::from(format!("task.status = todo AND task.label = {agent}")),
                     &agent,
                 )
                 .expect("claim must succeed");
@@ -760,7 +762,7 @@ mod tests {
         werk.set_dir(dir);
         werk.insert(Task::new("parent body").label(agent), "tester".into());
         let id = werk
-            .claim(&Query::from("status = todo"), agent)
+            .claim(&Query::from("task.status = todo"), agent)
             .expect("claim must succeed");
         (werk, id)
     }
@@ -872,7 +874,7 @@ mod tests {
             "tester".into(),
         );
         let parent_id = werk
-            .claim(&Query::from("status = todo"), "alice")
+            .claim(&Query::from("task.status = todo"), "alice")
             .expect("claim must succeed");
         let ctx = ctx_with(Arc::clone(&werk), "alice", dir.path().to_path_buf());
 
@@ -917,7 +919,7 @@ mod tests {
             "tester".into(),
         );
         let id = werk
-            .claim(&Query::from("status = todo"), agent)
+            .claim(&Query::from("task.status = todo"), agent)
             .expect("claim must succeed");
         (werk, id)
     }

--- a/crates/agentwerk/src/tools/task/mod.rs
+++ b/crates/agentwerk/src/tools/task/mod.rs
@@ -72,7 +72,7 @@ pub(super) fn resolve_current_id(werk: &Werk, ctx: &ToolContext) -> Result<Strin
     if let Some(id) = ctx.task_id.as_deref() {
         return Ok(id.to_string());
     }
-    // A closure, never `agent = {id}`: an id derives from a host-supplied label,
+    // A closure, never `task.assignee = {id}`: an id derives from a host-supplied label,
     // and AQL binds no values, so one carrying `=` or a quote rewrites the query.
     let agent_id = ctx.agent_id.clone().ok_or_else(|| {
         Event::error(ctx.directives.render(TASK_ID_MISSING, &[])).directive(TASK_ID_MISSING)
@@ -208,7 +208,14 @@ fn action_result(werk: &Werk, id: Option<String>, ctx: &ToolContext) -> Event {
 
 fn action_list(werk: &Werk, aql: Option<String>, directives: &DirectiveStore) -> Event {
     let pool: Vec<Task> = match aql.as_deref().map(Query::new) {
-        Some(Ok(query)) => werk.find_tasks(query),
+        Some(Ok(query)) => match query.expects_task() {
+            Ok(()) => werk.find_tasks(query),
+            Err(error) => {
+                return Event::error(
+                    directives.render(TASK_QUERY_INVALID, &[("error", &error.to_string())]),
+                )
+            }
+        },
         Some(Err(error)) => {
             return Event::error(
                 directives.render(TASK_QUERY_INVALID, &[("error", &error.to_string())]),
@@ -295,7 +302,7 @@ mod tests {
         werk.set_dir(isolated_test_dir());
         werk.insert(Task::new("body").label(agent), "tester".into());
         let id = werk
-            .claim(&Query::from("status = todo"), agent)
+            .claim(&Query::from("task.status = todo"), agent)
             .expect("claim must succeed");
         (werk, id)
     }
@@ -461,7 +468,7 @@ mod tests {
         let ctx = ctx_with(Arc::clone(&werk), "alice");
         let result = call(
             TaskTool,
-            serde_json::json!({"action": "list", "aql": "status = in_progress"}),
+            serde_json::json!({"action": "list", "aql": "task.status = in_progress"}),
             &ctx,
         )
         .await;
@@ -476,7 +483,7 @@ mod tests {
         let ctx = ctx_with(Arc::clone(&werk), "alice");
         let result = call(
             TaskTool,
-            serde_json::json!({"action": "list", "aql": "ORDER BY id DESC"}),
+            serde_json::json!({"action": "list", "aql": "ORDER BY task.id DESC"}),
             &ctx,
         )
         .await;
@@ -490,7 +497,7 @@ mod tests {
         let ctx = ctx_with(Arc::clone(&werk), "alice");
         let result = call(
             TaskTool,
-            serde_json::json!({"action": "list", "aql": "created > -1h"}),
+            serde_json::json!({"action": "list", "aql": "task.created > -1h"}),
             &ctx,
         )
         .await;
@@ -499,7 +506,7 @@ mod tests {
 
         let result = call(
             TaskTool,
-            serde_json::json!({"action": "list", "aql": "created < -1h"}),
+            serde_json::json!({"action": "list", "aql": "task.created < -1h"}),
             &ctx,
         )
         .await;
@@ -512,7 +519,7 @@ mod tests {
         let ctx = ctx_with(Arc::clone(&werk), "alice");
         let result = call(
             TaskTool,
-            serde_json::json!({"action": "list", "aql": "status = finished"}),
+            serde_json::json!({"action": "list", "aql": "task.status = finished"}),
             &ctx,
         )
         .await;
@@ -531,6 +538,21 @@ mod tests {
         .await;
         assert!(result.get_name() == Event::TOOL_CALL_FAILED, "{result:?}");
         assert!(unwrap_text(&result).contains("agent"));
+    }
+
+    #[tokio::test]
+    async fn list_rejects_an_event_query_as_a_task_query() {
+        let werk = werk_with_two_tasks();
+        let ctx = ctx_with(Arc::clone(&werk), "alice");
+        let result = call(
+            TaskTool,
+            serde_json::json!({"action": "list", "aql": "event.name = task_created"}),
+            &ctx,
+        )
+        .await;
+
+        assert!(result.get_name() == Event::TOOL_CALL_FAILED, "{result:?}");
+        assert!(unwrap_text(&result).contains("requires a task query"));
     }
 
     #[tokio::test]

--- a/crates/agentwerk/src/tools/task/mod.rs
+++ b/crates/agentwerk/src/tools/task/mod.rs
@@ -208,14 +208,7 @@ fn action_result(werk: &Werk, id: Option<String>, ctx: &ToolContext) -> Event {
 
 fn action_list(werk: &Werk, aql: Option<String>, directives: &DirectiveStore) -> Event {
     let pool: Vec<Task> = match aql.as_deref().map(Query::new) {
-        Some(Ok(query)) => match query.expects_task() {
-            Ok(()) => werk.find_tasks(query),
-            Err(error) => {
-                return Event::error(
-                    directives.render(TASK_QUERY_INVALID, &[("error", &error.to_string())]),
-                )
-            }
-        },
+        Some(Ok(query)) => werk.find_tasks(query),
         Some(Err(error)) => {
             return Event::error(
                 directives.render(TASK_QUERY_INVALID, &[("error", &error.to_string())]),
@@ -478,6 +471,22 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn list_accepts_task_label_shorthand() {
+        let werk = werk_with_two_tasks();
+        let ctx = ctx_with(Arc::clone(&werk), "alice");
+        let result = call(
+            TaskTool,
+            serde_json::json!({"action": "list", "aql": "review"}),
+            &ctx,
+        )
+        .await;
+        let text = unwrap_text(&result);
+
+        assert!(text.contains("t-1"), "{text}");
+        assert!(!text.contains("t-2"), "{text}");
+    }
+
+    #[tokio::test]
     async fn list_answers_in_the_order_the_aql_names() {
         let werk = werk_with_two_tasks();
         let ctx = ctx_with(Arc::clone(&werk), "alice");
@@ -541,7 +550,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn list_rejects_an_event_query_as_a_task_query() {
+    async fn list_projects_an_event_query_to_tasks() {
         let werk = werk_with_two_tasks();
         let ctx = ctx_with(Arc::clone(&werk), "alice");
         let result = call(
@@ -551,8 +560,10 @@ mod tests {
         )
         .await;
 
-        assert!(result.get_name() == Event::TOOL_CALL_FAILED, "{result:?}");
-        assert!(unwrap_text(&result).contains("requires a task query"));
+        assert!(result.get_name() == Event::TOOL_CALL_FINISHED, "{result:?}");
+        let output = unwrap_text(&result);
+        assert!(output.contains("t-1"));
+        assert!(output.contains("t-2"));
     }
 
     #[tokio::test]

--- a/crates/agentwerk/src/tools/task/task.schema.json
+++ b/crates/agentwerk/src/tools/task/task.schema.json
@@ -19,7 +19,7 @@
     },
     "aql": {
       "type": "string",
-      "description": "For `list`: which tasks to answer with, in AQL. Fields are `id`, `label`, `status`, `agent`, `parent`, `task`, `result`, `errors`, `created`, `started`, `finished`, `failed`. Operators are `=`, `!=`, `IN (a, b)`, `NOT IN (a, b)`, `IS EMPTY`, `IS NOT EMPTY`, and on `task`, `result`, `errors` the case-insensitive `~` and `!~`. The four times take `>`, `>=`, `<`, `<=` against a date like `2026-08-24` or an offset back from now like `-30m`, `-2h`, `-7d`, `-1w`; `started`, `finished`, `failed` also read `IS EMPTY`. Combine terms with `AND`, `OR`, `NOT`, and parentheses. Close with `ORDER BY <field> ASC|DESC`; without it tasks arrive oldest first. A lone word is the label, a lone `t-N` that task. Status is `todo`, `in_progress`, `finished`, or `failed`. Leave out to answer with every task."
+      "description": "For `list`: which tasks to answer with, in AQL. Fields are `task.id`, `task.label`, `task.status`, `task.pending`, `task.cancelled`, `task.assignee`, `task.parent_id`, `task.input`, `task.result`, `task.errors`, `task.created`, `task.started`, `task.finished`, `task.failed`. Operators are `=`, `!=`, `IN (a, b)`, `NOT IN (a, b)`, `IS EMPTY`, `IS NOT EMPTY`, and on `task.input`, `task.result`, `task.errors` the case-insensitive `~` and `!~`. The four times take `>`, `>=`, `<`, `<=` against a date like `2026-08-24` or an offset back from now like `-30m`, `-2h`, `-7d`, `-1w`; `task.started`, `task.finished`, `task.failed` also read `IS EMPTY`. Combine terms with `AND`, `OR`, `NOT`, and parentheses. Close with `ORDER BY <field> ASC|DESC`; without it tasks arrive oldest first. A lone `t-N` selects that task; other unqualified words are invalid. Status is `todo`, `in_progress`, `finished`, or `failed`. Leave out to answer with every task."
     },
     "label": {
       "type": "string",
@@ -46,11 +46,11 @@
     { "action": "task" },
     { "action": "result", "id": "t-3" },
     { "action": "list" },
-    { "action": "list", "aql": "status = todo AND label = review" },
-    { "action": "list", "aql": "task ~ \"retry budget\" AND agent IS EMPTY" },
-    { "action": "list", "aql": "status = finished ORDER BY finished DESC" },
-    { "action": "list", "aql": "finished IS EMPTY ORDER BY created" },
-    { "action": "list", "aql": "failed > -1h ORDER BY failed DESC" },
+    { "action": "list", "aql": "task.status = todo AND task.label = review" },
+    { "action": "list", "aql": "task.input ~ \"retry budget\" AND task.assignee IS EMPTY" },
+    { "action": "list", "aql": "task.status = finished ORDER BY task.finished DESC" },
+    { "action": "list", "aql": "task.finished IS EMPTY ORDER BY task.created" },
+    { "action": "list", "aql": "task.failed > -1h ORDER BY task.failed DESC" },
     {
       "action": "create",
       "task": "Check the retry budget on the upload path.",

--- a/crates/agentwerk/src/tools/task/task.schema.json
+++ b/crates/agentwerk/src/tools/task/task.schema.json
@@ -19,7 +19,7 @@
     },
     "aql": {
       "type": "string",
-      "description": "For `list`: which tasks to answer with, in AQL. Fields are `task.id`, `task.label`, `task.status`, `task.pending`, `task.cancelled`, `task.assignee`, `task.parent_id`, `task.input`, `task.result`, `task.errors`, `task.created`, `task.started`, `task.finished`, `task.failed`. Operators are `=`, `!=`, `IN (a, b)`, `NOT IN (a, b)`, `IS EMPTY`, `IS NOT EMPTY`, and on `task.input`, `task.result`, `task.errors` the case-insensitive `~` and `!~`. The four times take `>`, `>=`, `<`, `<=` against a date like `2026-08-24` or an offset back from now like `-30m`, `-2h`, `-7d`, `-1w`; `task.started`, `task.finished`, `task.failed` also read `IS EMPTY`. Combine terms with `AND`, `OR`, `NOT`, and parentheses. Close with `ORDER BY <field> ASC|DESC`; without it tasks arrive oldest first. A lone `t-N` selects that task; other unqualified words are invalid. Status is `todo`, `in_progress`, `finished`, or `failed`. Leave out to answer with every task."
+      "description": "For `list`: which tasks to answer with, in AQL. Task fields are `task.id`, `task.label`, `task.status`, `task.pending`, `task.cancelled`, `task.assignee`, `task.parent_id`, `task.input`, `task.result`, `task.errors`, `task.created`, `task.started`, `task.finished`, `task.failed`. Event fields are `event.name`, `event.agent_id`, `event.task_id`, `event.label`, `event.created`, `event.data`. A query combining both selects task-event pairs linked by `event.task_id`, then returns each referenced task once. Operators are `=`, `!=`, `IN (a, b)`, `NOT IN (a, b)`, `IS EMPTY`, `IS NOT EMPTY`; text fields take case-insensitive `~` and `!~`; time fields take `>`, `>=`, `<`, `<=` against a date like `2026-08-24` or an offset like `-30m`, `-2h`, `-7d`, `-1w`. Combine terms with `AND`, `OR`, `NOT`, and parentheses. Close with `ORDER BY <field> ASC|DESC`. A lone value selects `task.label`; quote it when it contains spaces or query words. A lone `t-N` selects `task.id` instead. Status is `todo`, `in_progress`, `finished`, or `failed`. Leave out to answer with every task."
     },
     "label": {
       "type": "string",
@@ -46,7 +46,7 @@
     { "action": "task" },
     { "action": "result", "id": "t-3" },
     { "action": "list" },
-    { "action": "list", "aql": "task.status = todo AND task.label = review" },
+    { "action": "list", "aql": "review AND task.status = todo" },
     { "action": "list", "aql": "task.input ~ \"retry budget\" AND task.assignee IS EMPTY" },
     { "action": "list", "aql": "task.status = finished ORDER BY task.finished DESC" },
     { "action": "list", "aql": "task.finished IS EMPTY ORDER BY task.created" },

--- a/crates/agentwerk/tests/integration/command_usage.rs
+++ b/crates/agentwerk/tests/integration/command_usage.rs
@@ -63,7 +63,7 @@ async fn command_tools_produce_the_schema_bound_result(
     );
 
     let json = werk
-        .finish_task("ORDER BY created DESC")
+        .finish_task("ORDER BY task.created DESC")
         .await
         .unwrap_or_default();
     common::print_result(&werk);

--- a/crates/agentwerk/tests/integration/edit_file_replaces_content.rs
+++ b/crates/agentwerk/tests/integration/edit_file_replaces_content.rs
@@ -47,7 +47,9 @@ async fn replaces_substring_in_place() -> std::result::Result<(), Box<dyn std::e
     common::print_result(&werk);
 
     assert!(
-        !werk.find_events("tool_call_started").is_empty(),
+        !werk
+            .find_events("event.name = tool_call_started")
+            .is_empty(),
         "agent must call at least one tool"
     );
 

--- a/crates/agentwerk/tests/integration/file_exploration.rs
+++ b/crates/agentwerk/tests/integration/file_exploration.rs
@@ -33,7 +33,9 @@ async fn file_tools_explore_the_repository() -> std::result::Result<(), Box<dyn 
     werk.finish_all_tasks().await;
     common::print_result(&werk);
 
-    assert!(!werk.find_events("tool_call_started").is_empty());
+    assert!(!werk
+        .find_events("event.name = tool_call_started")
+        .is_empty());
 
     Ok(())
 }

--- a/crates/agentwerk/tests/integration/list_directory_enumerates_entries.rs
+++ b/crates/agentwerk/tests/integration/list_directory_enumerates_entries.rs
@@ -69,13 +69,15 @@ async fn separates_files_and_directories() -> std::result::Result<(), Box<dyn st
     );
 
     let json = werk
-        .finish_task("ORDER BY created DESC")
+        .finish_task("ORDER BY task.created DESC")
         .await
         .unwrap_or_default();
     common::print_result(&werk);
 
     assert!(
-        !werk.find_events("tool_call_started").is_empty(),
+        !werk
+            .find_events("event.name = tool_call_started")
+            .is_empty(),
         "agent must call at least one tool"
     );
 

--- a/crates/agentwerk/tests/integration/task_all_actions.rs
+++ b/crates/agentwerk/tests/integration/task_all_actions.rs
@@ -92,7 +92,7 @@ async fn walks_every_task_action() -> std::result::Result<(), Box<dyn std::error
     // Not `finish_all_tasks`: the decoy and the record the agent files are labelled
     // for nobody, so they stay `todo` and a wait on the whole Werk only ever
     // ends at the time cap.
-    werk.finish_tasks("label IN (archive, auditor)").await;
+    werk.finish_tasks("task.label IN (archive, auditor)").await;
     common::print_result(&werk);
 
     let used = seen.lock().unwrap().clone();
@@ -110,12 +110,12 @@ async fn walks_every_task_action() -> std::result::Result<(), Box<dyn std::error
     // the intent has to reach, not every attempt on the way there.
     let written = written.lock().unwrap().clone();
     assert!(
-        written.iter().any(|q| Query::<Task>::new(q).is_ok()),
+        written.iter().any(|q| Query::new(q).is_ok()),
         "the narrowing intent reached no query that compiles; it wrote {written:?}"
     );
 
     let audit = werk
-        .find_task("label = auditor AND status = finished")
+        .find_task("task.label = auditor AND task.status = finished")
         .expect("the auditor must finish the task handed to it");
     let answer = audit.get_result().cloned().unwrap_or_default().to_string();
     assert!(

--- a/crates/agentwerk/tests/integration/traces_call_path_across_files.rs
+++ b/crates/agentwerk/tests/integration/traces_call_path_across_files.rs
@@ -109,13 +109,13 @@ async fn traces_three_hop_call_path() -> std::result::Result<(), Box<dyn std::er
     );
 
     let json = werk
-        .finish_task("ORDER BY created DESC")
+        .finish_task("ORDER BY task.created DESC")
         .await
         .unwrap_or_default();
     common::print_result(&werk);
 
     assert!(
-        werk.find_events("tool_call_started").len() >= 2,
+        werk.find_events("event.name = tool_call_started").len() >= 2,
         "tracing a call path requires at least two read-only tool calls"
     );
 

--- a/crates/agentwerk/tests/integration/write_file_creates_file.rs
+++ b/crates/agentwerk/tests/integration/write_file_creates_file.rs
@@ -45,7 +45,9 @@ async fn creates_file_with_token() -> std::result::Result<(), Box<dyn std::error
     common::print_result(&werk);
 
     assert!(
-        !werk.find_events("tool_call_started").is_empty(),
+        !werk
+            .find_events("event.name = tool_call_started")
+            .is_empty(),
         "agent must call at least one tool"
     );
 

--- a/crates/use-cases/src/deep_research/main.rs
+++ b/crates/use-cases/src/deep_research/main.rs
@@ -139,7 +139,7 @@ fn print_research_outcome(werk: &Werk, outcome: &Outcome) {
             eprintln!(" {label}");
             eprintln!("══════════════════════════════════════════════════════════\n");
             let researched: Vec<(String, String)> = werk
-                .find_tasks("status = finished AND label != report")
+                .find_tasks("task.status = finished AND task.label != report")
                 .iter()
                 .filter_map(|t| Some((t.get_id().to_string(), plain_text(t.get_result()?))))
                 .collect();
@@ -164,7 +164,7 @@ enum Outcome {
 /// task wins, an external cancel is surfaced, anything else means the
 /// chain stopped without reaching the report step.
 fn classify_outcome(werk: &Werk) -> Outcome {
-    let reported = werk.find_results("report").pop();
+    let reported = werk.find_results("task.label = report").pop();
     if let Some(result) = reported {
         return Outcome::Report(result);
     }
@@ -205,7 +205,7 @@ fn print_chain_summary(werk: &Werk) {
 fn print_stats(werk: &Werk) {
     eprintln!("\nStats:");
     eprintln!("  Duration : {:?}", werk.get_duration().unwrap_or_default());
-    let count = |name: &str| werk.find_events(name).len() as u64;
+    let count = |name: &str| werk.find_events(format!("event.name = {name}")).len() as u64;
     let done = count(Event::TASK_FINISHED);
     let failed = count(Event::TASK_FAILED);
     let resolved = done + failed;

--- a/crates/use-cases/src/malware_scanner/main.rs
+++ b/crates/use-cases/src/malware_scanner/main.rs
@@ -185,7 +185,9 @@ async fn main() {
                 return;
             }
             trip.store(true, Ordering::Relaxed);
-            werk.cancel_tasks("pending = true AND label IN (seeking, tracing, security_analysis)");
+            werk.cancel_tasks(
+                "task.pending = true AND task.label IN (seeking, tracing, security_analysis)",
+            );
         });
     }
 
@@ -347,7 +349,7 @@ async fn main() {
     // Stop every pool, including any Seeker still searching, before the report
     // phase: the Reporter runs on its own Werk, out of the cap's reach.
     let seekers_called_off = werk
-        .find_task("label = seeking AND cancelled = true")
+        .find_task("task.label = seeking AND task.cancelled = true")
         .is_some();
     werk.cancel_all_tasks();
     werk.finish_all_tasks().await;
@@ -474,7 +476,7 @@ fn resolve_models(
 /// [`Werk::finish_tasks`], which would wait on the entire Werk. A called-off
 /// pool's tasks stay pending forever, so they are skipped.
 async fn wait_for_report_inputs(werk: &Werk) {
-    werk.finish_tasks("label IN (security_analysis, tracing, exploration, seeking)")
+    werk.finish_tasks("task.label IN (security_analysis, tracing, exploration, seeking)")
         .await;
 }
 
@@ -524,13 +526,15 @@ fn refill_seekers(werk: &Arc<Werk>, search_body: &str, concurrency: usize) {
         // Query and insertion form one decision across concurrent finishes.
         let _refill = refill.lock().unwrap();
         if werk
-            .find_task("label IN (tracing, security_analysis) AND pending = true")
+            .find_task("task.label IN (tracing, security_analysis) AND task.pending = true")
             .is_some()
         {
             return;
         }
-        let pending = werk.find_tasks("label = seeking AND pending = true").len();
-        let created = werk.find_tasks("label = seeking").len();
+        let pending = werk
+            .find_tasks("task.label = seeking AND task.pending = true")
+            .len();
+        let created = werk.find_tasks("task.label = seeking").len();
         let open_slots = concurrency.saturating_sub(pending);
         let remaining = SEEKER_PASSES.saturating_sub(created);
         for _ in 0..open_slots.min(remaining) {
@@ -611,7 +615,7 @@ fn install_ctrl_c_handler(werk: Arc<Werk>) {
             "\n[ctrl-c] winding down: no new work, finishing in-flight analysis then reporting. \
              Press again to force exit."
         );
-        werk.cancel_tasks("label IN (exploration, seeking)");
+        werk.cancel_tasks("task.label IN (exploration, seeking)");
         if tokio::signal::ctrl_c().await.is_err() {
             return;
         }
@@ -624,7 +628,9 @@ fn install_ctrl_c_handler(werk: Arc<Werk>) {
 /// Read the Reporter's `{summary, details}` off its finished task and fold it
 /// into the analysis. Missing fields leave the `build_analysis` tally in place.
 fn merge_reporter_verdict(werk: &Werk, analysis: &mut Value) {
-    let reported = werk.find_results(REPORTER_LABEL).pop();
+    let reported = werk
+        .find_results(format!("task.label = {REPORTER_LABEL}"))
+        .pop();
     let Some(result) = reported else {
         return;
     };
@@ -739,7 +745,7 @@ mod tests {
         )
         .unwrap();
 
-        let traces = werk.find_tasks("label = tracing");
+        let traces = werk.find_tasks("task.label = tracing");
         assert_eq!(traces.len(), 1);
         assert_eq!(traces[0].get_parent(), Some(seeker.as_str()));
         assert_eq!(
@@ -765,7 +771,7 @@ mod tests {
         )
         .unwrap();
 
-        assert!(werk.find_tasks("label = tracing").is_empty());
+        assert!(werk.find_tasks("task.label = tracing").is_empty());
         drop(werk);
         let _ = std::fs::remove_dir_all(dir);
     }
@@ -784,7 +790,7 @@ mod tests {
         refill_seekers(&werk, "search", concurrency);
 
         for finished in 0..SEEKER_PASSES {
-            let pending = werk.find_tasks("label = seeking AND pending = true");
+            let pending = werk.find_tasks("task.label = seeking AND task.pending = true");
             assert_eq!(pending.len(), concurrency.min(SEEKER_PASSES - finished));
             assert!(pending.iter().all(|task| task.get_schema().is_some()));
             werk.set_task_finished(
@@ -794,9 +800,9 @@ mod tests {
             .unwrap();
         }
 
-        assert_eq!(werk.find_tasks("label = seeking").len(), SEEKER_PASSES);
+        assert_eq!(werk.find_tasks("task.label = seeking").len(), SEEKER_PASSES);
         assert!(werk
-            .find_tasks("label = seeking AND pending = true")
+            .find_tasks("task.label = seeking AND task.pending = true")
             .is_empty());
         drop(werk);
         let _ = std::fs::remove_dir_all(dir);
@@ -828,20 +834,21 @@ mod tests {
             json!({"outcome": "dry", "evidence": "pattern: nothing found"}),
         )
         .unwrap();
-        assert_eq!(werk.find_tasks("label = seeking").len(), 2);
+        assert_eq!(werk.find_tasks("task.label = seeking").len(), 2);
 
         let tracer = werk
-            .find_task("label = tracing")
+            .find_task("task.label = tracing")
             .expect("the hit opens one trace")
             .get_id()
             .to_string();
         let analyst = werk.add_task(Task::labeled(ANALYSIS_LABEL, "decide hit"));
         werk.set_task_finished(&tracer, "trace").unwrap();
-        assert_eq!(werk.find_tasks("label = seeking").len(), 2);
+        assert_eq!(werk.find_tasks("task.label = seeking").len(), 2);
 
         werk.set_task_finished(&analyst, "verdict").unwrap();
         assert_eq!(
-            werk.find_tasks("label = seeking AND pending = true").len(),
+            werk.find_tasks("task.label = seeking AND task.pending = true")
+                .len(),
             2
         );
         drop(werk);

--- a/crates/use-cases/src/malware_scanner/report.rs
+++ b/crates/use-cases/src/malware_scanner/report.rs
@@ -94,7 +94,7 @@ pub(crate) fn build_analysis(werk: &Werk, scan_dir: &Path, total_files: usize) -
     let mut index: HashMap<(String, Option<u64>, Option<u64>), usize> = HashMap::new();
     let mut unparsed: usize = 0;
 
-    for task in werk.find_tasks(ANALYSIS_LABEL) {
+    for task in werk.find_tasks(format!("task.label = {ANALYSIS_LABEL}")) {
         let Some(attached) = task.get_result() else {
             unparsed += 1;
             continue;


### PR DESCRIPTION
## Unify AQL across tasks, events, and joined queries

### Purpose

- `Query` can select tasks, events, or linked task-event pairs
- Every finder returns its record type from one AQL expression
- Lifecycle operations accept event and joined task selections

### What changed

- Bare values select `task.label`; bare `t-N` values select `task.id`
- Mixed `task.*` and `event.*` fields create an inner join
- `find_tasks`, `find_events`, and `find_results` project linked matches
- `finish_*` and `cancel_tasks` snapshot event-selected task IDs
- `make bench_aql` measures compilation, storage, matching, sorting, and joins

### Examples

```rust
werk.find_events("scan AND event.name = tool_call_failed");
werk.find_tasks("event.name = task_finished");
```

```python
werk.find_results("report AND task.result ~ risk")
werk.cancel_tasks("event.name = request_failed")
```