### PR TITLE
tools: make knowledge explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ The [prompt skill](skills/prompt/SKILL.md) provides a compact template for writi
 | | `templates(variables)` | Set several shared templates together. |
 | | `directive(key, template)` | Set a directive template by key. |
 | | `directives(overrides)` | Set more than one directive template. |
-| | `knowledge(store)` | Share a knowledge store with the agent. |
+| | `knowledge(store)` | Share a knowledge store and register its `KnowledgeTool`. |
 | | `interactive()` | Let the agent wait for new instructions to keep a task in-progress. |
 | **Work** | `add_task(task)` | Submit a task, or a `Task` carrying a label or schema, and return its task ID. |
 | | `start()` | Keep processing tasks in the background. |
@@ -1065,7 +1065,7 @@ let alice = Agent::new().knowledge(&store);
 let bob = Agent::new().knowledge(&store);
 ```
 
-Agents configured with a store can read and update its shared pages through `KnowledgeTool`.
+Calling `.knowledge(&store)` registers a `KnowledgeTool` bound to that store, so the agent can read and update its shared pages.
 
 <details>
 <summary>Knowledge reference</summary>

--- a/agentdocs/architecture.md
+++ b/agentdocs/architecture.md
@@ -101,6 +101,7 @@ The invariants that govern orchestration, tools, providers, events, and durable 
 **Keep `Knowledge` optional, durable, and shared only by explicit handle.**
 
 - Treat the directory passed to `Knowledge::load` as the OKF v0.1 bundle root and rebuild `index.md` from page frontmatter on load.
+- Register `KnowledgeTool` only through an explicit `.knowledge(...)` or `.tool(...)` call; constructing an agent must not expose it.
 - Inject only the index into the prompt; let `KnowledgeTool` read full pages on demand.
 - Read the index once per task so writes become visible on the next task without changing an active prompt prefix.
 - Cap injected index characters through `Knowledge::set_index_char_limit` without limiting stored page content.

--- a/crates/agentwerk-py/README.md
+++ b/crates/agentwerk-py/README.md
@@ -127,7 +127,7 @@ The [prompt skill](../../skills/prompt/SKILL.md) provides a compact template for
 | | `templates(variables)` | Set several shared templates together. |
 | | `directive(key, template)` | Set a directive template by key. |
 | | `directives(overrides)` | Set more than one directive template. |
-| | `knowledge(store)` | Share a knowledge store with the agent. |
+| | `knowledge(store)` | Share a knowledge store and register its `KnowledgeTool`. |
 | | `interactive()` | Let the agent wait for new instructions to keep a task in-progress. |
 | **Work** | `add_task(task)` | Submit a task, or a `Task` carrying a label or schema, and return its task ID. |
 | | `start()` | Keep processing tasks in the background. |
@@ -1076,7 +1076,7 @@ alice = Agent().knowledge(store)
 bob = Agent().knowledge(store)
 ```
 
-Agents configured with a store can read and update its shared pages through `KnowledgeTool()`.
+Calling `.knowledge(store)` registers a `KnowledgeTool(store)` bound to that store, so the agent can read and update its shared pages.
 
 <details>
 <summary>Knowledge reference</summary>

--- a/crates/agentwerk-py/src/agent.rs
+++ b/crates/agentwerk-py/src/agent.rs
@@ -158,8 +158,7 @@ impl PyAgent {
         slf
     }
 
-    /// Share a knowledge store, the durable memory the agent carries across
-    /// tasks and shares with other agents.
+    /// Share a knowledge store and register its knowledge tool.
     fn knowledge<'py>(
         mut slf: PyRefMut<'py, Self>,
         store: PyRef<'_, PyKnowledge>,

