### PR TITLE
Align README terminology and reference structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,8 +479,7 @@ werk.add_task(Task::labeled("report", "Write the board report."));
 
 agentwerk fills placeholders in the role and task just before each task's first model request. Newly added tasks use the latest template values and results.
 
-<details>
-<summary>Template reference</summary>
+#### Template reference
 
 | Expression | Output |
 |---|---|
@@ -493,8 +492,6 @@ agentwerk fills placeholders in the role and task just before each task's first 
 | `{{ readable(results: AQL) }}` | Matching results as a readable outline. |
 
 `{ name }` stays unchanged. To output the literal text `{{ name }}`, write `{{{{ name }}}}`.
-
-</details>
 
 #### Readable results
 
@@ -724,7 +721,10 @@ let agent = Agent::new()
     .tool(CommandTool::new("git").allow("git *"));
 ```
 
-### FinishTool
+<details>
+<summary>Tool reference</summary>
+
+#### FinishTool
 
 Agents use `FinishTool` to end their task and share their outcomes:
 
@@ -735,12 +735,9 @@ Agents use `FinishTool` to end their task and share their outcomes:
 }
 ```
 
-To return an object result, the agent must call `FinishTool`. If the task has a result schema, the tool validates the object against it. For a non-interactive task without a schema, the agent can instead finish by responding with plain text.
+To return a result, the agent must call `FinishTool`. If the task has a result schema, the tool validates the object against it. For a non-interactive task without a schema, the agent can instead finish by responding with plain text.
 
 [Interactive agents](#interactive) are the exception: they have no `FinishTool` unless you add one explicitly with `.tool(FinishTool)`.
-
-<details>
-<summary>Tool reference</summary>
 
 | | Tool | Description |
 |-|------|-------------|
@@ -938,7 +935,7 @@ werk.emit_event(Event::new("index_refreshed"));
 
 #### Read events
 
-Events are saved to `.agentwerk/events.jsonl`, except `text_chunk_received`. These streamed fragments reach hooks but are not available to event queries.
+Events are saved to `.agentwerk/events.jsonl`, except `text_chunk_received`.
 
 | Method | Description |
 |--------|-------------|

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ werk.finish().await;
 werk.set_task_finished(&id, "answered")?;
 ```
 
-Replies pause the task in `in_progress`, and completion methods return when it pauses. Use `add_reply(id, content)` to resume and `set_task_finished(id, result)` to end the conversation. Intermediate replies arrive as [events](#events); `on_result` receives the final result.
+Replies pause the task in `in_progress`, and completion methods return when it pauses. Use `add_reply(id, content)` to resume and `set_task_finished(id, result)` to end the conversation. Intermediate replies arrive as [events](#events). `on_result` receives the final result.
 
 See [`Agent`](https://docs.rs/agentwerk/latest/agentwerk/agents/agent/struct.Agent.html).
 
@@ -332,9 +332,9 @@ werk.find_results("t-3");
 | **Search** | `field ~ text`, `field !~ text` | Include or exclude case-insensitive text. |
 | **Compare** | `field > value`, `>=`, `<`, `<=` | Compare a time field. |
 | **Combine** | `A AND B`, `A OR B`, `NOT A`, `(A OR B)` | Combine or group conditions. |
-| **Task label** | `scan`, `"needs review"` | Short for `task.label = scan`; quote labels containing spaces or query words. |
-| **Task ID** | `t-3` | Short for `task.id = t-3`; IDs take precedence over labels. |
-| **Sort** | `ORDER BY field DESC` | Sort matches; `ASC` is the default. |
+| **Task label** | `scan`, `"needs review"` | Short for `task.label = scan`. Quote labels containing spaces or query words. |
+| **Task ID** | `t-3` | Short for `task.id = t-3`. IDs take precedence over labels. |
+| **Sort** | `ORDER BY field DESC` | Sort matches. `ASC` is the default. |
 
 #### Fields
 
@@ -343,7 +343,7 @@ werk.find_results("t-3");
 | **Task** | `task.id`, `task.label`, `task.status`, `task.pending`, `task.cancelled`, `task.assignee`, `task.input`, `task.result`, `task.errors`, `task.created`, `task.started`, `task.finished`, `task.failed` |
 | **Event** | `event.name`, `event.agent_id`, `event.task_id`, `event.label`, `event.created`, `event.data` |
 
-Queries using both namespaces match events with their referenced tasks. Events without an existing task do not match. Joined matches default to event-log order; `ORDER BY` accepts task or event fields.
+Queries using both namespaces match events with their referenced tasks. Events without an existing task do not match. Joined matches default to event-log order. `ORDER BY` accepts task or event fields.
 
 Result finders return raw results where `task.result` is present. They select finished tasks unless the query specifies another status.
 
@@ -353,9 +353,9 @@ Completion methods and `cancel_tasks` also accept AQL. Event and joined queries 
 
 Missing values do not match `!=`. Include unlabeled tasks with `task.label IS EMPTY OR task.label != scan`.
 
-Qualify fields in full expressions. Use parentheses when mixing `AND` and `OR`; `NOT` applies to the next condition or group. Query keywords ignore case; labels and IDs do not.
+Qualify fields in full expressions. Use parentheses when mixing `AND` and `OR`. `NOT` applies to the next condition or group. Query keywords ignore case. Labels and IDs do not.
 
-Times accept UTC dates such as `2026-08-30`, epoch milliseconds, or offsets such as `-30m`, `-2h`, `-7d`, and `-1w`. Offsets are resolved when a query is compiled; reusing a compiled query keeps its original cutoff.
+Times accept UTC dates such as `2026-08-30`, epoch milliseconds, or offsets such as `-30m`, `-2h`, `-7d`, and `-1w`. Offsets are resolved when a query is compiled. Reusing a compiled query keeps its original cutoff.
 
 Missing sort values come last in either direction. Tasks and results selected through events follow matching event order, with each task returned once. Events selected through tasks follow task order, then log order within each task.
 
@@ -484,7 +484,7 @@ agentwerk fills placeholders in the role and task just before each task's first 
 | Expression | Output |
 |---|---|
 | `{{ name }}` | The value assigned to `name`. |
-| `{{ result: AQL }}` | The first result; strings as text, other values as compact JSON. |
+| `{{ result: AQL }}` | The first result. Strings appear as text and other values as compact JSON. |
 | `{{ results: AQL }}` | A compact JSON array of matching results. |
 | `{{ result_path: AQL }}` | The absolute path of the first matching result file. |
 | `{{ result_paths: AQL }}` | A JSON array of absolute result file paths. |
@@ -576,7 +576,7 @@ werk.add_task(Task::new("Write a report.").schema(schema));
 <details>
 <summary>Schema reference</summary>
 
-Agentwerk corrects common result-formatting mistakes, such as a quoted number or a nested object encoded as JSON text. Schema-bound results must be objects; remaining schema violations trigger a retry, subject to `max_schema_retries`. Without a schema, a task may return any JSON value.
+Agentwerk corrects common result-formatting mistakes, such as a quoted number or a nested object encoded as JSON text. Schema-bound results must be objects. Remaining schema violations trigger a retry, subject to `max_schema_retries`. Without a schema, a task may return any JSON value.
 
 Use shallow, focused schemas for small models. Split complex work into tasks with separate schemas.
 
@@ -612,7 +612,7 @@ werk.set_policy(Policy {
 | `max_input_tokens` | Limit the total input tokens. |
 | `max_output_tokens` | Limit the total output tokens. |
 | `max_request_tokens` | Limit the output tokens of a single request. |
-| `max_schema_retries` | Limit consecutive failed tool calls or silent replies; a successful call resets the count. |
+| `max_schema_retries` | Limit consecutive failed tool calls or silent replies. A successful call resets the count. |
 | `max_request_retries` | Limit how often a failing request is retried. |
 | `request_retry_delay` | Set the base delay for exponential backoff between request retries. |
 | `compaction_threshold` | Compact once the next request would fill this share of the window. |
@@ -667,7 +667,7 @@ let agent = Agent::from_env()
 <details>
 <summary>Directive reference</summary>
 
-Built-in keys override recovery text; keys without overrides retain their defaults. Templates accept runtime values such as `{{ detail }}`, `{{ attempt }}`, and `{{ path }}`. Placeholders without a value remain unchanged.
+Built-in keys override recovery text. Keys without overrides retain their defaults. Templates accept runtime values such as `{{ detail }}`, `{{ attempt }}`, and `{{ path }}`. Placeholders without a value remain unchanged.
 
 See [prompts/directives](https://github.com/canvascomputing/agentwerk/tree/main/crates/agentwerk/src/prompts/directives) for the built-in text.
 
@@ -756,7 +756,7 @@ To return a result, the agent must call `FinishTool`. If the task has a result s
 
 #### Timeouts
 
-Override a tool's limit with `timeout(duration)`; zero disables it.
+Override a tool's limit with `timeout(duration)`. Zero disables it.
 
 ```rust
 use std::time::Duration;
@@ -792,7 +792,7 @@ The model supplies a name and optional JSON data:
 }
 ```
 
-Events carry the current task and agent context; see [Events](#events) for hooks and queries. Names are unrestricted; lowercase snake case is conventional.
+Events carry the current task and agent context. See [Events](#events) for hooks and queries. Names are unrestricted. Lowercase snake case is conventional.
 
 Only `task_finished` completes the current task. Its `data` is the result object:
 
@@ -954,14 +954,14 @@ Events are saved to `.agentwerk/events.jsonl`, except `text_chunk_received`.
 | `get_agent_id()` | Read the associated agent ID. |
 | `get_label()` | Read the associated task's label. |
 | `get_created_at()` | Read the timestamp in epoch milliseconds. |
-| `directive(value)` | Set directive metadata; this does not send an instruction to the model. |
+| `directive(value)` | Set directive metadata. This does not send an instruction to the model. |
 | `get_directive()` | Read the directive metadata. |
 
 When no event hook is installed, `event::default_logger()` logs events.
 
 #### Query events
 
-Query events with AQL or a predicate; see [Queries](#queries) for shared syntax.
+Query events with AQL or a predicate. See [Queries](#queries) for shared syntax.
 
 ```rust
 werk.find_events("event.name = tool_call_failed");
