### PR TITLE
api: add JSON paths to result templates

### DIFF
--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -1035,6 +1035,7 @@ Not bound: prompt preparation and rendering are private Werk behavior.
 |----------|------|------------|
 | Rust | `pub(crate) mod directives` | crate |
 | Rust | `mod prompt` | private |
+| Rust | `mod json_path` | private |
 | Rust | re-exports `RenderError` inside the crate | crate |
 | Rust | `CONTEXT_TEMPLATE: string` | private |
 | Rust | `retry_directive(detail: string): string` | crate |
@@ -1059,16 +1060,74 @@ Not bound: prompt preparation and rendering are private Werk behavior.
 | Rust | `render_template(template: string, resolve: (expression: string) => string? throws RenderError): string throws RenderError` | private |
 | Rust | `render_values(template: string, named_value: (name: string) => string?): string` | private |
 | Rust | `resolve_expression(werk: Werk, expression: string, named_value: (name: string) => string?): string? throws RenderError` | private |
+| Rust | `resolve_expression_value(werk: Werk, expression: string, named_value: (name: string) => string?): string? throws string` | private |
+| Rust | `resolve_result(werk: Werk, result: ResultExpression, named_value: (name: string) => string?): json throws string` | private |
 | Rust | `expand_nested(expression: string, named_value: (name: string) => string?): [string, boolean] throws string` | private |
 | Rust | `readable_expression(expression: string): string? throws string` | private |
-| Rust | `result_expression(expression: string): [string, string]?` | private |
+| Rust | `ResultKind` | private |
+| Rust | `.Result` | private |
+| Rust | `.Results` | private |
+| Rust | `.ResultPath` | private |
+| Rust | `.ResultPaths` | private |
+| Rust | `.parse(source: string): ResultKind?` | private |
+| Rust | `.selects_values(): boolean` | private |
+| Rust | `.is_plural(): boolean` | private |
+| Rust | `.uses_file_paths(): boolean` | private |
+| Rust | `ResultExpression { kind: ResultKind, query: string, json_path: string? }` | private |
+| Rust | `result_expression(expression: string): ResultExpression?` | private |
+| Rust | `split_json_path(source: string): [string, string?]` | private |
+| Rust | `is_json_path_separator(source: string, byte_offset: number): boolean` | private |
 | Rust | `expression_end(body: string): number? throws string` | private |
-| Rust | `is_plural(kind: string): boolean` | private |
-| Rust | `select_result(werk: Werk, kind: string, query: string): json throws string` | private |
-| Rust | `result_text(value: json, plural: boolean): string` | private |
+| Rust | `select_result(werk: Werk, kind: ResultKind, query: string): json throws string` | private |
+| Rust | `result_text(value: json): string` | private |
 | Rust | `readable(value: json): string` | private |
 | Rust | `readable_lines(value: json, indent: number): string[]` | private |
 | Rust | `result_value(werk: Werk, task: Task, use_path: boolean): json throws string` | private |
+
+## `crates/agentwerk/src/prompts/json_path.rs`
+
+### Internal
+
+| Language | Item | Visibility |
+|----------|------|------------|
+| Rust | `JsonPath { steps: Step[] }` | super |
+| Rust | `.parse(source: string): this throws JsonPathError` | super |
+| Rust | `.evaluate(value: json): json` | super |
+| Rust | `Step` | private |
+| Rust | `.Field(string)` | private |
+| Rust | `.Index(number)` | private |
+| Rust | `.Slice { start: number?, stop: number?, step: number }` | private |
+| Rust | `.ArrayWildcard` | private |
+| Rust | `.ObjectWildcard` | private |
+| Rust | `.Flatten` | private |
+| Rust | `JsonPathError { message: string }` | super |
+| Rust | `.new(message: string): this` | private |
+| Rust | `impl Display for JsonPathError` | super |
+| Rust | `impl Error for JsonPathError` | super |
+| Rust | `Parser { source: string, byte_offset: number }` | private |
+| Rust | `.new(source: string): this` | private |
+| Rust | `.parse(): JsonPath throws JsonPathError` | private |
+| Rust | `.initial_step(): Step throws JsonPathError` | private |
+| Rust | `.field_step(): Step throws JsonPathError` | private |
+| Rust | `.identifier(): Step throws JsonPathError` | private |
+| Rust | `.quoted_field(): Step throws JsonPathError` | private |
+| Rust | `.bracket_step(): Step throws JsonPathError` | private |
+| Rust | `.peek(): string?` | private |
+| Rust | `.advance(character: string): void` | private |
+| Rust | `.next_character(): string?` | private |
+| Rust | `.unsupported(): JsonPathError` | private |
+| Rust | `parse_index(source: string): Step throws JsonPathError` | private |
+| Rust | `parse_slice(source: string): Step throws JsonPathError` | private |
+| Rust | `parse_optional_integer(source: string, description: string): number? throws JsonPathError` | private |
+| Rust | `parse_integer(source: string, description: string): number throws JsonPathError` | private |
+| Rust | `is_identifier_start(character: string): boolean` | private |
+| Rust | `is_identifier_continue(character: string): boolean` | private |
+| Rust | `evaluate(value: json, steps: Step[]): json` | private |
+| Rust | `evaluate_each(values: json[], remaining_steps: Step[]): json` | private |
+| Rust | `array_index(length: number, index: number): number?` | private |
+| Rust | `slice(values: json[], start: number?, stop: number?, step: number): json[]` | private |
+| Rust | `positive_bound(bound: number?, length: number, default: number): number` | private |
+| Rust | `negative_bound(bound: number?, length: number, default: number): number` | private |
 
 ## `crates/agentwerk/src/providers/anthropic.rs`
 

--- a/README.md
+++ b/README.md
@@ -486,10 +486,60 @@ agentwerk fills placeholders in the role and task just before each task's first 
 | `{{ name }}` | The value assigned to `name`. |
 | `{{ result: AQL }}` | The first result. Strings appear as text and other values as compact JSON. |
 | `{{ results: AQL }}` | A compact JSON array of matching results. |
+| `{{ result: AQL \| path }}` | A value selected from the first result. |
+| `{{ results: AQL \| path }}` | A value selected from the array of matching results. |
 | `{{ result_path: AQL }}` | The absolute path of the first matching result file. |
 | `{{ result_paths: AQL }}` | A JSON array of absolute result file paths. |
 | `{{ readable(result: AQL) }}` | The first result as a readable outline. |
 | `{{ readable(results: AQL) }}` | Matching results as a readable outline. |