--- a/crates/agentwerk/src/agents/agent.rs
+++ b/crates/agentwerk/src/agents/agent.rs
@@ -119,10 +119,11 @@ impl Agent {
     /// `.add_task(...)`, `.start()`, and `.finish()` work without one being set up.
     /// `Werk::add_agent(...)` later moves those tasks into the shared Werk.
     ///
-    /// Give it a provider and a model before it starts work.
+    /// Give it a provider and a model before it starts work. It begins with no
+    /// tools; joining a Werk registers [`FinishTool`] unless it is interactive.
     pub fn new() -> Self {
         let knowledge = Knowledge::load(".agentwerk/knowledge").expect("open knowledge store");
-        let mut agent = Self {
+        Self {
             id: OnceLock::new(),
             provider: None,
             model: None,
@@ -134,9 +135,7 @@ impl Agent {
             dir: std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
             knowledge,
             directives: Arc::new(DirectiveStore::default()),
-        };
-        agent.register_tool(KnowledgeTool::new(Arc::clone(&agent.knowledge)));
-        agent
+        }
     }
 
     /// Create an agent with the provider and model from the environment.
@@ -259,9 +258,9 @@ impl Agent {
     /// Share a knowledge store, the durable memory the agent carries across
     /// tasks and shares with other agents.
     ///
-    /// It replaces the store opened by default, both for what the prompt shows
-    /// and for what `KnowledgeTool` writes to. Hand the same store to
-    /// several agents to share it between them.
+    /// It replaces the store opened by default for what the prompt shows and
+    /// registers a [`KnowledgeTool`] bound to it. Hand the same store to several
+    /// agents to share it between them.
     pub fn knowledge(mut self, store: &Arc<Knowledge>) -> Self {
         self.register_tool(KnowledgeTool::new(Arc::clone(store)));
         self.knowledge = Arc::clone(store);
@@ -1092,7 +1091,7 @@ mod tests {
     }
 
     #[test]
-    fn new_agent_has_the_knowledge_tool_registered() {
+    fn new_agent_does_not_have_the_knowledge_tool_registered() {
         let agent = Agent::new();
         let registry = agent.tool_list();
         let names: Vec<String> = registry
@@ -1100,8 +1099,8 @@ mod tests {
             .map(|tool| tool.get_name().to_string())
             .collect();
         assert!(
-            names.iter().any(|n| n == "knowledge"),
-            "knowledge must be registered on every new agent: {names:?}",
+            names.iter().all(|n| n != "knowledge"),
+            "knowledge must be registered explicitly: {names:?}",
         );
     }
 

--- a/crates/agentwerk/src/agents/loop/test_util.rs
+++ b/crates/agentwerk/src/agents/loop/test_util.rs
@@ -6,6 +6,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use crate::agents::agent::Agent;
+use crate::agents::knowledge::Knowledge;
 use crate::agents::policy::Policy;
 use crate::agents::tasks::{Task, Werk};
 use crate::event::Event;
@@ -316,6 +317,8 @@ pub async fn run_one(
     };
 
     let results_dir = crate::test_util::TempDir::new().unwrap();
+    let knowledge_dir = crate::test_util::TempDir::new().unwrap();
+    let knowledge = Knowledge::load(knowledge_dir.path()).unwrap();
     let werk = Werk::new();
     werk.set_dir(results_dir.path().to_path_buf())
         .set_policy(Policy {
@@ -332,6 +335,7 @@ pub async fn run_one(
             .provider(provider.clone())
             .model("mock")
             .role("test")
+            .knowledge(&knowledge)
             .tool(TaskTool),
     );
 

--- a/crates/agentwerk/src/tools/knowledge.rs
+++ b/crates/agentwerk/src/tools/knowledge.rs
@@ -12,8 +12,8 @@ use crate::prompts::directives::{
 use super::tool::{Tool, ToolContext};
 
 /// The model's four-action handle on a `Knowledge` store:
-/// `write`, `read`, `remove`, `list`. Registered automatically on every
-/// agent; `Agent::knowledge` rebinds it to the passed store.
+/// `write`, `read`, `remove`, `list`. `Agent::knowledge` registers it with
+/// the passed store.
 ///
 /// # Examples
 ///


### PR DESCRIPTION
## Make `KnowledgeTool` opt in

### Purpose

- New agents should expose only caller-selected tools
- Automatic `KnowledgeTool` access permits unintended store mutations
- Shared knowledge remains available through explicit configuration

### What changed

- `Agent::new()` no longer registers `KnowledgeTool`
- `.knowledge(store)` binds the store and registers `KnowledgeTool`
- Rust and Python documentation describe the opt-in contract

### Examples

```rust
let agent = Agent::new();
```

```python
agent = Agent().knowledge(store)
```