@@ -996,7 +996,7 @@ See [`Event`](https://docs.rs/agentwerk/latest/agentwerk/event/struct.Event.html
 | | `on_task(handler)` | Read task state changes. |
 | | `on_task_async(handler)` | Read task state changes in an async hook. |
 
-`on_result` runs synchronously on the agent; keep it brief. Use `on_result_async` for work that needs to await.
+`on_result` runs synchronously on the agent. Keep it brief. Use `on_result_async` for work that needs to await.
 
 Async hooks run while a completion method is waiting, and finish before it returns. `start()` alone does not run them. Do not call `finish`, `finish_task`, or `finish_tasks` inside an async hook: it can deadlock.
 
@@ -1034,7 +1034,7 @@ Pages use the Open Knowledge Format (OKF) and are stored at `./notes/pages/<slug
 | `get_pages().get_all()` | Get every page in the store. |
 | `clear()` | Remove every page from the store. |
 
-By default, prompts include up to 12,000 characters of the index; agents can read the rest from `index.md`. Pages are always saved in full.
+By default, prompts include up to 12,000 characters of the index. Agents can read the rest from `index.md`. Pages are always saved in full.
 
 Create entries in code:
 

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ See [`Agent`](https://docs.rs/agentwerk/latest/agentwerk/agents/agent/struct.Age
 
 ### Providers
 
-An LLM provider connects agents to Anthropic, OpenAI, Mistral, or a LiteLLM proxy.
+Connect agents to Anthropic, OpenAI, Mistral, or a LiteLLM proxy.
 
 ```rust
 use agentwerk::providers::Anthropic;
@@ -271,13 +271,13 @@ werk.add_task(Task::labeled("report", "Write up the ranking."));
 | | `set_task_finished(id, result)` | Finish a task with a result. |
 | | `set_task_failed(id)` | Fail a task. |
 | **Observe** | `on_event(handler)` | Read every event as it is emitted. |
-| | `on_event_async(handler)` | Read every event in an async handler. |
+| | `on_event_async(handler)` | Read every event in an async hook. |
 | | `on_result(handler)` | Read every finished task together with its result. |
-| | `on_result_async(handler)` | Read every finished task and result in an async handler. |
+| | `on_result_async(handler)` | Read every finished task and result in an async hook. |
 | | `on_failure(handler)` | Read every failure together with its task. |
-| | `on_failure_async(handler)` | Read every failure and task in an async handler. |
+| | `on_failure_async(handler)` | Read every failure and task in an async hook. |
 | | `on_task(handler)` | Read task state changes. |
-| | `on_task_async(handler)` | Read task state changes in an async handler. |
+| | `on_task_async(handler)` | Read task state changes in an async hook. |
 | **Run** | `start()` | Keep processing tasks in the background. |
 | | `finish_task(query)` | Wait for all matches and return the first result in query order. |
 | | `finish_tasks(query)` | Wait for matching tasks and get their results. |
@@ -440,10 +440,10 @@ See [`Task`](https://docs.rs/agentwerk/latest/agentwerk/struct.Task.html).
 Agents can pass work and results in five ways:
 
 1. **Result hook**: `on_result` creates follow-up tasks from completed work.
-2. **Template values**: fill placeholders with shared values or AQL-selected results.
-3. **Knowledge**: the `knowledge` tool shares durable pages between agents.
-4. **Task tool**: the `task` tool reads any finished task's result by ID.
-5. **Read result file**: the `read_file` tool opens a task's `result.json` in the session directory.
+2. **Template values**: enrich prompts with template strings or AQL-selected results.
+3. **KnowledgeTool**: shares durable pages between agents.
+4. **TaskTool**: reads any finished task's result by ID.
+5. **ReadFileTool**: opens a task's `result.json` in the session directory.
 
 <details>
 <summary>Result-sharing examples</summary>
@@ -519,7 +519,7 @@ Results such as `{"title":"Market","updates":["one","two"]}` render as:
 
 Nulls and empty collections do not appear.
 
-#### 3. Knowledge
+#### 3. KnowledgeTool
 
 Hand both agents one store, and either can write a page the other reads:
 
@@ -532,7 +532,7 @@ let writer = Agent::from_env().label("report").knowledge(&store);
 analyst.add_task("Rank the products by value, then save the ranking to your knowledge.");
 ```
 
-#### 4. Task tool
+#### 4. TaskTool
 
 Give the writer `TaskTool`, and it reads what any finished task produced, by ID:
 
@@ -544,7 +544,7 @@ let writer = Agent::from_env()
 writer.add_task("Read the result of t-1, then write the board report.");
 ```
 
-#### 5. Read result file
+#### 5. ReadFileTool
 
 Give the writer `ReadFileTool` instead, and it opens the result file named at the end of its task:
 
@@ -771,10 +771,10 @@ let patient_fetch = FetchTool::new().timeout(Duration::ZERO);
 
 | Tool | Default timeout |
 |------|-----------------|
-| Custom tools | None |
 | `FetchTool` | 60 seconds |
 | `GrepTool` | 180 seconds |
 | `CommandTool` | The call's `timeout_ms`, or 120 seconds if omitted |
+| All other tools | None |
 
 #### EventTool
 
@@ -795,7 +795,7 @@ The model supplies a name and optional JSON data:
 }
 ```
 
-Events carry the current task and agent context; see [Events](#events) for handlers and queries. Names are unrestricted; lowercase snake case is conventional.
+Events carry the current task and agent context; see [Events](#events) for hooks and queries. Names are unrestricted; lowercase snake case is conventional.
 
 Only `task_finished` completes the current task. Its `data` is the result object:
 
@@ -869,20 +869,17 @@ See [`Tool`](https://docs.rs/agentwerk/latest/agentwerk/tools/struct.Tool.html).
 
 ## Events
 
-Events record what agents, tools, and LLM providers do during execution.
+Events provide detailed observability into agent behavior during execution. Register hooks to react to every event, finished result, failure, or task state change:
 
 ```rust
-use agentwerk::Event;
-
-werk.on_event(|_, event| {
-    if event.get_name() == Event::TASK_FINISHED {
-        eprintln!("{}", event.get_data()["answer"]);
-    }
-});
+werk.on_event(|_, event| eprintln!("event: {}", event.get_name()));
+werk.on_result(|_, task, result| println!("{}: {result}", task.get_id()));
+werk.on_failure(|_, event, task| eprintln!("{}: {}", task.get_id(), event.get_name()));
+werk.on_task(|_, event, task| eprintln!("{}: {}", task.get_id(), event.get_name()));
 ```
 
 <details>
-<summary>Event reference</summary>
+<summary>Event and hook reference</summary>
 
 #### Event names
 
@@ -941,7 +938,7 @@ werk.emit_event(Event::new("index_refreshed"));
 
 #### Read events
 
-Events are saved to `.agentwerk/events.jsonl`, except `text_chunk_received`. These streamed fragments reach handlers but are not available to event queries.
+Events are saved to `.agentwerk/events.jsonl`, except `text_chunk_received`. These streamed fragments reach hooks but are not available to event queries.
 
 | Method | Description |
 |--------|-------------|
@@ -963,7 +960,7 @@ Events are saved to `.agentwerk/events.jsonl`, except `text_chunk_received`. The
 | `directive(value)` | Set directive metadata; this does not send an instruction to the model. |
 | `get_directive()` | Read the directive metadata. |
 
-When no event handler is installed, `event::default_logger()` logs events.
+When no event hook is installed, `event::default_logger()` logs events.
 
 #### Query events
 
@@ -989,63 +986,22 @@ Use `IS EMPTY` to find events without agent, task, or label context. `event.data
 
 See [`Event`](https://docs.rs/agentwerk/latest/agentwerk/event/struct.Event.html) and [`Werk`](https://docs.rs/agentwerk/latest/agentwerk/struct.Werk.html).
 
-</details>
-
-### Hooks
-
-A hook runs your function when an event, result, failure, or task state change occurs.
-
-```rust
-werk.on_failure(|werk, _, failed| {
-    if failed.get_label() == Some("scan") {
-        werk.add_task(Task::labeled("triage", failed.get_task().clone()));
-    }
-});
-```
-
-<details>
-<summary>Hook reference</summary>
+#### Hooks
 
 | | Method | Description |
 |-|--------|-------------|
 | **Observe** | `on_event(handler)` | Read every event as it is emitted. |
-| | `on_event_async(handler)` | Read every event in an async handler. |
+| | `on_event_async(handler)` | Read every event in an async hook. |
 | | `on_result(handler)` | Read every finished task together with its result. |
-| | `on_result_async(handler)` | Read every finished task and result in an async handler. |
+| | `on_result_async(handler)` | Read every finished task and result in an async hook. |
 | | `on_failure(handler)` | Read every failure together with its task. |
-| | `on_failure_async(handler)` | Read every failure and task in an async handler. |
+| | `on_failure_async(handler)` | Read every failure and task in an async hook. |
 | | `on_task(handler)` | Read task state changes. |
-| | `on_task_async(handler)` | Read task state changes in an async handler. |
-
-Save replies of every finished task as a training example:
-
-```rust
-werk.on_task(|werk, event, task| {
-    if event.get_name() == Event::TASK_FINISHED {
-        let model = werk.get_model_for_agent(event.get_agent_id());
-        let _ = Trajectory::from_task(event.get_agent_id(), model.as_deref(), task)
-            .save("datasets");
-    }
-});
-```
-
-#### Async handlers
+| | `on_task_async(handler)` | Read task state changes in an async hook. |
 
 `on_result` runs synchronously on the agent; keep it brief. Use `on_result_async` for work that needs to await.
 
 Async hooks run while a completion method is waiting, and finish before it returns. `start()` alone does not run them. Do not call `finish`, `finish_task`, or `finish_tasks` inside an async hook: it can deadlock.
-
-```rust
-let findings = Arc::clone(&database);
-werk.on_result_async(move |_, task, result| {
-    let findings = Arc::clone(&findings);
-    async move {
-        let _ = findings.insert(task.get_id(), &result).await;
-    }
-});
-```
-
-See [`Werk`](https://docs.rs/agentwerk/latest/agentwerk/struct.Werk.html).
 
 </details>
 

--- a/crates/agentwerk-py/README.md
+++ b/crates/agentwerk-py/README.md
@@ -173,7 +173,7 @@ await werk.finish()
 werk.set_task_finished(id, "answered")
 ```
 
-Replies pause the task in `in_progress`, and completion methods return when it pauses. Use `add_reply(id, content)` to resume and `set_task_finished(id, result)` to end the conversation. Intermediate replies arrive as [events](#events); `on_result` receives the final result.
+Replies pause the task in `in_progress`, and completion methods return when it pauses. Use `add_reply(id, content)` to resume and `set_task_finished(id, result)` to end the conversation. Intermediate replies arrive as [events](#events). `on_result` receives the final result.
 
 See [`Agent`](https://docs.rs/agentwerk/latest/agentwerk/agents/agent/struct.Agent.html).
 
@@ -347,9 +347,9 @@ werk.find_results("t-3")
 | **Search** | `field ~ text`, `field !~ text` | Include or exclude case-insensitive text. |
 | **Compare** | `field > value`, `>=`, `<`, `<=` | Compare a time field. |
 | **Combine** | `A AND B`, `A OR B`, `NOT A`, `(A OR B)` | Combine or group conditions. |
-| **Task label** | `scan`, `"needs review"` | Short for `task.label = scan`; quote labels containing spaces or query words. |
-| **Task ID** | `t-3` | Short for `task.id = t-3`; IDs take precedence over labels. |
-| **Sort** | `ORDER BY field DESC` | Sort matches; `ASC` is the default. |
+| **Task label** | `scan`, `"needs review"` | Short for `task.label = scan`. Quote labels containing spaces or query words. |
+| **Task ID** | `t-3` | Short for `task.id = t-3`. IDs take precedence over labels. |
+| **Sort** | `ORDER BY field DESC` | Sort matches. `ASC` is the default. |
 
 #### Fields
 
@@ -358,7 +358,7 @@ werk.find_results("t-3")
 | **Task** | `task.id`, `task.label`, `task.status`, `task.pending`, `task.cancelled`, `task.assignee`, `task.input`, `task.result`, `task.errors`, `task.created`, `task.started`, `task.finished`, `task.failed` |
 | **Event** | `event.name`, `event.agent_id`, `event.task_id`, `event.label`, `event.created`, `event.data` |
 
-Queries using both namespaces match events with their referenced tasks. Events without an existing task do not match. Joined matches default to event-log order; `ORDER BY` accepts task or event fields.
+Queries using both namespaces match events with their referenced tasks. Events without an existing task do not match. Joined matches default to event-log order. `ORDER BY` accepts task or event fields.
 
 Result finders return raw results where `task.result` is present. They select finished tasks unless the query specifies another status.
 
@@ -368,9 +368,9 @@ Completion methods and `cancel_tasks` also accept AQL. Event and joined queries 
 
 Missing values do not match `!=`. Include unlabeled tasks with `task.label IS EMPTY OR task.label != scan`.
 
-Qualify fields in full expressions. Use parentheses when mixing `AND` and `OR`; `NOT` applies to the next condition or group. Query keywords ignore case; labels and IDs do not.
+Qualify fields in full expressions. Use parentheses when mixing `AND` and `OR`. `NOT` applies to the next condition or group. Query keywords ignore case. Labels and IDs do not.
 
-Times accept UTC dates such as `2026-08-30`, epoch milliseconds, or offsets such as `-30m`, `-2h`, `-7d`, and `-1w`. Offsets are resolved when a query is compiled; reusing a compiled query keeps its original cutoff.
+Times accept UTC dates such as `2026-08-30`, epoch milliseconds, or offsets such as `-30m`, `-2h`, `-7d`, and `-1w`. Offsets are resolved when a query is compiled. Reusing a compiled query keeps its original cutoff.
 
 Missing sort values come last in either direction. Tasks and results selected through events follow matching event order, with each task returned once. Events selected through tasks follow task order, then log order within each task.
 
@@ -505,7 +505,7 @@ agentwerk fills placeholders in the role and task just before each task's first 
 | Expression | Output |
 |---|---|
 | `{{ name }}` | The value assigned to `name`. |
-| `{{ result: AQL }}` | The first result; strings as text, other values as compact JSON. |
+| `{{ result: AQL }}` | The first result. Strings appear as text and other values as compact JSON. |
 | `{{ results: AQL }}` | A compact JSON array of matching results. |
 | `{{ result_path: AQL }}` | The absolute path of the first matching result file. |
 | `{{ result_paths: AQL }}` | A JSON array of absolute result file paths. |
@@ -595,7 +595,7 @@ werk.add_task(Task("Write a report.", schema=schema))
 <details>
 <summary>Schema reference</summary>
 
-Agentwerk corrects common result-formatting mistakes, such as a quoted number or a nested object encoded as JSON text. Schema-bound results must be objects; remaining schema violations trigger a retry, subject to `max_schema_retries`. Without a schema, a task may return any JSON value.
+Agentwerk corrects common result-formatting mistakes, such as a quoted number or a nested object encoded as JSON text. Schema-bound results must be objects. Remaining schema violations trigger a retry, subject to `max_schema_retries`. Without a schema, a task may return any JSON value.
 
 Use shallow, focused schemas for small models. Split complex work into tasks with separate schemas.
 
@@ -626,7 +626,7 @@ werk.set_policy(Policy(max_turns=40, max_time=300.0))
 | `max_input_tokens` | Limit the total input tokens. |
 | `max_output_tokens` | Limit the total output tokens. |
 | `max_request_tokens` | Limit the output tokens of a single request. |
-| `max_schema_retries` | Limit consecutive failed tool calls or silent replies; a successful call resets the count. |
+| `max_schema_retries` | Limit consecutive failed tool calls or silent replies. A successful call resets the count. |
 | `max_request_retries` | Limit how often a failing request is retried. |
 | `request_retry_delay` | Set the base delay for exponential backoff between request retries. |
 | `compaction_threshold` | Compact once the next request would fill this share of the window. |
@@ -686,7 +686,7 @@ agent = (
 <details>
 <summary>Directive reference</summary>
 
-Built-in keys override recovery text; keys without overrides retain their defaults. Templates accept runtime values such as `{{ detail }}`, `{{ attempt }}`, and `{{ path }}`. Placeholders without a value remain unchanged.
+Built-in keys override recovery text. Keys without overrides retain their defaults. Templates accept runtime values such as `{{ detail }}`, `{{ attempt }}`, and `{{ path }}`. Placeholders without a value remain unchanged.
 
 See [prompts/directives](https://github.com/canvascomputing/agentwerk/tree/main/crates/agentwerk/src/prompts/directives) for the built-in text.
 
@@ -777,7 +777,7 @@ To return a result, the agent must call `FinishTool`. If the task has a result s
 
 #### Timeouts
 
-Override a tool's limit with `timeout(seconds)`; zero disables it.
+Override a tool's limit with `timeout(seconds)`. Zero disables it.
 
 ```python
 from agentwerk import FetchTool
@@ -814,7 +814,7 @@ The model supplies a name and optional JSON data:
 }
 ```
 
-Events carry the current task and agent context; see [Events](#events) for hooks and queries. Names are unrestricted; lowercase snake case is conventional.
+Events carry the current task and agent context. See [Events](#events) for hooks and queries. Names are unrestricted. Lowercase snake case is conventional.
 
 Only `task_finished` completes the current task. Its `data` is the result dictionary:
 
@@ -967,14 +967,14 @@ Events are saved to `.agentwerk/events.jsonl`, except `text_chunk_received`.
 | `get_agent_id()` | Read the associated agent ID. |
 | `get_label()` | Read the associated task's label. |
 | `get_created_at()` | Read the timestamp in epoch milliseconds. |
-| `directive(value)` | Set directive metadata; this does not send an instruction to the model. |
+| `directive(value)` | Set directive metadata. This does not send an instruction to the model. |
 | `get_directive()` | Read the directive metadata. |
 
 The default logger runs when no event hook is installed.
 
 #### Query events
 
-Query events with AQL or a predicate; see [Queries](#queries) for shared syntax.
+Query events with AQL or a predicate. See [Queries](#queries) for shared syntax.
 
 ```python
 werk.find_events("event.name = tool_call_failed")
@@ -1009,7 +1009,7 @@ See [`Event`](https://docs.rs/agentwerk/latest/agentwerk/event/struct.Event.html
 | | `on_task(handler)` | Read task state changes. |
 | | `on_task_async(handler)` | Read task state changes in an async hook. |
 
-`on_result` runs synchronously on the agent; keep it brief. Use `on_result_async` for work that needs to await.
+`on_result` runs synchronously on the agent. Keep it brief. Use `on_result_async` for work that needs to await.
 
 Async hooks run while a completion method is waiting, and finish before it returns. `start()` alone does not run them. Do not call `finish`, `finish_task`, or `finish_tasks` inside an async hook: it can deadlock. Python hooks use `async def` and run on the caller's event loop.
 
@@ -1047,7 +1047,7 @@ Pages use the Open Knowledge Format (OKF) and are stored at `./notes/pages/<slug
 | `get_pages().get_all()` | Get every page in the store. |
 | `clear()` | Remove every page from the store. |
 
-By default, prompts include up to 12,000 characters of the index; agents can read the rest from `index.md`. Pages are always saved in full.
+By default, prompts include up to 12,000 characters of the index. Agents can read the rest from `index.md`. Pages are always saved in full.
 
 Create entries in code:
 

--- a/crates/agentwerk-py/README.md
+++ b/crates/agentwerk-py/README.md
@@ -500,8 +500,7 @@ werk.add_task(Task("Write the board report.", label="report"))
 
 agentwerk fills placeholders in the role and task just before each task's first model request. Newly added tasks use the latest template values and results.
 
-<details>
-<summary>Template reference</summary>
+#### Template reference
 
 | Expression | Output |
 |---|---|
@@ -514,8 +513,6 @@ agentwerk fills placeholders in the role and task just before each task's first 
 | `{{ readable(results: AQL) }}` | Matching results as a readable outline. |
 
 `{ name }` stays unchanged. To output the literal text `{{ name }}`, write `{{{{ name }}}}`.
-
-</details>
 
 #### Readable results
 
@@ -745,7 +742,10 @@ agent = (
 )
 ```
 
-### FinishTool
+<details>
+<summary>Tool reference</summary>
+
+#### FinishTool
 
 Agents use `FinishTool` to end their task and share their outcomes:
 
@@ -756,12 +756,9 @@ Agents use `FinishTool` to end their task and share their outcomes:
 }
 ```
 
-To return an object result, the agent must call `FinishTool`. If the task has a result schema, the tool validates the object against it. For a non-interactive task without a schema, the agent can instead finish by responding with plain text.
+To return a result, the agent must call `FinishTool`. If the task has a result schema, the tool validates the object against it. For a non-interactive task without a schema, the agent can instead finish by responding with plain text.
 
 [Interactive agents](#interactive) are the exception: they have no `FinishTool` unless you add one explicitly with `.tool(FinishTool())`.
-
-<details>
-<summary>Tool reference</summary>
 
 | | Tool | Description |
 |-|------|-------------|
@@ -951,7 +948,7 @@ werk.emit_event(Event("index_refreshed"))
 
 #### Read events
 
-Events are saved to `.agentwerk/events.jsonl`, except `text_chunk_received`. These streamed fragments reach hooks but are not available to event queries.
+Events are saved to `.agentwerk/events.jsonl`, except `text_chunk_received`.
 
 | Method | Description |
 |--------|-------------|

--- a/crates/agentwerk-py/README.md
+++ b/crates/agentwerk-py/README.md
@@ -181,7 +181,7 @@ See [`Agent`](https://docs.rs/agentwerk/latest/agentwerk/agents/agent/struct.Age
 
 ### Providers
 
-An LLM provider connects agents to Anthropic, OpenAI, Mistral, or a LiteLLM proxy.
+Connect agents to Anthropic, OpenAI, Mistral, or a LiteLLM proxy.
 
 ```python
 from agentwerk import Agent, Anthropic
@@ -286,13 +286,13 @@ werk.add_task(Task("Write up the ranking.", label="report"))
 | | `set_task_finished(id, result)` | Finish a task with a result. |
 | | `set_task_failed(id)` | Fail a task. |
 | **Observe** | `on_event(handler)` | Read every event as it is emitted. |
-| | `on_event_async(handler)` | Read every event in an async handler. |
+| | `on_event_async(handler)` | Read every event in an async hook. |
 | | `on_result(handler)` | Read every finished task together with its result. |
-| | `on_result_async(handler)` | Read every finished task and result in an async handler. |
+| | `on_result_async(handler)` | Read every finished task and result in an async hook. |
 | | `on_failure(handler)` | Read every failure together with its task. |
-| | `on_failure_async(handler)` | Read every failure and task in an async handler. |
+| | `on_failure_async(handler)` | Read every failure and task in an async hook. |
 | | `on_task(handler)` | Read task state changes. |
-| | `on_task_async(handler)` | Read task state changes in an async handler. |
+| | `on_task_async(handler)` | Read task state changes in an async hook. |
 | **Run** | `start()` | Keep processing tasks in the background. |
 | | `finish_task(query)` | Wait for all matches and return the first result in query order. |
 | | `finish_tasks(query)` | Wait for matching tasks and get their results. |
@@ -457,10 +457,10 @@ See [`Task`](https://docs.rs/agentwerk/latest/agentwerk/struct.Task.html).
 Agents can pass work and results in five ways:
 
 1. **Result hook**: `on_result` creates follow-up tasks from completed work.
-2. **Template values**: fill placeholders with shared values or AQL-selected results.
-3. **Knowledge**: the `knowledge` tool shares durable pages between agents.
-4. **Task tool**: the `task` tool reads any finished task's result by ID.
-5. **Read result file**: the `read_file` tool opens a task's `result.json` in the session directory.
+2. **Template values**: enrich prompts with template strings or AQL-selected results.
+3. **KnowledgeTool**: shares durable pages between agents.
+4. **TaskTool**: reads any finished task's result by ID.
+5. **ReadFileTool**: opens a task's `result.json` in the session directory.
 
 <details>
 <summary>Result-sharing examples</summary>
@@ -540,7 +540,7 @@ Results such as `{"title":"Market","updates":["one","two"]}` render as:
 
 Nulls and empty collections do not appear.
 
-#### 3. Knowledge
+#### 3. KnowledgeTool
 
 Hand both agents one store, and either can write a page the other reads:
 
@@ -553,9 +553,9 @@ writer = Agent.from_env().label("report").knowledge(store)
 analyst.add_task("Rank the products by value, then save the ranking to your knowledge.")
 ```
 
-#### 4. Task tool
+#### 4. TaskTool
 
-Give the writer `TaskTool()`, and it reads what any finished task produced, by ID:
+Give the writer `TaskTool`, and it reads what any finished task produced, by ID:
 
 ```python
 writer = Agent.from_env().label("report").tool(TaskTool())
@@ -563,9 +563,9 @@ writer = Agent.from_env().label("report").tool(TaskTool())
 writer.add_task("Read the result of t-1, then write the board report.")
 ```
 
-#### 5. Read result file
+#### 5. ReadFileTool
 
-Give the writer `ReadFileTool()` instead, and it opens the result file named at the end of its task:
+Give the writer `ReadFileTool` instead, and it opens the result file named at the end of its task:
 
 ```python
 writer = Agent.from_env().label("report").tool(ReadFileTool())
@@ -747,7 +747,7 @@ agent = (
 
 ### FinishTool
 
-Agents use `FinishTool()` to end their task and share their outcomes:
+Agents use `FinishTool` to end their task and share their outcomes:
 
 ```json
 {
@@ -756,27 +756,27 @@ Agents use `FinishTool()` to end their task and share their outcomes:
 }
 ```
 
-To return an object result, the agent must call `FinishTool()`. If the task has a result schema, the tool validates the object against it. For a non-interactive task without a schema, the agent can instead finish by responding with plain text.
+To return an object result, the agent must call `FinishTool`. If the task has a result schema, the tool validates the object against it. For a non-interactive task without a schema, the agent can instead finish by responding with plain text.
 
-[Interactive agents](#interactive) are the exception: they have no `FinishTool()` unless you add one explicitly with `.tool(FinishTool())`.
+[Interactive agents](#interactive) are the exception: they have no `FinishTool` unless you add one explicitly with `.tool(FinishTool())`.
 
 <details>
 <summary>Tool reference</summary>
 
 | | Tool | Description |
 |-|------|-------------|
-| **File** | `ReadFileTool()` | Read a file with line numbers, offset, and limit. |
-| | `WriteFileTool()` | Create or overwrite a file. |
-| | `EditFileTool()` | Replace text in a file. |
-| **Search** | `GlobTool()` | Find files by pattern. |
-| | `GrepTool()` | Search file contents by regular expression, or by code shape with `syntax: "code"`. |
-| | `ListDirectoryTool()` | List files and directories. |
-| **Command** | `CommandTool(name)` | Give access to specific commands. |
-| **Web** | `FetchTool()` | Fetch a URL and read its body. |
-| **Events** | `EventTool()` | Publish an event. `task_finished` also completes the current task. |
-| **Tasks** | `FinishTool()` | Write the result for the current task and mark it finished. |
-| | `TaskTool()` | Read the Werk and create or edit tasks. |
-| **Knowledge** | `KnowledgeTool(store)` | Write, read, remove, or list pages in a knowledge store. |
+| **File** | `ReadFileTool` | Read a file with line numbers, offset, and limit. |
+| | `WriteFileTool` | Create or overwrite a file. |
+| | `EditFileTool` | Replace text in a file. |
+| **Search** | `GlobTool` | Find files by pattern. |
+| | `GrepTool` | Search file contents by regular expression, or by code shape with `syntax: "code"`. |
+| | `ListDirectoryTool` | List files and directories. |
+| **Command** | `CommandTool` | Give access to specific commands. |
+| **Web** | `FetchTool` | Fetch a URL and read its body. |
+| **Events** | `EventTool` | Publish an event. `task_finished` also completes the current task. |
+| **Tasks** | `FinishTool` | Write the result for the current task and mark it finished. |
+| | `TaskTool` | Read the Werk and create or edit tasks. |
+| **Knowledge** | `KnowledgeTool` | Write, read, remove, or list pages in a knowledge store. |
 
 #### Timeouts
 
@@ -791,16 +791,16 @@ patient_fetch = FetchTool().timeout(0)
 
 | Tool | Default timeout |
 |------|-----------------|
-| Custom tools | None |
 | `FetchTool` | 60 seconds |
 | `GrepTool` | 180 seconds |
 | `CommandTool` | The call's `timeout_ms`, or 120 seconds if omitted |
+| All other tools | None |
 
 When a Python tool times out, the agent stops waiting, but its worker thread may continue in the background.
 
 #### EventTool
 
-Give an agent `EventTool()` to let it publish custom events:
+Give an agent `EventTool` to let it publish custom events:
 
 ```python
 from agentwerk import EventTool
@@ -817,7 +817,7 @@ The model supplies a name and optional JSON data:
 }
 ```
 
-Events carry the current task and agent context; see [Events](#events) for handlers and queries. Names are unrestricted; lowercase snake case is conventional.
+Events carry the current task and agent context; see [Events](#events) for hooks and queries. Names are unrestricted; lowercase snake case is conventional.
 
 Only `task_finished` completes the current task. Its `data` is the result dictionary:
 
@@ -883,19 +883,17 @@ See [`Tool`](https://docs.rs/agentwerk/latest/agentwerk/tools/struct.Tool.html).
 
 ## Events
 
-Events record what agents, tools, and LLM providers do during execution.
+Events provide detailed observability into agent behavior during execution. Register hooks to react to every event, finished result, failure, or task state change:
 
 ```python
-def log(werk, event):
-    if event.get_name() == Event.TASK_FINISHED:
-        print(event.get_data().get("answer"))
-
-
-werk.on_event(log)
+werk.on_event(lambda _, event: print(f"event: {event.get_name()}"))
+werk.on_result(lambda _, task, result: print(f"{task.get_id()}: {result}"))
+werk.on_failure(lambda _, event, task: print(f"{task.get_id()}: {event.get_name()}"))
+werk.on_task(lambda _, event, task: print(f"{task.get_id()}: {event.get_name()}"))
 ```
 
 <details>
-<summary>Event reference</summary>
+<summary>Event and hook reference</summary>
 
 #### Event names
 
@@ -953,7 +951,7 @@ werk.emit_event(Event("index_refreshed"))
 
 #### Read events
 
-Events are saved to `.agentwerk/events.jsonl`, except `text_chunk_received`. These streamed fragments reach handlers but are not available to event queries.
+Events are saved to `.agentwerk/events.jsonl`, except `text_chunk_received`. These streamed fragments reach hooks but are not available to event queries.
 
 | Method | Description |
 |--------|-------------|
@@ -975,7 +973,7 @@ Events are saved to `.agentwerk/events.jsonl`, except `text_chunk_received`. The
 | `directive(value)` | Set directive metadata; this does not send an instruction to the model. |
 | `get_directive()` | Read the directive metadata. |
 
-The default logger runs when no event handler is installed.
+The default logger runs when no event hook is installed.
 
 #### Query events
 
@@ -1001,62 +999,22 @@ Use `IS EMPTY` to find events without agent, task, or label context. `event.data
 
 See [`Event`](https://docs.rs/agentwerk/latest/agentwerk/event/struct.Event.html) and [`Werk`](https://docs.rs/agentwerk/latest/agentwerk/struct.Werk.html).
 
-</details>
-
-### Hooks
-
-A hook runs your function when an event, result, failure, or task state change occurs.
-
-```python
-def triage(werk, event, failed):
-    if failed.get_label() == "scan":
-        werk.add_task(Task(failed.get_task(), label="triage"))
-
-
-werk.on_failure(triage)
-```
-
-<details>
-<summary>Hook reference</summary>
+#### Hooks
 
 | | Method | Description |
 |-|--------|-------------|
 | **Observe** | `on_event(handler)` | Read every event as it is emitted. |
-| | `on_event_async(handler)` | Read every event in an async handler. |
+| | `on_event_async(handler)` | Read every event in an async hook. |
 | | `on_result(handler)` | Read every finished task together with its result. |
-| | `on_result_async(handler)` | Read every finished task and result in an async handler. |
+| | `on_result_async(handler)` | Read every finished task and result in an async hook. |
 | | `on_failure(handler)` | Read every failure together with its task. |
-| | `on_failure_async(handler)` | Read every failure and task in an async handler. |
+| | `on_failure_async(handler)` | Read every failure and task in an async hook. |
 | | `on_task(handler)` | Read task state changes. |
-| | `on_task_async(handler)` | Read task state changes in an async handler. |
-
-Save replies of every finished task as a training example:
-
-```python
-def capture(werk, event, task):
-    if event.get_name() == Event.TASK_FINISHED:
-        model = werk.get_model_for_agent(event.get_agent_id())
-        Trajectory.from_task(event.get_agent_id(), model, task).save("datasets")
-
-
-werk.on_task(capture)
-```
-
-#### Async handlers
+| | `on_task_async(handler)` | Read task state changes in an async hook. |
 
 `on_result` runs synchronously on the agent; keep it brief. Use `on_result_async` for work that needs to await.
 
-Async hooks run while a completion method is waiting, and finish before it returns. `start()` alone does not run them. Do not call `finish`, `finish_task`, or `finish_tasks` inside an async hook: it can deadlock. Python handlers use `async def` and run on the caller's event loop.
-
-```python
-async def store(werk, task, result):
-    await database.insert(task.get_id(), result)
-
-
-werk.on_result_async(store)
-```
-
-See [`Werk`](https://docs.rs/agentwerk/latest/agentwerk/struct.Werk.html).
+Async hooks run while a completion method is waiting, and finish before it returns. `start()` alone does not run them. Do not call `finish`, `finish_task`, or `finish_tasks` inside an async hook: it can deadlock. Python hooks use `async def` and run on the caller's event loop.
 
 </details>
 
@@ -1076,7 +1034,7 @@ alice = Agent().knowledge(store)
 bob = Agent().knowledge(store)
 ```
 
-Calling `.knowledge(store)` registers a `KnowledgeTool(store)` bound to that store, so the agent can read and update its shared pages.
+Calling `.knowledge(store)` registers a `KnowledgeTool` bound to that store, so the agent can read and update its shared pages.
 
 <details>
 <summary>Knowledge reference</summary>


### PR DESCRIPTION
## Align README terminology and reference structure

### Purpose

- Rust and Python guides need matching terminology
- Tool references need one public naming style
- Completion caveats belong with the complete tool reference
- Event guidance needs one overview of agent behavior

### What changed

- Tool references use `ReadFileTool`-style names in Rust and Python
- `FinishTool` behavior and timeout defaults live inside `Tool reference`
- `Template reference` stays visible inside result-sharing details
- Event hooks and queries share one observability reference
- Reference prose uses matching sentence structure in both guides

### Examples

```rust
use agentwerk::{tools::ReadFileTool, Agent};
let agent = Agent::new().tool(ReadFileTool);
```

```python
from agentwerk import Agent, ReadFileTool
agent = Agent().tool(ReadFileTool())
```