+
+You can select results with AQL and use ` | path` to select a value from their JSON. You can also use paths with functions such as `readable`: `{{ readable(result: research | findings[*].summary) }}`.
+
+For example, given this `research` result:
+
+```json
+{
+  "company": {"name": "Canvas Computing"},
+  "findings": [{"summary": "one"}, {"summary": "two"}]
+}
+```
+
+This template:
+
+```text
+{{ result: research | company.name }}
+```
+
+Renders as:
+
+```text
+Canvas Computing
+```
+
+Using `readable` with a wildcard:
+
+```text
+{{ readable(result: research | findings[*].summary) }}
+```
+
+Renders as:
+
+```text
+- one
+- two
+```
+
+| Path | Selects |
+|---|---|
+| `company.name` | A nested field. |
+| `metadata."build-id"` | A field that requires JSON quoting. |
+| `findings[0]`, `findings[-1]` | An array element. |
+| `findings[1:4]`, `findings[::-1]` | An array slice. |
+| `findings[*].summary` | The `summary` field from each array element. |
+| `authors.*.name` | The `name` field from each object value, in unspecified order. |
+| `groups[].members` | The `members` field after flattening one array level. |
+
+Missing fields, incompatible types, and out-of-range indexes produce `null`. Wildcards, slices, and flattening omit null values when more path steps follow. Filters, comparisons, logical expressions, literals, multi-selects, functions, and additional pipes are not supported.
 
 `{ name }` stays unchanged. To output the literal text `{{ name }}`, write `{{{{ name }}}}`.
 

--- a/agentdocs/architecture.md
+++ b/agentdocs/architecture.md
@@ -19,6 +19,7 @@ The invariants that govern orchestration, tools, providers, events, and durable 
 - Delegate Agent setters to Werk. Import missing templates when binding; destination values win.
 - Parse double-brace syntax once in `prompts/prompt.rs`; use strict expression resolution for prompts and infallible named resolution for directives and runtime context. Never scan inserted values.
 - Allow one layer of named values inside result queries as raw AQL source. Keep `readable` limited to singular and plural result selectors, formatting their JSON values as an indented outline.
+- Split a whitespace-delimited JSON path from AQL before expanding named query values. Evaluate it through `prompts/json_path.rs` after selecting results and before plain or readable formatting.
 - Let Werk snapshot shared templates once when it prepares a role and initial string task, and report failures through `prompt_render_failed` before the first request.
 - Freeze the complete rendered system prompt at the task's first request. Reuse its earliest persisted system reply through later turns, retries, continuation, compaction, and reload.
 - Record the prepared task message and one frozen system prompt in replies. Keep shared templates as runtime configuration rather than persisted session data; ignore legacy captured template fields when loading tasks.

--- a/agentdocs/layout.md
+++ b/agentdocs/layout.md
@@ -20,7 +20,7 @@ Where code, tests, bindings, examples, and repository guidance live.
 - `src/event.rs` owns `Event`; `src/persistence.rs` owns shared file primitives and stays crate-private.
 - `src/agents/` owns agent configuration, tasks, orchestration, policy, queries, statistics, retries, compaction, and knowledge.
 - `src/providers/`, `src/tools/`, and `src/schemas/` own LLM providers, agent actions, and result validation.
-- `src/prompts/prompt.rs` owns Werk's single-pass template substitution and AQL expressions. `prompts/mod.rs` supplies runtime string values and directives; Agent and Task pass prompts to Werk.
+- `src/prompts/prompt.rs` owns Werk's single-pass template substitution and AQL expressions; `json_path.rs` parses and evaluates JSON paths over selected results. `prompts/mod.rs` supplies runtime string values and directives; Agent and Task pass prompts to Werk.
 
 ## Agents and Tasks
 

--- a/crates/agentwerk-py/README.md
+++ b/crates/agentwerk-py/README.md
@@ -507,10 +507,60 @@ agentwerk fills placeholders in the role and task just before each task's first 
 | `{{ name }}` | The value assigned to `name`. |
 | `{{ result: AQL }}` | The first result. Strings appear as text and other values as compact JSON. |
 | `{{ results: AQL }}` | A compact JSON array of matching results. |
+| `{{ result: AQL \| path }}` | A value selected from the first result. |
+| `{{ results: AQL \| path }}` | A value selected from the array of matching results. |
 | `{{ result_path: AQL }}` | The absolute path of the first matching result file. |
 | `{{ result_paths: AQL }}` | A JSON array of absolute result file paths. |
 | `{{ readable(result: AQL) }}` | The first result as a readable outline. |
 | `{{ readable(results: AQL) }}` | Matching results as a readable outline. |
+
+You can select results with AQL and use ` | path` to select a value from their JSON. You can also use paths with functions such as `readable`: `{{ readable(result: research | findings[*].summary) }}`.
+
+For example, given this `research` result:
+
+```json
+{
+  "company": {"name": "Canvas Computing"},
+  "findings": [{"summary": "one"}, {"summary": "two"}]
+}
+```
+
+This template:
+
+```text
+{{ result: research | company.name }}
+```
+
+Renders as:
+
+```text
+Canvas Computing
+```
+
+Using `readable` with a wildcard:
+
+```text
+{{ readable(result: research | findings[*].summary) }}
+```
+
+Renders as:
+
+```text
+- one
+- two
+```
+
+| Path | Selects |
+|---|---|
+| `company.name` | A nested field. |
+| `metadata."build-id"` | A field that requires JSON quoting. |
+| `findings[0]`, `findings[-1]` | An array element. |
+| `findings[1:4]`, `findings[::-1]` | An array slice. |
+| `findings[*].summary` | The `summary` field from each array element. |
+| `authors.*.name` | The `name` field from each object value, in unspecified order. |
+| `groups[].members` | The `members` field after flattening one array level. |
+
+Missing fields, incompatible types, and out-of-range indexes produce `null`. Wildcards, slices, and flattening omit null values when more path steps follow. Filters, comparisons, logical expressions, literals, multi-selects, functions, and additional pipes are not supported.
 
 `{ name }` stays unchanged. To output the literal text `{{ name }}`, write `{{{{ name }}}}`.
 

