### PR TITLE
release: gate publishing on complete runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,55 @@ on:
   push:
     tags: ['v*']
 jobs:
+  verify-main:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Require the tagged commit on main
+        run: |
+          git fetch origin main
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" FETCH_HEAD; then
+            echo "::error::Release tags must point to a commit contained in origin/main"
+            exit 1
+          fi
+
+  rust-tests:
+    needs: verify-main
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - run: sudo apt-get update && sudo apt-get install -y ripgrep
+      - run: make test
+
+  python-tests:
+    needs: verify-main
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: sudo apt-get update && sudo apt-get install -y ripgrep
+      - run: python -m venv .venv
+      - run: .venv/bin/python -m pip install maturin pytest pytest-asyncio
+      - run: .venv/bin/maturin develop --manifest-path crates/agentwerk-py/Cargo.toml
+      - run: .venv/bin/python -m pytest crates/agentwerk-py/tests -q -m 'not live'
+
+  crate:
+    name: crate dry run
+    needs: verify-main
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo publish -p agentwerk --dry-run
+
   wheels:
+    needs: verify-main
     name: wheels ${{ matrix.platform.runner }} ${{ matrix.platform.target }}
     runs-on: ${{ matrix.platform.runner }}
     strategy:
@@ -29,6 +77,7 @@ jobs:
           path: crates/agentwerk-py/dist
 
   sdist:
+    needs: verify-main
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -43,7 +92,7 @@ jobs:
           path: crates/agentwerk-py/dist
 
   publish-wheels:
-    needs: [wheels, sdist]
+    needs: [rust-tests, python-tests, crate, wheels, sdist]
     runs-on: ubuntu-latest
     environment: release
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,8 +37,7 @@ jobs:
           python-version: '3.12'
       - run: sudo apt-get update && sudo apt-get install -y ripgrep
       - run: python -m venv .venv
-      - run: .venv/bin/python -m pip install maturin pytest pytest-asyncio
-      - run: .venv/bin/maturin develop --manifest-path crates/agentwerk-py/Cargo.toml
+      - run: .venv/bin/python -m pip install './crates/agentwerk-py[test]'
       - run: .venv/bin/python -m pytest crates/agentwerk-py/tests -q -m 'not live'
 
   crate:

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -49,13 +49,20 @@ make use_case name=deep-research args="What is a good life?"  # with arguments
 
 ## Publishing
 
+Run releases from `main`. Push the version bump commit before its tag; the
+publish workflow rejects tags whose commit is not contained in `origin/main`.
+
 ```bash
 make bump                  # bump patch version, run tests, commit, tag
 make bump part=minor       # bump minor version
 make bump part=major       # bump major version
+git push                   # push the version commit to main first
+git push --tags            # trigger the gated publish workflow
 ```
 
-GitHub Actions handles the crates.io publish via trusted publishing once the new tag is pushed (`git push --tags`).
+GitHub Actions builds both packages and reruns the offline Rust and Python test
+suites before publishing to PyPI, then crates.io. No registry publish starts
+unless every test and package preflight succeeds.
 
 ## Documentation
 

--- a/agentdocs/workflow.md
+++ b/agentdocs/workflow.md
@@ -94,13 +94,18 @@ make use_case name=deep-research args="What is a good life?"
 
 **Use `make bump` only when a versioned release is intended.**
 
+Run it from `main`, and push the version commit before the tag. The publish
+workflow rejects tags whose commit is not contained in `origin/main`.
+
 ```bash
 make bump
 make bump part=minor
 make bump part=major
-git push && git push --tags
+git push
+git push --tags
 ```
 
 - The target runs tests, updates both crate versions, commits, and creates a `v<version>` tag.
 - Omit `part` for a patch release; use only `patch`, `minor`, or `major`.
-- GitHub Actions publishes after the tag is pushed.
+- GitHub Actions reruns the offline Rust and Python suites and preflights both
+  packages before publishing to PyPI, then crates.io.

--- a/crates/agentwerk/src/agents/loop/agent.rs
+++ b/crates/agentwerk/src/agents/loop/agent.rs
@@ -300,7 +300,7 @@ mod tests {
 
     use crate::agents::agent::Agent;
     use crate::agents::r#loop::test_util::*;
-    use crate::agents::tasks::{Author, Status, Task, Werk};
+    use crate::agents::tasks::{Author, FinishReason, Status, Task, Werk};
     use crate::agents::Knowledge;
     use crate::tools::{EventTool, TaskTool};
 
@@ -1453,7 +1453,6 @@ mod tests {
             .set_policy(Policy {
                 max_request_retries: 0,
                 request_retry_delay: Duration::from_millis(1),
-                max_time: Some(Duration::from_millis(500)),
                 ..Default::default()
             });
         werk.add_agent(
@@ -1465,7 +1464,10 @@ mod tests {
         );
         werk.add_task("first");
         werk.add_task("second");
-        let _ = werk.finish().await;
+        tokio::time::timeout(Duration::from_secs(5), werk.finish())
+            .await
+            .expect("cross-task knowledge run did not finish within 5s");
+        assert_eq!(werk.get_finish_reason(), Some(FinishReason::Drained));
 
         let prompts = provider.received_system_prompts();
         assert_eq!(prompts.len(), 3);

--- a/crates/agentwerk/src/agents/loop/test_util.rs
+++ b/crates/agentwerk/src/agents/loop/test_util.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 use crate::agents::agent::Agent;
 use crate::agents::knowledge::Knowledge;
 use crate::agents::policy::Policy;
-use crate::agents::tasks::{Task, Werk};
+use crate::agents::tasks::{FinishReason, Task, Werk};
 use crate::event::Event;
 use crate::providers::types::{ModelResponse, ResponseStatus, TokenUsage};
 use crate::providers::{ContentBlock, Message, ProviderError, ProviderResult};
@@ -325,7 +325,6 @@ pub async fn run_one(
             max_request_retries,
             request_retry_delay: Duration::from_millis(1),
             max_schema_retries: Some(max_schema_retries),
-            max_time: Some(Duration::from_millis(200)),
             ..Default::default()
         });
 
@@ -345,7 +344,10 @@ pub async fn run_one(
         werk.add_task("go");
     }
 
-    let _ = werk.finish().await;
+    tokio::time::timeout(Duration::from_secs(5), werk.finish())
+        .await
+        .expect("test run did not finish within 5s");
+    assert_eq!(werk.get_finish_reason(), Some(FinishReason::Drained));
     let events = collected.lock().unwrap().clone();
     let task = werk
         .get_tasks()


### PR DESCRIPTION
## Summary

- replace unrelated policy deadlines in async test fixtures with explicit completion guards
- require release tags on main and gate publishing on Rust, Python, and package preflights
- document the ordered main-commit and tag push flow

## Verification

- both previously failing tests pass individually
- agentwerk library suite passes three consecutive parallel runs
- `make test`
- 256 offline Python tests
- `cargo publish -p agentwerk --dry-run --allow-dirty`
- release workflow YAML parse and main-ancestry checks