--- a/crates/agentwerk-py/tests/test_prompts.py
+++ b/crates/agentwerk-py/tests/test_prompts.py
@@ -55,6 +55,27 @@ async def test_direct_aql_expressions_resolve_results_and_paths(
     )
 
 
+async def test_result_json_paths_navigate_selected_json(werk, scripted_openai):
+    first = werk.add_task(aw.Task("first", label="research"))
+    second = werk.add_task(aw.Task("second", label="research"))
+    werk.set_task_finished(first, {"company": {"name": "Acme"}})
+    werk.set_task_finished(second, {"company": {"name": "Canvas"}})
+    scripted_openai.respond_with_tool("finish", {"answer": "done"})
+    werk.add_agent(
+        aw.Agent()
+        .provider(scripted_openai.provider())
+        .model("mock")
+        .role("{{ result: research | company.name }}")
+    )
+    werk.add_task("{{ results: research | [*].company.name }}")
+
+    await asyncio.wait_for(werk.finish(), timeout=5)
+
+    messages = scripted_openai.requests[0]["messages"]
+    assert messages[0]["content"] == "Acme"
+    assert messages[1]["content"] == '["Acme","Canvas"]'
+
+
 async def test_nested_query_values_and_readable_results(
     werk, scripted_openai
 ):

--- a/crates/agentwerk/src/agents/loop/render_tests.rs
+++ b/crates/agentwerk/src/agents/loop/render_tests.rs
@@ -387,6 +387,20 @@ async fn nested_render_failures_report_the_outer_expression() {
 }
 
 #[tokio::test]
+async fn json_path_failures_report_the_complete_template_expression() {
+    let (werk, _dir, _provider, id, _failures) =
+        fail_to_render(true, "{{ result: absent | items[?active] }}").await;
+
+    let task = werk.get_task(&id).unwrap();
+    let error = &task.get_errors()[0];
+    assert_eq!(error.get_name(), Event::PROMPT_RENDER_FAILED);
+    assert_eq!(
+        error.get_data()["expression"],
+        "result: absent | items[?active]"
+    );
+}
+
+#[tokio::test]
 async fn concurrent_tasks_receive_their_own_runtime_prompt_values() {
     let (werk, _dir) = session();
     let alpha = MockProvider::with_results(vec![Ok(write_result_response("alpha"))]);

--- a/crates/agentwerk/src/prompts/json_path.rs
+++ b/crates/agentwerk/src/prompts/json_path.rs
@@ -1,0 +1,563 @@
+//! Parses and evaluates the navigation subset used by result templates.
+
+use std::fmt;
+
+use serde_json::Value;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct JsonPath {
+    steps: Vec<Step>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Step {
+    Field(String),
+    Index(isize),
+    Slice {
+        start: Option<isize>,
+        stop: Option<isize>,
+        step: isize,
+    },
+    ArrayWildcard,
+    ObjectWildcard,
+    Flatten,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct JsonPathError {
+    message: String,
+}
+
+impl JsonPathError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for JsonPathError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for JsonPathError {}
+
+impl JsonPath {
+    pub(super) fn parse(source: &str) -> Result<Self, JsonPathError> {
+        Parser::new(source.trim()).parse()
+    }
+
+    pub(super) fn evaluate(&self, value: &Value) -> Value {
+        evaluate(value, &self.steps)
+    }
+}
+
+struct Parser<'a> {
+    source: &'a str,
+    byte_offset: usize,
+}
+
+impl<'a> Parser<'a> {
+    fn new(source: &'a str) -> Self {
+        Self {
+            source,
+            byte_offset: 0,
+        }
+    }
+
+    fn parse(mut self) -> Result<JsonPath, JsonPathError> {
+        if self.source.is_empty() {
+            return Err(JsonPathError::new("JSON path cannot be empty"));
+        }
+
+        let mut steps = vec![self.initial_step()?];
+        while let Some(character) = self.peek() {
+            match character {
+                '.' => {
+                    self.advance('.');
+                    steps.push(self.field_step()?);
+                }
+                '[' => steps.push(self.bracket_step()?),
+                _ => return Err(self.unsupported()),
+            }
+        }
+
+        Ok(JsonPath { steps })
+    }
+
+    fn initial_step(&mut self) -> Result<Step, JsonPathError> {
+        match self.peek() {
+            Some('"') => self.quoted_field(),
+            Some('*') => {
+                self.advance('*');
+                Ok(Step::ObjectWildcard)
+            }
+            Some('[') => self.bracket_step(),
+            Some(character) if is_identifier_start(character) => self.identifier(),
+            _ => Err(self.unsupported()),
+        }
+    }
+
+    fn field_step(&mut self) -> Result<Step, JsonPathError> {
+        match self.peek() {
+            Some('"') => self.quoted_field(),
+            Some('*') => {
+                self.advance('*');
+                Ok(Step::ObjectWildcard)
+            }
+            Some(character) if is_identifier_start(character) => self.identifier(),
+            _ => Err(JsonPathError::new(format!(
+                "expected a JSON path field at byte {}",
+                self.byte_offset
+            ))),
+        }
+    }
+
+    fn identifier(&mut self) -> Result<Step, JsonPathError> {
+        let start = self.byte_offset;
+        while let Some(character) = self.peek() {
+            if !is_identifier_continue(character) {
+                break;
+            }
+            self.advance(character);
+        }
+
+        Ok(Step::Field(
+            self.source[start..self.byte_offset].to_string(),
+        ))
+    }
+
+    fn quoted_field(&mut self) -> Result<Step, JsonPathError> {
+        let start = self.byte_offset;
+        self.advance('"');
+        let mut escaped = false;
+        while let Some(character) = self.next_character() {
+            if escaped {
+                escaped = false;
+                continue;
+            }
+            if character == '\\' {
+                escaped = true;
+                continue;
+            }
+            if character == '"' {
+                let encoded = &self.source[start..self.byte_offset];
+                let field = serde_json::from_str::<String>(encoded)
+                    .map_err(|_| JsonPathError::new("invalid quoted JSON path field"))?;
+                if field.is_empty() {
+                    return Err(JsonPathError::new(
+                        "quoted JSON path fields cannot be empty",
+                    ));
+                }
+                return Ok(Step::Field(field));
+            }
+        }
+        Err(JsonPathError::new("unclosed quoted JSON path field"))
+    }
+
+    fn bracket_step(&mut self) -> Result<Step, JsonPathError> {
+        self.advance('[');
+        let start = self.byte_offset;
+        let Some(relative_end) = self.source[start..].find(']') else {
+            return Err(JsonPathError::new("unclosed JSON path bracket"));
+        };
+        let end = start + relative_end;
+        let body = &self.source[start..end];
+        self.byte_offset = end + ']'.len_utf8();
+
+        match body {
+            "" => Ok(Step::Flatten),
+            "*" => Ok(Step::ArrayWildcard),
+            body if body.contains(':') => parse_slice(body),
+            body => parse_index(body),
+        }
+    }
+
+    fn peek(&self) -> Option<char> {
+        self.source[self.byte_offset..].chars().next()
+    }
+
+    fn advance(&mut self, character: char) {
+        self.byte_offset += character.len_utf8();
+    }
+
+    fn next_character(&mut self) -> Option<char> {
+        let character = self.peek()?;
+        self.advance(character);
+        Some(character)
+    }
+
+    fn unsupported(&self) -> JsonPathError {
+        JsonPathError::new(format!(
+            "unsupported JSON path syntax at byte {}",
+            self.byte_offset
+        ))
+    }
+}
+
+fn parse_index(source: &str) -> Result<Step, JsonPathError> {
+    let index = parse_integer(source, "array index")?;
+    Ok(Step::Index(index))
+}
+
+fn parse_slice(source: &str) -> Result<Step, JsonPathError> {
+    let parts = source.split(':').collect::<Vec<_>>();
+    if !(2..=3).contains(&parts.len()) {
+        return Err(JsonPathError::new("invalid JSON path slice"));
+    }
+    let start = parse_optional_integer(parts[0], "slice bound")?;
+    let stop = parse_optional_integer(parts[1], "slice bound")?;
+    let step = match parts.get(2).copied().filter(|part| !part.is_empty()) {
+        Some(step) => parse_integer(step, "slice step")?,
+        None => 1,
+    };
+    if step == 0 {
+        return Err(JsonPathError::new("JSON path slice step cannot be zero"));
+    }
+    Ok(Step::Slice { start, stop, step })
+}
+
+fn parse_optional_integer(source: &str, description: &str) -> Result<Option<isize>, JsonPathError> {
+    if source.is_empty() {
+        return Ok(None);
+    }
+    parse_integer(source, description).map(Some)
+}
+
+fn parse_integer(source: &str, description: &str) -> Result<isize, JsonPathError> {
+    let digits = source.strip_prefix('-').unwrap_or(source);
+    if digits.is_empty() || !digits.bytes().all(|byte| byte.is_ascii_digit()) {
+        return Err(JsonPathError::new(format!(
+            "invalid JSON path {description}"
+        )));
+    }
+    source.parse::<isize>().map_err(|_| {
+        JsonPathError::new(format!(
+            "JSON path {description} is outside the supported range"
+        ))
+    })
+}
+
+fn is_identifier_start(character: char) -> bool {
+    character.is_ascii_alphabetic() || character == '_'
+}
+
+fn is_identifier_continue(character: char) -> bool {
+    character.is_ascii_alphanumeric() || character == '_'
+}
+
+fn evaluate(value: &Value, steps: &[Step]) -> Value {
+    let Some((step, remaining_steps)) = steps.split_first() else {
+        return value.clone();
+    };
+
+    match step {
+        Step::Field(field) => {
+            let Some(value) = value.as_object().and_then(|fields| fields.get(field)) else {
+                return Value::Null;
+            };
+            evaluate(value, remaining_steps)
+        }
+        Step::Index(index) => {
+            let Some(values) = value.as_array() else {
+                return Value::Null;
+            };
+            let Some(position) = array_index(values.len(), *index) else {
+                return Value::Null;
+            };
+            evaluate(&values[position], remaining_steps)
+        }
+        Step::Slice { start, stop, step } => {
+            let Some(values) = value.as_array() else {
+                return Value::Null;
+            };
+            let selected = slice(values, *start, *stop, *step);
+            evaluate_each(selected, remaining_steps)
+        }
+        Step::ArrayWildcard => {
+            let Some(values) = value.as_array() else {
+                return Value::Null;
+            };
+            evaluate_each(values.iter(), remaining_steps)
+        }
+        Step::ObjectWildcard => {
+            let Some(fields) = value.as_object() else {
+                return Value::Null;
+            };
+            evaluate_each(fields.values(), remaining_steps)
+        }
+        Step::Flatten => {
+            let Some(values) = value.as_array() else {
+                return Value::Null;
+            };
+            evaluate_each(flatten_once(values), remaining_steps)
+        }
+    }
+}
+
+fn evaluate_each<'a>(
+    values: impl IntoIterator<Item = &'a Value>,
+    remaining_steps: &[Step],
+) -> Value {
+    let selected = values
+        .into_iter()
+        .filter_map(|value| {
+            let selected = evaluate(value, remaining_steps);
+            (remaining_steps.is_empty() || !selected.is_null()).then_some(selected)
+        })
+        .collect();
+    Value::Array(selected)
+}
+
+fn flatten_once(values: &[Value]) -> Vec<&Value> {
+    let mut flattened = Vec::new();
+    for value in values {
+        match value {
+            Value::Array(nested) => flattened.extend(nested),
+            value => flattened.push(value),
+        }
+    }
+    flattened
+}
+
+fn array_index(length: usize, index: isize) -> Option<usize> {
+    let length = length as i128;
+    let index = index as i128;
+    let index = if index < 0 { length + index } else { index };
+    if !(0..length).contains(&index) {
+        return None;
+    }
+    usize::try_from(index).ok()
+}
+
+fn slice(values: &[Value], start: Option<isize>, stop: Option<isize>, step: isize) -> Vec<&Value> {
+    let length = values.len() as i128;
+    let step = step as i128;
+    let (mut index, stop) = if step > 0 {
+        (
+            positive_bound(start, length, 0),
+            positive_bound(stop, length, length),
+        )
+    } else {
+        (
+            negative_bound(start, length, length - 1),
+            negative_bound(stop, length, -1),
+        )
+    };
+
+    let mut selected = Vec::new();
+    while (step > 0 && index < stop) || (step < 0 && index > stop) {
+        if let Some(value) = usize::try_from(index)
+            .ok()
+            .and_then(|position| values.get(position))
+        {
+            selected.push(value);
+        }
+        index += step;
+    }
+    selected
+}
+
+fn positive_bound(bound: Option<isize>, length: i128, default: i128) -> i128 {
+    let Some(bound) = bound else {
+        return default;
+    };
+    let mut bound = bound as i128;
+    if bound < 0 {
+        bound += length;
+    }
+    bound.clamp(0, length)
+}
+
+fn negative_bound(bound: Option<isize>, length: i128, default: i128) -> i128 {
+    let Some(bound) = bound else {
+        return default;
+    };
+    let mut bound = bound as i128;
+    if bound < 0 {
+        bound += length;
+    }
+    bound.clamp(-1, length - 1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn evaluate_path(path: &str, value: Value) -> Value {
+        JsonPath::parse(path).unwrap().evaluate(&value)
+    }
+
+    #[test]
+    fn fields_support_chaining_and_json_quoted_names() {
+        let value = json!({
+            "company": {"display-name": "Acme"},
+            "quote\"field": "escaped",
+        });
+
+        assert_eq!(
+            evaluate_path(r#"company."display-name""#, value.clone()),
+            json!("Acme")
+        );
+        assert_eq!(evaluate_path(r#""quote\"field""#, value), json!("escaped"));
+    }
+
+    #[test]
+    fn fields_return_null_when_missing_or_applied_to_another_type() {
+        assert_eq!(
+            evaluate_path("missing", json!({"name": "Acme"})),
+            Value::Null
+        );
+        assert_eq!(
+            evaluate_path("name.first", json!({"name": "Acme"})),
+            Value::Null
+        );
+    }
+
+    #[test]
+    fn collection_steps_return_null_for_incompatible_types() {
+        for path in ["[0]", "[:2]", "[*]", "[]"] {
+            assert_eq!(evaluate_path(path, json!({"name": "Acme"})), Value::Null);
+        }
+        assert_eq!(evaluate_path("*", json!(["one", "two"])), Value::Null);
+    }
+
+    #[test]
+    fn indexes_accept_positive_negative_and_chained_positions() {
+        let value = json!([["first"], ["last"]]);
+
+        assert_eq!(evaluate_path("[0][0]", value.clone()), json!("first"));
+        assert_eq!(evaluate_path("[-1][0]", value), json!("last"));
+    }
+
+    #[test]
+    fn out_of_range_indexes_return_null() {
+        for path in ["[100]", "[-100]"] {
+            assert_eq!(evaluate_path(path, json!(["first"])), Value::Null);
+        }
+    }
+
+    #[test]
+    fn slices_follow_python_bounds_and_steps() {
+        let value = json!([0, 1, 2, 3]);
+        for (path, expected) in [
+            ("[0:3]", json!([0, 1, 2])),
+            ("[:2]", json!([0, 1])),
+            ("[::2]", json!([0, 2])),
+            ("[-2:]", json!([2, 3])),
+            ("[::-1]", json!([3, 2, 1, 0])),
+            ("[3::-1]", json!([3, 2, 1, 0])),
+            ("[3:-1:-1]", json!([])),
+            ("[3:0:-2]", json!([3, 1])),
+            ("[-10:10]", json!([0, 1, 2, 3])),
+            ("[10:-10:-1]", json!([3, 2, 1, 0])),
+            ("[8:10]", json!([])),
+        ] {
+            assert_eq!(evaluate_path(path, value.clone()), expected, "{path}");
+        }
+        assert_eq!(evaluate_path("[::-1]", json!([])), json!([]));
+    }
+
+    #[test]
+    fn slices_reject_zero_steps() {
+        assert_eq!(
+            JsonPath::parse("[::0]").unwrap_err().to_string(),
+            "JSON path slice step cannot be zero"
+        );
+    }
+
+    #[test]
+    fn array_integers_must_fit_the_supported_range() {
+        for path in [
+            "[999999999999999999999999]",
+            "[-999999999999999999999999]",
+            "[999999999999999999999999:]",
+            "[:999999999999999999999999]",
+            "[::999999999999999999999999]",
+        ] {
+            assert!(JsonPath::parse(path).is_err(), "{path}");
+        }
+    }
+
+    #[test]
+    fn collection_projections_apply_the_remaining_path_and_omit_nulls() {
+        let value = json!([{"name": "one"}, {}, {"name": null}, {"name": "two"}]);
+
+        for (path, expected) in [
+            ("[*].name", json!(["one", "two"])),
+            ("[1:].name", json!(["two"])),
+        ] {
+            assert_eq!(evaluate_path(path, value.clone()), expected, "{path}");
+        }
+    }
+
+    #[test]
+    fn object_wildcards_apply_the_remaining_path() {
+        let value = json!({
+            "one": {"name": "first"},
+            "two": {},
+            "three": {"name": "last"}
+        });
+        let mut selected = evaluate_path("*.name", value).as_array().unwrap().clone();
+        selected.sort_by_key(Value::to_string);
+
+        assert_eq!(selected, vec![json!("first"), json!("last")]);
+    }
+
+    #[test]
+    fn flatten_merges_one_level_then_applies_the_remaining_path() {
+        let value = json!([[{"name": "one"}], {"name": "two"}, [[{"name": "deep"}]]]);
+
+        assert_eq!(evaluate_path("[].name", value), json!(["one", "two"]));
+    }
+
+    #[test]
+    fn collection_steps_without_a_following_path_preserve_nulls() {
+        let value = json!([[1, null], null, [2]]);
+
+        assert_eq!(
+            evaluate_path("[]", value.clone()),
+            json!([1, null, null, 2])
+        );
+        assert_eq!(evaluate_path("[*]", value), json!([[1, null], null, [2]]));
+    }
+
+    #[test]
+    fn unsupported_jmespath_features_are_rejected() {
+        for path in [
+            "items[?active]",
+            "foo == bar",
+            "foo || bar",
+            "length(items)",
+            "[foo,bar]",
+            "{foo: foo}",
+            "'literal'",
+            "`1`",
+            "@",
+            "foo | bar",
+        ] {
+            assert!(JsonPath::parse(path).is_err(), "{path}");
+        }
+    }
+
+    #[test]
+    fn malformed_json_paths_are_rejected() {
+        for path in [
+            "",
+            "foo.",
+            "foo..bar",
+            "foo bar",
+            "\"",
+            "\"\"",
+            "[",
+            "[one]",
+            "[1:2:3:4]",
+            r#""\q""#,
+        ] {
+            assert!(JsonPath::parse(path).is_err(), "{path}");
+        }
+    }
+}

--- a/crates/agentwerk/src/prompts/mod.rs
+++ b/crates/agentwerk/src/prompts/mod.rs
@@ -2,6 +2,7 @@
 //! `{{ context }}` expands to.
 
 pub(crate) mod directives;
+mod json_path;
 mod prompt;
 
 use std::path::Path;

--- a/crates/agentwerk/src/prompts/prompt.rs
+++ b/crates/agentwerk/src/prompts/prompt.rs
@@ -5,6 +5,7 @@ use std::fmt;
 
 use serde_json::Value;
 
+use super::json_path::JsonPath;
 use crate::{Query, Werk};
 
 /// An expression that could not be rendered.
@@ -126,53 +127,59 @@ fn resolve_expression(
     named_value: &mut impl FnMut(&str) -> Option<String>,
 ) -> Result<Option<String>, RenderError> {
     let expression = expression.trim();
-    let (expanded, nested) =
-        expand_nested(expression, named_value).map_err(|message| RenderError {
-            expression: expression.to_string(),
-            message,
-        })?;
-    let expanded = expanded.trim();
-
-    if let Some(inner) = readable_expression(expanded).map_err(|message| RenderError {
+    resolve_expression_value(werk, expression, named_value).map_err(|message| RenderError {
         expression: expression.to_string(),
         message,
-    })? {
-        let Some((kind, query)) = result_expression(inner) else {
-            return Err(RenderError {
-                expression: expression.to_string(),
-                message: "readable expects a result: or results: expression".into(),
-            });
+    })
+}
+
+fn resolve_expression_value(
+    werk: &Werk,
+    expression: &str,
+    named_value: &mut impl FnMut(&str) -> Option<String>,
+) -> Result<Option<String>, String> {
+    if let Some(inner) = readable_expression(expression)? {
+        let Some(result) = result_expression(inner) else {
+            return Err("readable expects a result: or results: expression".into());
         };
-        if !matches!(kind, "result" | "results") {
-            return Err(RenderError {
-                expression: expression.to_string(),
-                message: "readable expects a result: or results: expression".into(),
-            });
+        if !result.kind.selects_values() {
+            return Err("readable expects a result: or results: expression".into());
         }
-        return select_result(werk, kind, query)
-            .map(|value| Some(readable(&value)))
-            .map_err(|message| RenderError {
-                expression: expression.to_string(),
-                message,
-            });
+        let value = resolve_result(werk, result, named_value)?;
+        return Ok(Some(readable(&value)));
     }
 
-    if let Some((kind, query)) = result_expression(expanded) {
-        return select_result(werk, kind, query)
-            .map(|value| Some(result_text(value, is_plural(kind))))
-            .map_err(|message| RenderError {
-                expression: expression.to_string(),
-                message,
-            });
+    if let Some(result) = result_expression(expression) {
+        let value = resolve_result(werk, result, named_value)?;
+        return Ok(Some(result_text(value)));
     }
 
-    if nested {
-        return Err(RenderError {
-            expression: expression.to_string(),
-            message: "nested values are only supported inside result expressions".into(),
-        });
+    let (expanded, had_nested_value) = expand_nested(expression, named_value)?;
+    if had_nested_value {
+        return Err("nested values are only supported inside result expressions".into());
     }
-    Ok(named_value(expanded))
+    Ok(named_value(expanded.trim()))
+}
+
+fn resolve_result(
+    werk: &Werk,
+    result: ResultExpression<'_>,
+    named_value: &mut impl FnMut(&str) -> Option<String>,
+) -> Result<Value, String> {
+    let (query, _had_nested_value) = expand_nested(result.query, named_value)?;
+    if result.json_path.is_some() && !result.kind.selects_values() {
+        return Err("JSON paths require result: or results:".into());
+    }
+    let json_path = result
+        .json_path
+        .map(JsonPath::parse)
+        .transpose()
+        .map_err(|error| error.to_string())?;
+    let value = select_result(werk, result.kind, query.trim())?;
+    let Some(json_path) = json_path else {
+        return Ok(value);
+    };
+    Ok(json_path.evaluate(&value))
 }
 
 fn expand_nested(
@@ -217,32 +224,136 @@ fn readable_expression(expression: &str) -> Result<Option<&str>, String> {
     Ok(Some(body.trim()))
 }
 
-fn result_expression(expression: &str) -> Option<(&str, &str)> {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ResultKind {
+    Result,
+    Results,
+    ResultPath,
+    ResultPaths,
+}
+
+impl ResultKind {
+    fn parse(source: &str) -> Option<Self> {
+        Some(match source {
+            "result" => Self::Result,
+            "results" => Self::Results,
+            "result_path" => Self::ResultPath,
+            "result_paths" => Self::ResultPaths,
+            _ => return None,
+        })
+    }
+
+    fn selects_values(self) -> bool {
+        matches!(self, Self::Result | Self::Results)
+    }
+
+    fn is_plural(self) -> bool {
+        matches!(self, Self::Results | Self::ResultPaths)
+    }
+
+    fn uses_file_paths(self) -> bool {
+        matches!(self, Self::ResultPath | Self::ResultPaths)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ResultExpression<'a> {
+    kind: ResultKind,
+    query: &'a str,
+    json_path: Option<&'a str>,
+}
+
+fn result_expression(expression: &str) -> Option<ResultExpression<'_>> {
     let (kind, query) = expression.split_once(':')?;
-    let kind = kind.trim();
-    matches!(kind, "result" | "results" | "result_path" | "result_paths")
-        .then_some((kind, query.trim()))
+    let kind = ResultKind::parse(kind.trim())?;
+    let (query, json_path) = split_json_path(query);
+    Some(ResultExpression {
+        kind,
+        query: query.trim(),
+        json_path: json_path.map(str::trim),
+    })
+}
+
+fn split_json_path(source: &str) -> (&str, Option<&str>) {
+    let mut quote = None;
+    let mut escaped = false;
+    let mut parenthesis_depth = 0usize;
+    let mut inside_nested_expression = false;
+    let mut byte_offset = 0;
+    while byte_offset < source.len() {
+        let remaining = &source[byte_offset..];
+        if inside_nested_expression {
+            if remaining.starts_with(EXPRESSION_CLOSE) {
+                inside_nested_expression = false;
+                byte_offset += EXPRESSION_CLOSE.len();
+                continue;
+            }
+            let character = remaining.chars().next().expect("remaining is nonempty");
+            byte_offset += character.len_utf8();
+            continue;
+        }
+        if remaining.starts_with(EXPRESSION_OPEN) {
+            inside_nested_expression = true;
+            byte_offset += EXPRESSION_OPEN.len();
+            continue;
+        }
+
+        let character = remaining.chars().next().expect("remaining is nonempty");
+        if let Some(delimiter) = quote {
+            if escaped {
+                escaped = false;
+            } else if character == '\\' {
+                escaped = true;
+            } else if character == delimiter {
+                quote = None;
+            }
+            byte_offset += character.len_utf8();
+            continue;
+        }
+        match character {
+            '\'' | '"' => quote = Some(character),
+            '(' => parenthesis_depth += 1,
+            ')' => parenthesis_depth = parenthesis_depth.saturating_sub(1),
+            '|' if parenthesis_depth == 0 && is_json_path_separator(source, byte_offset) => {
+                return (
+                    &source[..byte_offset],
+                    Some(&source[byte_offset + character.len_utf8()..]),
+                );
+            }
+            _ => {}
+        }
+        byte_offset += character.len_utf8();
+    }
+    (source, None)
+}
+
+fn is_json_path_separator(source: &str, byte_offset: usize) -> bool {
+    let before = &source[..byte_offset];
+    let after = &source[byte_offset + '|'.len_utf8()..];
+    let has_space_before = before.chars().next_back().is_some_and(char::is_whitespace);
+    let has_space_after = after.is_empty() || after.chars().next().is_some_and(char::is_whitespace);
+    has_space_before && has_space_after
 }
 
 /// Nested placeholders may appear in quoted AQL; ordinary braces remain data.
 fn expression_end(body: &str) -> Result<Option<usize>, &'static str> {
     let mut brace_depth = 0;
-    let mut nested = false;
+    let mut inside_nested_expression = false;
     let mut quote = None;
     let mut escaped = false;
-    let mut index = 0;
-    while index < body.len() {
-        let remaining = &body[index..];
-        if nested {
+    let mut byte_offset = 0;
+    while byte_offset < body.len() {
+        let remaining = &body[byte_offset..];
+        if inside_nested_expression {
             if remaining.starts_with(EXPRESSION_OPEN) {
                 return Err("nested expressions may only be one level deep");
             }
             if remaining.starts_with(EXPRESSION_CLOSE) {
-                nested = false;
-                index += EXPRESSION_CLOSE.len();
+                inside_nested_expression = false;
+                byte_offset += EXPRESSION_CLOSE.len();
                 continue;
             }
-            index += remaining
+            byte_offset += remaining
                 .chars()
                 .next()
                 .expect("remaining is nonempty")
@@ -250,59 +361,55 @@ fn expression_end(body: &str) -> Result<Option<usize>, &'static str> {
             continue;
         }
         if remaining.starts_with(EXPRESSION_OPEN) {
-            nested = true;
-            index += EXPRESSION_OPEN.len();
+            inside_nested_expression = true;
+            byte_offset += EXPRESSION_OPEN.len();
             continue;
         }
 
-        let ch = remaining.chars().next().expect("remaining is nonempty");
+        let character = remaining.chars().next().expect("remaining is nonempty");
         if let Some(delimiter) = quote {
             if escaped {
                 escaped = false;
-            } else if ch == '\\' {
+            } else if character == '\\' {
                 escaped = true;
-            } else if ch == delimiter {
+            } else if character == delimiter {
                 quote = None;
             }
-            index += ch.len_utf8();
+            byte_offset += character.len_utf8();
             continue;
         }
-        match ch {
-            '\'' | '"' => quote = Some(ch),
+        match character {
+            '\'' | '"' => quote = Some(character),
             '{' => brace_depth += 1,
             '}' if brace_depth > 0 => brace_depth -= 1,
-            '}' if remaining.starts_with(EXPRESSION_CLOSE) => return Ok(Some(index)),
+            '}' if remaining.starts_with(EXPRESSION_CLOSE) => return Ok(Some(byte_offset)),
             _ => {}
         }
-        index += ch.len_utf8();
+        byte_offset += character.len_utf8();
     }
-    if nested {
+    if inside_nested_expression {
         Err("unclosed nested expression")
     } else {
         Ok(None)
     }
 }
 
-fn is_plural(kind: &str) -> bool {
-    matches!(kind, "results" | "result_paths")
-}
-
-fn select_result(werk: &Werk, kind: &str, query: &str) -> Result<Value, String> {
+fn select_result(werk: &Werk, kind: ResultKind, query: &str) -> Result<Value, String> {
     let query = Query::new(query).map_err(|error| error.to_string())?;
     let mut tasks = werk.result_tasks(query);
-    let plural = is_plural(kind);
-    if !plural && tasks.is_empty() {
+    let is_plural = kind.is_plural();
+    if !is_plural && tasks.is_empty() {
         return Err("no matching result".into());
     }
-    if !plural {
+    if !is_plural {
         tasks.truncate(1);
     }
-    let use_paths = matches!(kind, "result_path" | "result_paths");
+    let use_file_paths = kind.uses_file_paths();
     let values = tasks
         .iter()
-        .map(|task| result_value(werk, task, use_paths))
+        .map(|task| result_value(werk, task, use_file_paths))
         .collect::<Result<Vec<_>, _>>()?;
-    if plural {
+    if is_plural {
         return Ok(Value::Array(values));
     }
     Ok(values
@@ -311,9 +418,9 @@ fn select_result(werk: &Werk, kind: &str, query: &str) -> Result<Value, String> 
         .expect("singular selection is nonempty"))
 }
 
-fn result_text(value: Value, plural: bool) -> String {
+fn result_text(value: Value) -> String {
     match value {
-        Value::String(text) if !plural => text,
+        Value::String(text) => text,
         value => value.to_string(),
     }
 }
@@ -555,6 +662,162 @@ mod tests {
         assert_eq!(
             render(&werk, format!("{{{{ result: {second} }}}}")).unwrap(),
             r#"{"answer":42}"#
+        );
+    }
+
+    #[test]
+    fn result_json_paths_render_fields_and_structured_values() {
+        let (werk, _dir) = session();
+        let id = werk.add_task(Task::labeled("research", "go"));
+        werk.set_task_finished(
+            &id,
+            serde_json::json!({
+                "company": {"name": "Acme"},
+                "findings": [{"summary": "one"}],
+                "}}": "closed",
+            }),
+        )
+        .unwrap();
+
+        assert_eq!(
+            render(&werk, "{{ result: research | company.name }}").unwrap(),
+            "Acme"
+        );
+        assert_eq!(
+            render(&werk, "{{ result: research | findings[0] }}").unwrap(),
+            r#"{"summary":"one"}"#
+        );
+        assert_eq!(
+            render(&werk, "{{ result: research | company.missing }}").unwrap(),
+            "null"
+        );
+        assert_eq!(
+            render(&werk, r#"{{ result: research | "}}" }}"#).unwrap(),
+            "closed"
+        );
+    }
+
+    #[test]
+    fn plural_result_json_paths_use_the_selected_array_as_the_root() {
+        let (werk, _dir) = session();
+        for verdict in ["safe", "review"] {
+            let id = werk.add_task(Task::labeled("scan", "go"));
+            werk.set_task_finished(&id, serde_json::json!({"verdict": verdict}))
+                .unwrap();
+        }
+
+        assert_eq!(
+            render(&werk, "{{ results: scan | [*].verdict }}").unwrap(),
+            r#"["safe","review"]"#
+        );
+        assert_eq!(
+            render(&werk, "{{ results: scan | [0].verdict }}").unwrap(),
+            "safe"
+        );
+        assert_eq!(
+            render(&werk, "{{ results: missing | [*].verdict }}").unwrap(),
+            "[]"
+        );
+    }
+
+    #[test]
+    fn readable_formats_the_selected_json_path_value() {
+        let (werk, _dir) = session();
+        let id = werk.add_task(Task::labeled("research", "go"));
+        werk.set_task_finished(
+            &id,
+            serde_json::json!({"findings": [{"summary": "one"}, {"summary": "two"}]}),
+        )
+        .unwrap();
+
+        assert_eq!(
+            render(
+                &werk,
+                "{{ readable(result: research | findings[*].summary) }}",
+            )
+            .unwrap(),
+            "- one\n- two"
+        );
+    }
+
+    #[test]
+    fn json_path_boundaries_ignore_quoted_aql_pipes() {
+        let (werk, _dir) = session();
+        let id = werk.add_task(Task::labeled("research | notes", "go"));
+        werk.set_task_finished(&id, serde_json::json!({"answer": "found"}))
+            .unwrap();
+        let compact = werk.add_task(Task::labeled("research|notes", "go"));
+        werk.set_task_finished(&compact, serde_json::json!("compact"))
+            .unwrap();
+
+        assert_eq!(
+            render(
+                &werk,
+                r#"{{ result: task.label = "research | notes" | answer }}"#,
+            )
+            .unwrap(),
+            "found"
+        );
+        assert_eq!(
+            render(&werk, "{{ result: research|notes }}").unwrap(),
+            "compact"
+        );
+    }
+
+    #[test]
+    fn json_path_boundaries_ignore_parenthesized_and_nested_pipes() {
+        assert_eq!(
+            split_json_path("task.label IN (one | two) | answer"),
+            ("task.label IN (one | two) ", Some(" answer"))
+        );
+        assert_eq!(
+            split_json_path("{{ selection | literal }} | answer"),
+            ("{{ selection | literal }} ", Some(" answer"))
+        );
+        assert_eq!(split_json_path("research|notes"), ("research|notes", None));
+    }
+
+    #[test]
+    fn result_file_paths_cannot_have_json_paths() {
+        let (werk, _dir) = session();
+        let id = werk.add_task("go");
+        werk.set_task_finished(&id, serde_json::json!({"answer": "done"}))
+            .unwrap();
+
+        let error = render(&werk, format!("{{{{ result_path: {id} | answer }}}}")).unwrap_err();
+
+        assert_eq!(error.message, "JSON paths require result: or results:");
+    }
+
+    #[test]
+    fn json_paths_are_static_and_fail_closed() {
+        let (werk, _dir) = session();
+        let id = werk.add_task(Task::labeled("research", "go"));
+        werk.set_task_finished(&id, serde_json::json!({"answer": "found"}))
+            .unwrap();
+        werk.set_templates([("selection", "research | answer"), ("path", "answer")]);
+
+        for prompt in [
+            "{{ result: research | }}",
+            "{{ result: research | answer || missing }}",
+            "{{ result: research | {{ path }} }}",
+            "{{ result: {{ selection }} }}",
+        ] {
+            assert!(render(&werk, prompt).is_err(), "{prompt}");
+        }
+    }
+
+    #[test]
+    fn strings_selected_by_json_paths_are_not_rendered_again() {
+        let (werk, _dir) = session();
+        let id = werk.add_task(Task::labeled("research", "go"));
+        werk.set_task_finished(&id, serde_json::json!({"answer": "{{ company }}"}))
+            .unwrap();
+        werk.set_template("company", "Acme");
+
+        assert_eq!(
+            render(&werk, "{{ result: research | answer }}").unwrap(),
+            "{{ company }}"
         );
     }
 


### PR DESCRIPTION
## Add JSON paths to result templates

### Purpose

- Result templates previously exposed complete selected values
- JSON paths let prompts consume only the fields an agent needs
- Static paths prevent named template values from changing navigation

### What changed

- `result:` and `results:` accept fields, indexes, slices, wildcards, and flattening
- `readable` formats values selected by a JSON path
- Missing fields, incompatible types, and out-of-range indexes produce `null`
- Unsupported JMESPath features fail prompt rendering

### Examples

```text
{{ result: research | company.name }}
```

```text
{{ readable(result: research | findings[*].summary) }}
```
