### PR TITLE
Expand prompt templates with JSONPath selectors

### DIFF
--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -1061,28 +1061,26 @@ Not bound: prompt preparation and rendering are private Werk behavior.
 | Rust | `render_values(template: string, named_value: (name: string) => string?): string` | private |
 | Rust | `resolve_expression(werk: Werk, expression: string, named_value: (name: string) => string?): string? throws RenderError` | private |
 | Rust | `resolve_expression_value(werk: Werk, expression: string, named_value: (name: string) => string?): string? throws string` | private |
-| Rust | `resolve_result(werk: Werk, result: ResultExpression, named_value: (name: string) => string?): json throws string` | private |
+| Rust | `resolve_named_value(expression: string, named_value: (name: string) => string?): string? throws string` | private |
+| Rust | `resolve_selection(werk: Werk, selection: SelectionExpression, named_value: (name: string) => string?): json throws string` | private |
 | Rust | `expand_nested(expression: string, named_value: (name: string) => string?): [string, boolean] throws string` | private |
-| Rust | `readable_expression(expression: string): string? throws string` | private |
-| Rust | `ResultKind` | private |
+| Rust | `SelectionKind` | private |
 | Rust | `.Result` | private |
 | Rust | `.Results` | private |
-| Rust | `.ResultPath` | private |
-| Rust | `.ResultPaths` | private |
-| Rust | `.parse(source: string): ResultKind?` | private |
-| Rust | `.selects_values(): boolean` | private |
+| Rust | `.Task` | private |
+| Rust | `.Tasks` | private |
+| Rust | `.Event` | private |
+| Rust | `.Events` | private |
+| Rust | `.parse(source: string): SelectionKind?` | private |
 | Rust | `.is_plural(): boolean` | private |
-| Rust | `.uses_file_paths(): boolean` | private |
-| Rust | `ResultExpression { kind: ResultKind, query: string, json_path: string? }` | private |
-| Rust | `result_expression(expression: string): ResultExpression?` | private |
+| Rust | `SelectionExpression { kind: SelectionKind, query: string, json_path: string? }` | private |
+| Rust | `selection_expression(expression: string): SelectionExpression?` | private |
 | Rust | `split_json_path(source: string): [string, string?]` | private |
 | Rust | `is_json_path_separator(source: string, byte_offset: number): boolean` | private |
 | Rust | `expression_end(body: string): number? throws string` | private |
-| Rust | `select_result(werk: Werk, kind: ResultKind, query: string): json throws string` | private |
+| Rust | `select_value(werk: Werk, kind: SelectionKind, query: string): json throws string` | private |
+| Rust | `select_result(werk: Werk, kind: SelectionKind, query: Query): json throws string` | private |
 | Rust | `result_text(value: json): string` | private |
-| Rust | `readable(value: json): string` | private |
-| Rust | `readable_lines(value: json, indent: number): string[]` | private |
-| Rust | `result_value(werk: Werk, task: Task, use_path: boolean): json throws string` | private |
 
 ## `crates/agentwerk/src/prompts/json_path.rs`
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ async fn main() {
 
 ## API
 
-agentwerk has five core concepts. An `Agent` uses tools to complete a `Task`, a unit of work whose result is a JSON value. A `Werk` coordinates agents and tasks, and an `Event` records activity.
+agentwerk has six core concepts. An `Agent` uses `Tools` to complete a `Task` and create a JSON result. A `Werk` coordinates agents and tasks, `Events` record activity, and `Knowledge` provides durable shared memory.
 
 | Section | Covers |
 |---|---|

--- a/README.md
+++ b/README.md
@@ -78,11 +78,16 @@ async fn main() {
 
 ## API
 
-- [Agents](#agents): Set agent roles, behavior, and tasks.
-- [Werk](#werk): Assign work and collect results across agents.
-- [Tools](#tools): Give agents controlled ways to act.
-- [Events](#events): Inspect requests, tool calls, and failures.
-- [Knowledge](#knowledge): Share durable memory across agents and tasks.
+agentwerk has five core concepts. An `Agent` uses tools to complete a `Task`, a unit of work whose result is a JSON value. A `Werk` coordinates agents and tasks, and an `Event` records activity.
+
+| Section | Covers |
+|---|---|
+| [Agents](#agents) | Roles, behavior, and [providers](#providers). |
+| [Tasks](#tasks) | [Templates](#template-values), [JSONPath](#template-reference), [schemas](#schemas), and [directives](#directives). |
+| [Werk](#werk) | [Queries](#queries), [execution](#execution), [result sharing](#sharing-results), [configuration](#configuration), [compaction](#compaction), and [sessions](#sessions). |
+| [Tools](#tools) | Controlled capabilities for agents. |
+| [Events](#events) | Observability and hooks. |
+| [Knowledge](#knowledge) | Durable shared memory. |
 
 ## Agents
 
@@ -103,8 +108,6 @@ agent.add_task("Read CHANGELOG.md and summarize the entries added since the last
 
 let results = agent.finish().await;
 ```
-
-The [prompt skill](skills/prompt/SKILL.md) provides a compact template for writing agent roles.
 
 <details>
 <summary>Agent reference</summary>
@@ -228,6 +231,159 @@ let agent = Agent::new().model(
 ```
 
 See [`Provider`](https://docs.rs/agentwerk/latest/agentwerk/providers/struct.Provider.html) and [`Model`](https://docs.rs/agentwerk/latest/agentwerk/providers/struct.Model.html).
+
+</details>
+
+## Tasks
+
+Roles and tasks can interpolate shared values and selected runtime data. The [prompt skill](skills/prompt/SKILL.md) provides a compact template for writing agent roles.
+
+### Template values
+
+Define an agent with placeholders, then set the template values before adding its task:
+
+```rust
+use agentwerk::{Agent, Task};
+
+werk.add_agent(
+    Agent::from_env()
+        .label("report")
+        .role("Write for {{ company }} using:\n{{ results: research }}"),
+);
+werk.set_template("company", "Canvas Computing");
+werk.finish_tasks("research").await;
+werk.add_task(Task::labeled("report", "Write the board report."));
+```
+
+agentwerk fills placeholders in the role and task just before each task's first model request. Newly added tasks use the latest template values and results.
+
+<details>
+<summary id="template-reference">Template reference</summary>
+
+| Expression | Output |
+|---|---|
+| `{{ name }}` | The value assigned to `name`. |
+| `{{ name \| JSONPath }}` | A value selected from the template variable after parsing it as JSON. |
+| `{{ result: AQL }}` | The first result. Strings appear as text and other values as compact JSON. |
+| `{{ results: AQL }}` | A compact JSON array of matching results. |
+| `{{ result: AQL \| JSONPath }}` | A value selected from the first result. |
+| `{{ results: AQL \| JSONPath }}` | A value selected from the array of matching results. |
+| `{{ task: AQL }}` | The first matching task as compact JSON, or `null`. |
+| `{{ tasks: AQL }}` | A compact JSON array of matching tasks. |
+| `{{ task: AQL \| JSONPath }}` | A value selected from the first matching task. |
+| `{{ tasks: AQL \| JSONPath }}` | A value selected from the array of matching tasks. |
+| `{{ event: AQL }}` | The first matching event as compact JSON, or `null`. |
+| `{{ events: AQL }}` | A compact JSON array of matching events. |
+| `{{ event: AQL \| JSONPath }}` | A value selected from the first matching event. |
+| `{{ events: AQL \| JSONPath }}` | A value selected from the array of matching events. |
+
+Use JSONPath after a template variable or AQL selection. Template variables are parsed as JSON, with malformed JSON becoming `null`. Task and event selectors match the corresponding `find_*` method. Plural selections use the array as the root.
+
+| Record | JSONPath properties |
+|---|---|
+| Task | `task`, `label`, `schema`, `id`, `status`, `reporter`, `assignee`, `created_at`, `started_at`, `finished_at`, `failed_at` |
+| Event | `name`, `directive`, `data`, `task_id`, `agent_id`, `label`, `created_at` |
+
+`task` is the original JSON input. Unset `label`, `schema`, `assignee`, and `directive` properties are omitted. Task results, errors, replies, and cancellation state are not serialized.
+
+For example, given this `research` result:
+
+```json
+{
+  "company": {"name": "Canvas Computing"},
+  "findings": [{"summary": "one"}, {"summary": "two"}]
+}
+```
+
+This template:
+
+```text
+{{ result: research | company.name }}
+```
+
+Renders as:
+
+```text
+Canvas Computing
+```
+
+Select each task input or event's data:
+
+```text
+{{ tasks: research | [*].task }}
+{{ events: event.name = tool_call_failed | [*].data }}
+```
+
+`research` is shorthand for `task.label = research`.
+
+| Path | Selects |
+|---|---|
+| `company.name` | A nested field. |
+| `metadata."build-id"` | A field that requires JSON quoting. |
+| `findings[0]`, `findings[-1]` | An array element. |
+| `findings[1:4]`, `findings[::-1]` | An array slice. |
+| `findings[*].summary` | The `summary` field from each array element. |
+| `authors.*.name` | The `name` field from each object value, in unspecified order. |
+| `groups[].members` | The `members` field after flattening one array level. |
+
+Missing fields, incompatible types, and out-of-range indexes produce `null`. Wildcards, slices, and flattening omit null values when more path steps follow. Filters, comparisons, logical expressions, literals, multi-selects, functions, and additional pipes are not supported.
+
+`{ name }` stays unchanged. To output the literal text `{{ name }}`, write `{{{{ name }}}}`.
+
+</details>
+
+### Schemas
+
+A `Schema` constrains a task result.
+
+```rust
+use agentwerk::schemas::Schema;
+
+let schema = Schema::new(json!({
+    "type": "object",
+    "properties": { "title": { "type": "string" } },
+    "required": ["title"]
+}))?;
+
+werk.add_task(Task::new("Write a report.").schema(schema));
+```
+
+<details>
+<summary>Schema reference</summary>
+
+agentwerk corrects common result-formatting mistakes, such as a quoted number or a nested object encoded as JSON text. Schema-bound results must be objects. Remaining schema violations trigger a retry, subject to `max_schema_retries`. Without a schema, a task may return any JSON value.
+
+Use shallow, focused schemas for small models. Split complex work into tasks with separate schemas.
+
+| | Method | Description |
+|-|--------|-------------|
+| **Schema** | `Schema::new(document)` | Create a schema. |
+| | `validate(value)` | Return the validated value and JSON pointers to repaired values, or report violations. |
+| | `get_raw_schema()` | Read the JSON Schema document the schema was built from. |
+
+See [`Schema`](https://docs.rs/agentwerk/latest/agentwerk/schemas/struct.Schema.html).
+
+</details>
+
+### Directives
+
+Directives tell the model how to recover from failures. Override their wording for your model or environment.
+
+```rust
+let agent = Agent::from_env()
+    .directive("grep_failed", "The search did not run. Narrow `path`.")
+    .directives([
+        ("tool_timed_out", "Reduce the command scope."),
+        ("cache_miss", "No cache entry exists for {{ path }}."),
+    ]);
+```
+
+<details>
+<summary>Directive reference</summary>
+
+Built-in keys override recovery text. Keys without overrides retain their defaults. Templates accept runtime values such as `{{ detail }}`, `{{ attempt }}`, and `{{ path }}`. Placeholders without a value remain unchanged.
+
+See [prompts/directives](https://github.com/canvascomputing/agentwerk/tree/main/crates/agentwerk/src/prompts/directives) for the built-in text.
 
 </details>
 
@@ -440,13 +596,13 @@ See [`Task`](https://docs.rs/agentwerk/latest/agentwerk/struct.Task.html).
 Agents can pass work and results in five ways:
 
 1. **Result hook**: `on_result` creates follow-up tasks from completed work.
-2. **Template values**: enrich prompts with template strings or AQL-selected results.
+2. **[Task templates](#template-values)**: interpolate shared values, results, tasks, and events.
 3. **KnowledgeTool**: shares durable pages between agents.
 4. **TaskTool**: reads any finished task's result by ID.
 5. **ReadFileTool**: opens a task's `result.json` in the session directory.
 
 <details>
-<summary>Result-sharing examples</summary>
+<summary>Other result-sharing examples</summary>
 
 #### 1. Result hook
 
@@ -459,112 +615,6 @@ werk.on_result(|werk, done, result| {
     }
 });
 ```
-
-#### 2. Template values
-
-Define an agent with placeholders, then set the template values before adding its task:
-
-```rust
-use agentwerk::{Agent, Task};
-
-werk.add_agent(
-    Agent::from_env()
-        .label("report")
-        .role("Write for {{ company }} using:\n{{ results: research }}"),
-);
-werk.set_template("company", "Canvas Computing");
-werk.finish_tasks("research").await;
-werk.add_task(Task::labeled("report", "Write the board report."));
-```
-
-agentwerk fills placeholders in the role and task just before each task's first model request. Newly added tasks use the latest template values and results.
-
-#### Template reference
-
-| Expression | Output |
-|---|---|
-| `{{ name }}` | The value assigned to `name`. |
-| `{{ result: AQL }}` | The first result. Strings appear as text and other values as compact JSON. |
-| `{{ results: AQL }}` | A compact JSON array of matching results. |
-| `{{ result: AQL \| path }}` | A value selected from the first result. |
-| `{{ results: AQL \| path }}` | A value selected from the array of matching results. |
-| `{{ result_path: AQL }}` | The absolute path of the first matching result file. |
-| `{{ result_paths: AQL }}` | A JSON array of absolute result file paths. |
-| `{{ readable(result: AQL) }}` | The first result as a readable outline. |
-| `{{ readable(results: AQL) }}` | Matching results as a readable outline. |
-
-You can select results with AQL and use ` | path` to select a value from their JSON. You can also use paths with functions such as `readable`: `{{ readable(result: research | findings[*].summary) }}`.
-
-For example, given this `research` result:
-
-```json
-{
-  "company": {"name": "Canvas Computing"},
-  "findings": [{"summary": "one"}, {"summary": "two"}]
-}
-```
-
-This template:
-
-```text
-{{ result: research | company.name }}
-```
-
-Renders as:
-
-```text
-Canvas Computing
-```
-
-Using `readable` with a wildcard:
-
-```text
-{{ readable(result: research | findings[*].summary) }}
-```
-
-Renders as:
-
-```text
-- one
-- two
-```
-
-| Path | Selects |
-|---|---|
-| `company.name` | A nested field. |
-| `metadata."build-id"` | A field that requires JSON quoting. |
-| `findings[0]`, `findings[-1]` | An array element. |
-| `findings[1:4]`, `findings[::-1]` | An array slice. |
-| `findings[*].summary` | The `summary` field from each array element. |
-| `authors.*.name` | The `name` field from each object value, in unspecified order. |
-| `groups[].members` | The `members` field after flattening one array level. |
-
-Missing fields, incompatible types, and out-of-range indexes produce `null`. Wildcards, slices, and flattening omit null values when more path steps follow. Filters, comparisons, logical expressions, literals, multi-selects, functions, and additional pipes are not supported.
-
-`{ name }` stays unchanged. To output the literal text `{{ name }}`, write `{{{{ name }}}}`.
-
-#### Readable results
-
-Use `readable` when an agent should receive structured results as an outline instead of JSON:
-
-```rust
-werk.add_agent(
-    Agent::from_env()
-        .label("report")
-        .role("Summarize:\n{{ readable(results: task.label = research) }}"),
-);
-```
-
-Results such as `{"title":"Market","updates":["one","two"]}` render as:
-
-```text
-- title: Market
-  updates:
-    - one
-    - two
-```
-
-Nulls and empty collections do not appear.
 
 #### 3. KnowledgeTool
 
@@ -604,39 +654,6 @@ writer.add_task("Read .agentwerk/tasks/t-1/result.json, then write the board rep
 ```
 
 Results live in the session directory, one `result.json` per task.
-
-</details>
-
-### Schemas
-
-A `Schema` constrains a task result.
-
-```rust
-use agentwerk::schemas::Schema;
-
-let schema = Schema::new(json!({
-    "type": "object",
-    "properties": { "title": { "type": "string" } },
-    "required": ["title"]
-}))?;
-
-werk.add_task(Task::new("Write a report.").schema(schema));
-```
-
-<details>
-<summary>Schema reference</summary>
-
-Agentwerk corrects common result-formatting mistakes, such as a quoted number or a nested object encoded as JSON text. Schema-bound results must be objects. Remaining schema violations trigger a retry, subject to `max_schema_retries`. Without a schema, a task may return any JSON value.
-
-Use shallow, focused schemas for small models. Split complex work into tasks with separate schemas.
-
-| | Method | Description |
-|-|--------|-------------|
-| **Schema** | `Schema::new(document)` | Create a schema. |
-| | `validate(value)` | Return the validated value and JSON pointers to repaired values, or report violations. |
-| | `get_raw_schema()` | Read the JSON Schema document the schema was built from. |
-
-See [`Schema`](https://docs.rs/agentwerk/latest/agentwerk/schemas/struct.Schema.html).
 
 </details>
 
@@ -698,28 +715,6 @@ werk.on_event(|_, event| {
 ```
 
 Each compaction event carries the trigger: `proactive` before a context-window error or `reactive` after one. A failure also carries a stable `kind` and human-readable `message`.
-
-</details>
-
-### Directives
-
-Directives tell the model how to recover from failures. Override their wording for your model or environment.
-
-```rust
-let agent = Agent::from_env()
-    .directive("grep_failed", "The search did not run. Narrow `path`.")
-    .directives([
-        ("tool_timed_out", "Reduce the command scope."),
-        ("cache_miss", "No cache entry exists for {{ path }}."),
-    ]);
-```
-
-<details>
-<summary>Directive reference</summary>
-
-Built-in keys override recovery text. Keys without overrides retain their defaults. Templates accept runtime values such as `{{ detail }}`, `{{ attempt }}`, and `{{ path }}`. Placeholders without a value remain unchanged.
-
-See [prompts/directives](https://github.com/canvascomputing/agentwerk/tree/main/crates/agentwerk/src/prompts/directives) for the built-in text.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -82,9 +82,9 @@ agentwerk has five core concepts. An `Agent` uses tools to complete a `Task`, a 
 
 | Section | Covers |
 |---|---|
-| [Agents](#agents) | Roles, behavior, and [providers](#providers). |
-| [Tasks](#tasks) | [Templates](#template-values), [JSONPath](#template-reference), [schemas](#schemas), and [directives](#directives). |
-| [Werk](#werk) | [Queries](#queries), [execution](#execution), [result sharing](#sharing-results), [configuration](#configuration), [compaction](#compaction), and [sessions](#sessions). |
+| [Agents](#agents) | Roles, behavior, and [Providers](#providers). |
+| [Tasks](#tasks) | [Templates](#template-values), [JSONPath](#template-reference), [Schemas](#schemas), and [Directives](#directives). |
+| [Werk](#werk) | [Queries](#queries), [Execution](#execution), [Result sharing](#sharing-results), [Configuration](#configuration), [Compaction](#compaction), and [Sessions](#sessions). |
 | [Tools](#tools) | Controlled capabilities for agents. |
 | [Events](#events) | Observability and hooks. |
 | [Knowledge](#knowledge) | Durable shared memory. |

--- a/agentdocs/architecture.md
+++ b/agentdocs/architecture.md
@@ -18,8 +18,8 @@ The invariants that govern orchestration, tools, providers, events, and durable 
 
 - Delegate Agent setters to Werk. Import missing templates when binding; destination values win.
 - Parse double-brace syntax once in `prompts/prompt.rs`; use strict expression resolution for prompts and infallible named resolution for directives and runtime context. Never scan inserted values.
-- Allow one layer of named values inside result queries as raw AQL source. Keep `readable` limited to singular and plural result selectors, formatting their JSON values as an indented outline.
-- Split a whitespace-delimited JSON path from AQL before expanding named query values. Evaluate it through `prompts/json_path.rs` after selecting results and before plain or readable formatting.
+- Allow one layer of template variables inside selector queries as raw AQL source.
+- Split a whitespace-delimited JSON path from template variables or selector AQL before expanding query variables. Evaluate it through `prompts/json_path.rs` before plain formatting.
 - Let Werk snapshot shared templates once when it prepares a role and initial string task, and report failures through `prompt_render_failed` before the first request.
 - Freeze the complete rendered system prompt at the task's first request. Reuse its earliest persisted system reply through later turns, retries, continuation, compaction, and reload.
 - Record the prepared task message and one frozen system prompt in replies. Keep shared templates as runtime configuration rather than persisted session data; ignore legacy captured template fields when loading tasks.

--- a/agentdocs/layout.md
+++ b/agentdocs/layout.md
@@ -20,7 +20,7 @@ Where code, tests, bindings, examples, and repository guidance live.
 - `src/event.rs` owns `Event`; `src/persistence.rs` owns shared file primitives and stays crate-private.
 - `src/agents/` owns agent configuration, tasks, orchestration, policy, queries, statistics, retries, compaction, and knowledge.
 - `src/providers/`, `src/tools/`, and `src/schemas/` own LLM providers, agent actions, and result validation.
-- `src/prompts/prompt.rs` owns Werk's single-pass template substitution and AQL expressions; `json_path.rs` parses and evaluates JSON paths over selected results. `prompts/mod.rs` supplies runtime string values and directives; Agent and Task pass prompts to Werk.
+- `src/prompts/prompt.rs` owns Werk's single-pass template substitution and AQL expressions. `json_path.rs` parses and evaluates JSON paths over template variables and selected tasks, results, or events. `prompts/mod.rs` supplies runtime string values and directives. Agent and Task pass prompts to Werk.
 
 ## Agents and Tasks
 

--- a/crates/agentwerk-py/README.md
+++ b/crates/agentwerk-py/README.md
@@ -83,7 +83,7 @@ asyncio.run(main())
 
 ## API
 
-agentwerk has five core concepts. An `Agent` uses tools to complete a `Task`, a unit of work whose result is a JSON value. A `Werk` coordinates agents and tasks, and an `Event` records activity.
+agentwerk has six core concepts. An `Agent` uses `Tools` to complete a `Task` and create a JSON result. A `Werk` coordinates agents and tasks, `Events` record activity, and `Knowledge` provides durable shared memory.
 
 | Section | Covers |
 |---|---|

--- a/crates/agentwerk-py/README.md
+++ b/crates/agentwerk-py/README.md
@@ -83,11 +83,16 @@ asyncio.run(main())
 
 ## API
 
-- [Agents](#agents): Set agent roles, behavior, and tasks.
-- [Werk](#werk): Assign work and collect results across agents.
-- [Tools](#tools): Give agents controlled ways to act.
-- [Events](#events): Inspect requests, tool calls, and failures.
-- [Knowledge](#knowledge): Share durable memory across agents and tasks.
+agentwerk has five core concepts. An `Agent` uses tools to complete a `Task`, a unit of work whose result is a JSON value. A `Werk` coordinates agents and tasks, and an `Event` records activity.
+
+| Section | Covers |
+|---|---|
+| [Agents](#agents) | Roles, behavior, and [providers](#providers). |
+| [Tasks](#tasks) | [Templates](#template-values), [JSONPath](#template-reference), [schemas](#schemas), and [directives](#directives). |
+| [Werk](#werk) | [Queries](#queries), [execution](#execution), [result sharing](#sharing-results), [configuration](#configuration), [compaction](#compaction), and [sessions](#sessions). |
+| [Tools](#tools) | Controlled capabilities for agents. |
+| [Events](#events) | Observability and hooks. |
+| [Knowledge](#knowledge) | Durable shared memory. |
 
 ## Agents
 
@@ -110,8 +115,6 @@ agent.add_task("Read CHANGELOG.md and summarize the entries added since the last
 
 results = await agent.finish()
 ```
-
-The [prompt skill](../../skills/prompt/SKILL.md) provides a compact template for writing agent roles.
 
 <details>
 <summary>Agent reference</summary>
@@ -239,6 +242,170 @@ agent = Agent().model(
 ```
 
 See [`Provider`](https://docs.rs/agentwerk/latest/agentwerk/providers/struct.Provider.html) and [`Model`](https://docs.rs/agentwerk/latest/agentwerk/providers/struct.Model.html).
+
+</details>
+
+## Tasks
+
+Roles and tasks can interpolate shared values and selected runtime data. The [prompt skill](../../skills/prompt/SKILL.md) provides a compact template for writing agent roles.
+
+### Template values
+
+Define an agent with placeholders, then set the template values before adding its task:
+
+```python
+from agentwerk import Agent, Task
+
+werk.add_agent(
+    Agent.from_env()
+    .label("report")
+    .role(
+        "Write for {{ company }} using:\n"
+        "{{ results: research }}"
+    )
+)
+werk.set_template("company", "Canvas Computing")
+await werk.finish_tasks("research")
+werk.add_task(Task("Write the board report.", label="report"))
+```
+
+agentwerk fills placeholders in the role and task just before each task's first model request. Newly added tasks use the latest template values and results.
+
+<details>
+<summary id="template-reference">Template reference</summary>
+
+| Expression | Output |
+|---|---|
+| `{{ name }}` | The value assigned to `name`. |
+| `{{ name \| JSONPath }}` | A value selected from the template variable after parsing it as JSON. |
+| `{{ result: AQL }}` | The first result. Strings appear as text and other values as compact JSON. |
+| `{{ results: AQL }}` | A compact JSON array of matching results. |
+| `{{ result: AQL \| JSONPath }}` | A value selected from the first result. |
+| `{{ results: AQL \| JSONPath }}` | A value selected from the array of matching results. |
+| `{{ task: AQL }}` | The first matching task as compact JSON, or `null`. |
+| `{{ tasks: AQL }}` | A compact JSON array of matching tasks. |
+| `{{ task: AQL \| JSONPath }}` | A value selected from the first matching task. |
+| `{{ tasks: AQL \| JSONPath }}` | A value selected from the array of matching tasks. |
+| `{{ event: AQL }}` | The first matching event as compact JSON, or `null`. |
+| `{{ events: AQL }}` | A compact JSON array of matching events. |
+| `{{ event: AQL \| JSONPath }}` | A value selected from the first matching event. |
+| `{{ events: AQL \| JSONPath }}` | A value selected from the array of matching events. |
+
+Use JSONPath after a template variable or AQL selection. Template variables are parsed as JSON, with malformed JSON becoming `null`. Task and event selectors match the corresponding `find_*` method. Plural selections use the array as the root.
+
+| Record | JSONPath properties |
+|---|---|
+| Task | `task`, `label`, `schema`, `id`, `status`, `reporter`, `assignee`, `created_at`, `started_at`, `finished_at`, `failed_at` |
+| Event | `name`, `directive`, `data`, `task_id`, `agent_id`, `label`, `created_at` |
+
+`task` is the original JSON input. Unset `label`, `schema`, `assignee`, and `directive` properties are omitted. Task results, errors, replies, and cancellation state are not serialized.
+
+For example, given this `research` result:
+
+```json
+{
+  "company": {"name": "Canvas Computing"},
+  "findings": [{"summary": "one"}, {"summary": "two"}]
+}
+```
+
+This template:
+
+```text
+{{ result: research | company.name }}
+```
+
+Renders as:
+
+```text
+Canvas Computing
+```
+
+Select each task input or event's data:
+
+```text
+{{ tasks: research | [*].task }}
+{{ events: event.name = tool_call_failed | [*].data }}
+```
+
+`research` is shorthand for `task.label = research`.
+
+| Path | Selects |
+|---|---|
+| `company.name` | A nested field. |
+| `metadata."build-id"` | A field that requires JSON quoting. |
+| `findings[0]`, `findings[-1]` | An array element. |
+| `findings[1:4]`, `findings[::-1]` | An array slice. |
+| `findings[*].summary` | The `summary` field from each array element. |
+| `authors.*.name` | The `name` field from each object value, in unspecified order. |
+| `groups[].members` | The `members` field after flattening one array level. |
+
+Missing fields, incompatible types, and out-of-range indexes produce `null`. Wildcards, slices, and flattening omit null values when more path steps follow. Filters, comparisons, logical expressions, literals, multi-selects, functions, and additional pipes are not supported.
+
+`{ name }` stays unchanged. To output the literal text `{{ name }}`, write `{{{{ name }}}}`.
+
+</details>
+
+### Schemas
+
+A `Schema` constrains a task result.
+
+```python
+from agentwerk import Schema, Task
+
+schema = Schema(
+    {
+        "type": "object",
+        "properties": {"title": {"type": "string"}},
+        "required": ["title"],
+    }
+)
+
+werk.add_task(Task("Write a report.", schema=schema))
+```
+
+<details>
+<summary>Schema reference</summary>
+
+agentwerk corrects common result-formatting mistakes, such as a quoted number or a nested object encoded as JSON text. Schema-bound results must be objects. Remaining schema violations trigger a retry, subject to `max_schema_retries`. Without a schema, a task may return any JSON value.
+
+Use shallow, focused schemas for small models. Split complex work into tasks with separate schemas.
+
+| | Method | Description |
+|-|--------|-------------|
+| **Schema** | `Schema(document)` | Create a schema. |
+| | `validate(value)` | Return the validated value and JSON pointers to repaired values, or report violations. |
+
+See [`Schema`](https://docs.rs/agentwerk/latest/agentwerk/schemas/struct.Schema.html).
+
+</details>
+
+### Directives
+
+Directives tell the model how to recover from failures. Override their wording for your model or environment.
+
+```python
+from agentwerk import Agent
+
+
+agent = (
+    Agent.from_env()
+    .directive("grep_failed", "The search did not run. Narrow `path`.")
+    .directives(
+        {
+            "tool_timed_out": "Reduce the command scope.",
+            "cache_miss": "No cache entry exists for {{ path }}.",
+        }
+    )
+)
+```
+
+<details>
+<summary>Directive reference</summary>
+
+Built-in keys override recovery text. Keys without overrides retain their defaults. Templates accept runtime values such as `{{ detail }}`, `{{ attempt }}`, and `{{ path }}`. Placeholders without a value remain unchanged.
+
+See [prompts/directives](https://github.com/canvascomputing/agentwerk/tree/main/crates/agentwerk/src/prompts/directives) for the built-in text.
 
 </details>
 
@@ -457,13 +624,13 @@ See [`Task`](https://docs.rs/agentwerk/latest/agentwerk/struct.Task.html).
 Agents can pass work and results in five ways:
 
 1. **Result hook**: `on_result` creates follow-up tasks from completed work.
-2. **Template values**: enrich prompts with template strings or AQL-selected results.
+2. **[Task templates](#template-values)**: interpolate shared values, results, tasks, and events.
 3. **KnowledgeTool**: shares durable pages between agents.
 4. **TaskTool**: reads any finished task's result by ID.
 5. **ReadFileTool**: opens a task's `result.json` in the session directory.
 
 <details>
-<summary>Result-sharing examples</summary>
+<summary>Other result-sharing examples</summary>
 
 #### 1. Result hook
 
@@ -477,115 +644,6 @@ def hand_to_report(werk, done, result):
 
 werk.on_result(hand_to_report)
 ```
-
-#### 2. Template values
-
-Define an agent with placeholders, then set the template values before adding its task:
-
-```python
-from agentwerk import Agent, Task
-
-werk.add_agent(
-    Agent.from_env()
-    .label("report")
-    .role(
-        "Write for {{ company }} using:\n"
-        "{{ results: research }}"
-    )
-)
-werk.set_template("company", "Canvas Computing")
-await werk.finish_tasks("research")
-werk.add_task(Task("Write the board report.", label="report"))
-```
-
-agentwerk fills placeholders in the role and task just before each task's first model request. Newly added tasks use the latest template values and results.
-
-#### Template reference
-
-| Expression | Output |
-|---|---|
-| `{{ name }}` | The value assigned to `name`. |
-| `{{ result: AQL }}` | The first result. Strings appear as text and other values as compact JSON. |
-| `{{ results: AQL }}` | A compact JSON array of matching results. |
-| `{{ result: AQL \| path }}` | A value selected from the first result. |
-| `{{ results: AQL \| path }}` | A value selected from the array of matching results. |
-| `{{ result_path: AQL }}` | The absolute path of the first matching result file. |
-| `{{ result_paths: AQL }}` | A JSON array of absolute result file paths. |
-| `{{ readable(result: AQL) }}` | The first result as a readable outline. |
-| `{{ readable(results: AQL) }}` | Matching results as a readable outline. |
-
-You can select results with AQL and use ` | path` to select a value from their JSON. You can also use paths with functions such as `readable`: `{{ readable(result: research | findings[*].summary) }}`.
-
-For example, given this `research` result:
-
-```json
-{
-  "company": {"name": "Canvas Computing"},
-  "findings": [{"summary": "one"}, {"summary": "two"}]
-}
-```
-
-This template:
-
-```text
-{{ result: research | company.name }}
-```
-
-Renders as:
-
-```text
-Canvas Computing
-```
-
-Using `readable` with a wildcard:
-
-```text
-{{ readable(result: research | findings[*].summary) }}
-```
-
-Renders as:
-
-```text
-- one
-- two
-```
-
-| Path | Selects |
-|---|---|
-| `company.name` | A nested field. |
-| `metadata."build-id"` | A field that requires JSON quoting. |
-| `findings[0]`, `findings[-1]` | An array element. |
-| `findings[1:4]`, `findings[::-1]` | An array slice. |
-| `findings[*].summary` | The `summary` field from each array element. |
-| `authors.*.name` | The `name` field from each object value, in unspecified order. |
-| `groups[].members` | The `members` field after flattening one array level. |
-
-Missing fields, incompatible types, and out-of-range indexes produce `null`. Wildcards, slices, and flattening omit null values when more path steps follow. Filters, comparisons, logical expressions, literals, multi-selects, functions, and additional pipes are not supported.
-
-`{ name }` stays unchanged. To output the literal text `{{ name }}`, write `{{{{ name }}}}`.
-
-#### Readable results
-
-Use `readable` when an agent should receive structured results as an outline instead of JSON:
-
-```python
-werk.add_agent(
-    Agent.from_env()
-    .label("report")
-    .role("Summarize:\n{{ readable(results: task.label = research) }}")
-)
-```
-
-Results such as `{"title":"Market","updates":["one","two"]}` render as:
-
-```text
-- title: Market
-  updates:
-    - one
-    - two
-```
-
-Nulls and empty collections do not appear.
 
 #### 3. KnowledgeTool
 
@@ -621,40 +679,6 @@ writer.add_task("Read .agentwerk/tasks/t-1/result.json, then write the board rep
 ```
 
 Results live in the session directory, one `result.json` per task.
-
-</details>
-
-### Schemas
-
-A `Schema` constrains a task result.
-
-```python
-from agentwerk import Schema, Task
-
-schema = Schema(
-    {
-        "type": "object",
-        "properties": {"title": {"type": "string"}},
-        "required": ["title"],
-    }
-)
-
-werk.add_task(Task("Write a report.", schema=schema))
-```
-
-<details>
-<summary>Schema reference</summary>
-
-Agentwerk corrects common result-formatting mistakes, such as a quoted number or a nested object encoded as JSON text. Schema-bound results must be objects. Remaining schema violations trigger a retry, subject to `max_schema_retries`. Without a schema, a task may return any JSON value.
-
-Use shallow, focused schemas for small models. Split complex work into tasks with separate schemas.
-
-| | Method | Description |
-|-|--------|-------------|
-| **Schema** | `Schema(document)` | Create a schema. |
-| | `validate(value)` | Return the validated value and JSON pointers to repaired values, or report violations. |
-
-See [`Schema`](https://docs.rs/agentwerk/latest/agentwerk/schemas/struct.Schema.html).
 
 </details>
 
@@ -710,35 +734,6 @@ werk.on_event(watch)
 ```
 
 Each compaction event carries the trigger: `proactive` before a context-window error or `reactive` after one. A failure also carries a stable `kind` and human-readable `message`.
-
-</details>
-
-### Directives
-
-Directives tell the model how to recover from failures. Override their wording for your model or environment.
-
-```python
-from agentwerk import Agent
-
-
-agent = (
-    Agent.from_env()
-    .directive("grep_failed", "The search did not run. Narrow `path`.")
-    .directives(
-        {
-            "tool_timed_out": "Reduce the command scope.",
-            "cache_miss": "No cache entry exists for {{ path }}.",
-        }
-    )
-)
-```
-
-<details>
-<summary>Directive reference</summary>
-
-Built-in keys override recovery text. Keys without overrides retain their defaults. Templates accept runtime values such as `{{ detail }}`, `{{ attempt }}`, and `{{ path }}`. Placeholders without a value remain unchanged.
-
-See [prompts/directives](https://github.com/canvascomputing/agentwerk/tree/main/crates/agentwerk/src/prompts/directives) for the built-in text.
 
 </details>
 

--- a/crates/agentwerk-py/README.md
+++ b/crates/agentwerk-py/README.md
@@ -87,9 +87,9 @@ agentwerk has five core concepts. An `Agent` uses tools to complete a `Task`, a 
 
 | Section | Covers |
 |---|---|
-| [Agents](#agents) | Roles, behavior, and [providers](#providers). |
-| [Tasks](#tasks) | [Templates](#template-values), [JSONPath](#template-reference), [schemas](#schemas), and [directives](#directives). |
-| [Werk](#werk) | [Queries](#queries), [execution](#execution), [result sharing](#sharing-results), [configuration](#configuration), [compaction](#compaction), and [sessions](#sessions). |
+| [Agents](#agents) | Roles, behavior, and [Providers](#providers). |
+| [Tasks](#tasks) | [Templates](#template-values), [JSONPath](#template-reference), [Schemas](#schemas), and [Directives](#directives). |
+| [Werk](#werk) | [Queries](#queries), [Execution](#execution), [Result sharing](#sharing-results), [Configuration](#configuration), [Compaction](#compaction), and [Sessions](#sessions). |
 | [Tools](#tools) | Controlled capabilities for agents. |
 | [Events](#events) | Observability and hooks. |
 | [Knowledge](#knowledge) | Durable shared memory. |

--- a/crates/agentwerk-py/tests/test_prompts.py
+++ b/crates/agentwerk-py/tests/test_prompts.py
@@ -28,28 +28,22 @@ async def test_shared_template_values_are_inserted_literally(werk, scripted_open
     assert messages[1]["content"] == "For {{ company }}: {{ result: missing }} {{ unknown }}"
 
 
-async def test_direct_aql_expressions_resolve_results_and_paths(
-    werk, tmp_path, scripted_openai
-):
+async def test_direct_aql_expressions_resolve_results(werk, scripted_openai):
     first = werk.add_task(aw.Task("first", label="research"))
     second = werk.add_task(aw.Task("second", label="research"))
     werk.set_task_finished(first, {"research": "one {{ company }}"})
     werk.set_task_finished(second, {"answer": 42})
-    second_path = (tmp_path / "tasks" / second / "result.json").resolve()
-    role = f"{{{{ result: research }}}} | {{{{ result_path: {second} }}}}"
     scripted_openai.respond_with_tool("finish", {"answer": "done"})
     werk.add_agent(
         aw.Agent()
         .provider(scripted_openai.provider())
         .model("mock")
-        .role(role)
+        .role("{{ result: research }}")
     )
     werk.add_task("{{ results: research ORDER BY task.id DESC }}")
     await asyncio.wait_for(werk.finish(), timeout=5)
     messages = scripted_openai.requests[0]["messages"]
-    assert messages[0]["content"] == (
-        f'{{"research":"one {{{{ company }}}}"}} | {second_path}'
-    )
+    assert messages[0]["content"] == '{"research":"one {{ company }}"}'
     assert messages[1]["content"] == (
         '[{"answer":42},{"research":"one {{ company }}"}]'
     )
@@ -76,9 +70,64 @@ async def test_result_json_paths_navigate_selected_json(werk, scripted_openai):
     assert messages[1]["content"] == '["Acme","Canvas"]'
 
 
-async def test_nested_query_values_and_readable_results(
-    werk, scripted_openai
-):
+async def test_template_variable_json_paths(werk, scripted_openai):
+    werk.set_template("profile", '{"company":{"name":"Acme"}}')
+    scripted_openai.respond_with_tool("finish", {"answer": "done"})
+    werk.add_agent(
+        aw.Agent()
+        .provider(scripted_openai.provider())
+        .model("mock")
+        .role("{{ profile | company.name }}")
+    )
+    werk.add_task("go")
+
+    await asyncio.wait_for(werk.finish(), timeout=5)
+
+    messages = scripted_openai.requests[0]["messages"]
+    assert messages[0]["content"] == "Acme"
+
+
+async def test_task_expressions_select_json(werk, scripted_openai):
+    first = werk.add_task(aw.Task({"file": "one"}, label="scan"))
+    second = werk.add_task(aw.Task({"file": "two"}, label="scan"))
+    werk.set_task_finished(first, {"status": "done"})
+    werk.set_task_finished(second, {"status": "done"})
+    scripted_openai.respond_with_tool("finish", {"answer": "done"})
+    werk.add_agent(
+        aw.Agent()
+        .provider(scripted_openai.provider())
+        .model("mock")
+        .role("{{ task: scan ORDER BY task.id DESC | task.file }}")
+    )
+    werk.add_task("{{ tasks: scan | [*].id }}")
+
+    await asyncio.wait_for(werk.finish(), timeout=5)
+
+    messages = scripted_openai.requests[0]["messages"]
+    assert messages[0]["content"] == "two"
+    assert messages[1]["content"] == f'["{first}","{second}"]'
+
+
+async def test_event_expressions_select_json(werk, scripted_openai):
+    werk.emit_event(aw.Event("inspection").data({"name": "one"}))
+    werk.emit_event(aw.Event("inspection").data({"name": "two"}))
+    scripted_openai.respond_with_tool("finish", {"answer": "done"})
+    werk.add_agent(
+        aw.Agent()
+        .provider(scripted_openai.provider())
+        .model("mock")
+        .role("{{ event: event.name = inspection | data.name }}")
+    )
+    werk.add_task("{{ events: event.name = inspection | [*].data.name }}")
+
+    await asyncio.wait_for(werk.finish(), timeout=5)
+
+    messages = scripted_openai.requests[0]["messages"]
+    assert messages[0]["content"] == "one"
+    assert messages[1]["content"] == '["one","two"]'
+
+
+async def test_nested_query_values_select_results(werk, scripted_openai):
     first = werk.add_task(aw.Task("first", label="research"))
     second = werk.add_task(aw.Task("second", label="research"))
     werk.set_task_finished(first, {"title": "Market", "empty": None})
@@ -89,12 +138,12 @@ async def test_nested_query_values_and_readable_results(
         aw.Agent()
         .provider(scripted_openai.provider())
         .model("mock")
-        .role("{{ readable(results: {{ selection }}) }}")
+        .role("{{ results: {{ selection }} }}")
     )
     werk.add_task("go")
     await asyncio.wait_for(werk.finish(), timeout=5)
     assert scripted_openai.requests[0]["messages"][0]["content"] == (
-        "- title: Market\n-\n  - one\n  - two"
+        '[{"empty":null,"title":"Market"},["one",null,"two"]]'
     )
 
 

--- a/crates/agentwerk/src/agents/loop/render_tests.rs
+++ b/crates/agentwerk/src/agents/loop/render_tests.rs
@@ -76,10 +76,9 @@ async fn later_template_and_result_updates_do_not_change_the_task_prompts() {
         Ok(paused_text_response("continue")),
         Ok(write_result_response("done")),
     ]);
-    let first = research(&werk, "old research");
-    let first_path = werk.result_path(&first).canonicalize().unwrap();
+    research(&werk, "old research");
     werk.set_template("company", "Old");
-    let role = "{{ company }}: {{ result: research ORDER BY task.id DESC }} | {{ result_path: research ORDER BY task.id DESC }}";
+    let role = "{{ company }}: {{ result: research ORDER BY task.id DESC }}";
     werk.add_agent(task_agent(&provider).role(role));
     let id = werk.add_task("{{ company }}: {{ result: research ORDER BY task.id DESC }}");
     werk.on_event(|werk, event| {
@@ -89,10 +88,7 @@ async fn later_template_and_result_updates_do_not_change_the_task_prompts() {
         }
     });
     finish(&werk).await;
-    let frozen = format!(
-        r#"Old: {{"research":"old research"}} | {}"#,
-        first_path.display()
-    );
+    let frozen = r#"Old: {"research":"old research"}"#.to_string();
     assert_eq!(
         provider.received_system_prompts(),
         [frozen.clone(), frozen.clone()]

--- a/crates/agentwerk/src/prompts/json_path.rs
+++ b/crates/agentwerk/src/prompts/json_path.rs
@@ -1,4 +1,4 @@
-//! Parses and evaluates the navigation subset used by result templates.
+//! Parses and evaluates the navigation subset used by template expressions.
 
 use std::fmt;
 
@@ -471,14 +471,33 @@ mod tests {
 
     #[test]
     fn array_integers_must_fit_the_supported_range() {
-        for path in [
-            "[999999999999999999999999]",
-            "[-999999999999999999999999]",
-            "[999999999999999999999999:]",
-            "[:999999999999999999999999]",
-            "[::999999999999999999999999]",
+        for (path, message) in [
+            (
+                "[999999999999999999999999]",
+                "JSON path array index is outside the supported range",
+            ),
+            (
+                "[-999999999999999999999999]",
+                "JSON path array index is outside the supported range",
+            ),
+            (
+                "[999999999999999999999999:]",
+                "JSON path slice bound is outside the supported range",
+            ),
+            (
+                "[:999999999999999999999999]",
+                "JSON path slice bound is outside the supported range",
+            ),
+            (
+                "[::999999999999999999999999]",
+                "JSON path slice step is outside the supported range",
+            ),
         ] {
-            assert!(JsonPath::parse(path).is_err(), "{path}");
+            assert_eq!(
+                JsonPath::parse(path).unwrap_err().to_string(),
+                message,
+                "{path}"
+            );
         }
     }
 
@@ -526,38 +545,46 @@ mod tests {
     }
 
     #[test]
-    fn unsupported_jmespath_features_are_rejected() {
-        for path in [
-            "items[?active]",
-            "foo == bar",
-            "foo || bar",
-            "length(items)",
-            "[foo,bar]",
-            "{foo: foo}",
-            "'literal'",
-            "`1`",
-            "@",
-            "foo | bar",
+    fn unsupported_jmespath_features_report_the_unsupported_syntax() {
+        for (path, message) in [
+            ("items[?active]", "invalid JSON path array index"),
+            ("foo == bar", "unsupported JSON path syntax at byte 3"),
+            ("foo || bar", "unsupported JSON path syntax at byte 3"),
+            ("length(items)", "unsupported JSON path syntax at byte 6"),
+            ("[foo,bar]", "invalid JSON path array index"),
+            ("{foo: foo}", "unsupported JSON path syntax at byte 0"),
+            ("'literal'", "unsupported JSON path syntax at byte 0"),
+            ("`1`", "unsupported JSON path syntax at byte 0"),
+            ("@", "unsupported JSON path syntax at byte 0"),
+            ("foo | bar", "unsupported JSON path syntax at byte 3"),
         ] {
-            assert!(JsonPath::parse(path).is_err(), "{path}");
+            assert_eq!(
+                JsonPath::parse(path).unwrap_err().to_string(),
+                message,
+                "{path}"
+            );
         }
     }
 
     #[test]
-    fn malformed_json_paths_are_rejected() {
-        for path in [
-            "",
-            "foo.",
-            "foo..bar",
-            "foo bar",
-            "\"",
-            "\"\"",
-            "[",
-            "[one]",
-            "[1:2:3:4]",
-            r#""\q""#,
+    fn malformed_json_paths_report_why_parsing_failed() {
+        for (path, message) in [
+            ("", "JSON path cannot be empty"),
+            ("foo.", "expected a JSON path field at byte 4"),
+            ("foo..bar", "expected a JSON path field at byte 4"),
+            ("foo bar", "unsupported JSON path syntax at byte 3"),
+            ("\"", "unclosed quoted JSON path field"),
+            ("\"\"", "quoted JSON path fields cannot be empty"),
+            ("[", "unclosed JSON path bracket"),
+            ("[one]", "invalid JSON path array index"),
+            ("[1:2:3:4]", "invalid JSON path slice"),
+            (r#""\q""#, "invalid quoted JSON path field"),
         ] {
-            assert!(JsonPath::parse(path).is_err(), "{path}");
+            assert_eq!(
+                JsonPath::parse(path).unwrap_err().to_string(),
+                message,
+                "{path}"
+            );
         }
     }
 }

--- a/crates/agentwerk/src/prompts/prompt.rs
+++ b/crates/agentwerk/src/prompts/prompt.rs
@@ -138,44 +138,46 @@ fn resolve_expression_value(
     expression: &str,
     named_value: &mut impl FnMut(&str) -> Option<String>,
 ) -> Result<Option<String>, String> {
-    if let Some(inner) = readable_expression(expression)? {
-        let Some(result) = result_expression(inner) else {
-            return Err("readable expects a result: or results: expression".into());
-        };
-        if !result.kind.selects_values() {
-            return Err("readable expects a result: or results: expression".into());
-        }
-        let value = resolve_result(werk, result, named_value)?;
-        return Ok(Some(readable(&value)));
-    }
-
-    if let Some(result) = result_expression(expression) {
-        let value = resolve_result(werk, result, named_value)?;
+    if let Some(selection) = selection_expression(expression) {
+        let value = resolve_selection(werk, selection, named_value)?;
         return Ok(Some(result_text(value)));
     }
 
-    let (expanded, had_nested_value) = expand_nested(expression, named_value)?;
-    if had_nested_value {
-        return Err("nested values are only supported inside result expressions".into());
-    }
-    Ok(named_value(expanded.trim()))
+    resolve_named_value(expression, named_value)
 }
 
-fn resolve_result(
+fn resolve_named_value(
+    expression: &str,
+    named_value: &mut impl FnMut(&str) -> Option<String>,
+) -> Result<Option<String>, String> {
+    let (name, json_path) = split_json_path(expression);
+    let (expanded, had_nested_value) = expand_nested(name, named_value)?;
+    if had_nested_value {
+        return Err("nested values are only supported inside selection expressions".into());
+    }
+    let Some(text) = named_value(expanded.trim()) else {
+        return Ok(None);
+    };
+    let Some(json_path) = json_path else {
+        return Ok(Some(text));
+    };
+    let json_path = JsonPath::parse(json_path.trim()).map_err(|error| error.to_string())?;
+    let value = serde_json::from_str(&text).unwrap_or(Value::Null);
+    Ok(Some(result_text(json_path.evaluate(&value))))
+}
+
+fn resolve_selection(
     werk: &Werk,
-    result: ResultExpression<'_>,
+    selection: SelectionExpression<'_>,
     named_value: &mut impl FnMut(&str) -> Option<String>,
 ) -> Result<Value, String> {
-    let (query, _had_nested_value) = expand_nested(result.query, named_value)?;
-    if result.json_path.is_some() && !result.kind.selects_values() {
-        return Err("JSON paths require result: or results:".into());
-    }
-    let json_path = result
+    let (query, _had_nested_value) = expand_nested(selection.query, named_value)?;
+    let json_path = selection
         .json_path
         .map(JsonPath::parse)
         .transpose()
         .map_err(|error| error.to_string())?;
-    let value = select_result(werk, result.kind, query.trim())?;
+    let value = select_value(werk, selection.kind, query.trim())?;
     let Some(json_path) = json_path else {
         return Ok(value);
     };
@@ -196,10 +198,7 @@ fn expand_nested(
             return Err("unclosed nested expression".into());
         };
         let name = body[..close].trim();
-        if name.is_empty()
-            || name.contains(EXPRESSION_OPEN)
-            || result_expression(name).is_some()
-            || name.starts_with("readable(")
+        if name.is_empty() || name.contains(EXPRESSION_OPEN) || selection_expression(name).is_some()
         {
             return Err("nested expressions must name a template value".into());
         }
@@ -214,60 +213,46 @@ fn expand_nested(
     Ok((output, expanded))
 }
 
-fn readable_expression(expression: &str) -> Result<Option<&str>, String> {
-    let Some(body) = expression.strip_prefix("readable(") else {
-        return Ok(None);
-    };
-    let Some(body) = body.strip_suffix(')') else {
-        return Err("unclosed readable call".into());
-    };
-    Ok(Some(body.trim()))
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ResultKind {
+enum SelectionKind {
     Result,
     Results,
-    ResultPath,
-    ResultPaths,
+    Task,
+    Tasks,
+    Event,
+    Events,
 }
 
-impl ResultKind {
+impl SelectionKind {
     fn parse(source: &str) -> Option<Self> {
         Some(match source {
             "result" => Self::Result,
             "results" => Self::Results,
-            "result_path" => Self::ResultPath,
-            "result_paths" => Self::ResultPaths,
+            "task" => Self::Task,
+            "tasks" => Self::Tasks,
+            "event" => Self::Event,
+            "events" => Self::Events,
             _ => return None,
         })
     }
 
-    fn selects_values(self) -> bool {
-        matches!(self, Self::Result | Self::Results)
-    }
-
     fn is_plural(self) -> bool {
-        matches!(self, Self::Results | Self::ResultPaths)
-    }
-
-    fn uses_file_paths(self) -> bool {
-        matches!(self, Self::ResultPath | Self::ResultPaths)
+        matches!(self, Self::Results | Self::Tasks | Self::Events)
     }
 }
 
 #[derive(Debug, Clone, Copy)]
-struct ResultExpression<'a> {
-    kind: ResultKind,
+struct SelectionExpression<'a> {
+    kind: SelectionKind,
     query: &'a str,
     json_path: Option<&'a str>,
 }
 
-fn result_expression(expression: &str) -> Option<ResultExpression<'_>> {
+fn selection_expression(expression: &str) -> Option<SelectionExpression<'_>> {
     let (kind, query) = expression.split_once(':')?;
-    let kind = ResultKind::parse(kind.trim())?;
+    let kind = SelectionKind::parse(kind.trim())?;
     let (query, json_path) = split_json_path(query);
-    Some(ResultExpression {
+    Some(SelectionExpression {
         kind,
         query: query.trim(),
         json_path: json_path.map(str::trim),
@@ -394,8 +379,19 @@ fn expression_end(body: &str) -> Result<Option<usize>, &'static str> {
     }
 }
 
-fn select_result(werk: &Werk, kind: ResultKind, query: &str) -> Result<Value, String> {
+fn select_value(werk: &Werk, kind: SelectionKind, query: &str) -> Result<Value, String> {
     let query = Query::new(query).map_err(|error| error.to_string())?;
+    match kind {
+        SelectionKind::Task => serde_json::to_value(werk.find_task(query)),
+        SelectionKind::Tasks => serde_json::to_value(werk.find_tasks(query)),
+        SelectionKind::Event => serde_json::to_value(werk.find_event(query)),
+        SelectionKind::Events => serde_json::to_value(werk.find_events(query)),
+        kind => return select_result(werk, kind, query),
+    }
+    .map_err(|error| format!("cannot serialize selection: {error}"))
+}
+
+fn select_result(werk: &Werk, kind: SelectionKind, query: Query) -> Result<Value, String> {
     let mut tasks = werk.result_tasks(query);
     let is_plural = kind.is_plural();
     if !is_plural && tasks.is_empty() {
@@ -404,11 +400,14 @@ fn select_result(werk: &Werk, kind: ResultKind, query: &str) -> Result<Value, St
     if !is_plural {
         tasks.truncate(1);
     }
-    let use_file_paths = kind.uses_file_paths();
     let values = tasks
         .iter()
-        .map(|task| result_value(werk, task, use_file_paths))
-        .collect::<Result<Vec<_>, _>>()?;
+        .map(|task| {
+            task.get_result()
+                .cloned()
+                .expect("result selector requires a result")
+        })
+        .collect::<Vec<_>>();
     if is_plural {
         return Ok(Value::Array(values));
     }
@@ -423,88 +422,6 @@ fn result_text(value: Value) -> String {
         Value::String(text) => text,
         value => value.to_string(),
     }
-}
-
-fn readable(value: &Value) -> String {
-    readable_lines(value, 0).join("\n")
-}
-
-fn readable_lines(value: &Value, indent: usize) -> Vec<String> {
-    let padding = " ".repeat(indent);
-    match value {
-        Value::Null => Vec::new(),
-        Value::Bool(_) | Value::Number(_) => vec![format!("{padding}{value}")],
-        Value::String(text) => {
-            if text.is_empty() {
-                return vec![padding];
-            }
-            text.lines()
-                .map(|line| format!("{padding}{line}"))
-                .collect()
-        }
-        Value::Array(values) => {
-            let mut lines = Vec::new();
-            for value in values {
-                let mut nested = readable_lines(value, indent + 2);
-                if nested.is_empty() {
-                    continue;
-                }
-                if value.is_array() {
-                    lines.push(format!("{padding}-"));
-                    lines.extend(nested);
-                    continue;
-                }
-                let first = nested.remove(0);
-                lines.push(format!("{padding}- {}", &first[indent + 2..]));
-                lines.extend(nested);
-            }
-            lines
-        }
-        Value::Object(fields) => {
-            let mut lines = Vec::new();
-            for (key, value) in fields {
-                if let Value::String(text) = value {
-                    let mut text_lines = text.lines();
-                    let first = text_lines.next().unwrap_or_default();
-                    lines.push(format!("{padding}{key}: {first}"));
-                    let continuation = " ".repeat(indent + key.chars().count() + 2);
-                    lines.extend(text_lines.map(|line| format!("{continuation}{line}")));
-                    continue;
-                }
-                let nested = readable_lines(value, indent + 2);
-                if nested.is_empty() {
-                    continue;
-                }
-                if matches!(value, Value::Bool(_) | Value::Number(_)) {
-                    lines.push(format!("{padding}{key}: {}", &nested[0][indent + 2..]));
-                } else {
-                    lines.push(format!("{padding}{key}:"));
-                    lines.extend(nested);
-                }
-            }
-            lines
-        }
-    }
-}
-
-fn result_value(werk: &Werk, task: &crate::Task, use_path: bool) -> Result<Value, String> {
-    if !use_path {
-        return Ok(task
-            .get_result()
-            .cloned()
-            .expect("result selector requires a result"));
-    }
-    let path = werk.result_path(task.get_id());
-    let absolute = path
-        .canonicalize()
-        .map_err(|error| format!("cannot access result file `{}`: {error}", path.display()))?;
-    if !absolute.is_file() {
-        return Err(format!(
-            "result path `{}` is not a file",
-            absolute.display()
-        ));
-    }
-    Ok(Value::String(absolute.to_string_lossy().into_owned()))
 }
 
 #[cfg(test)]
@@ -639,6 +556,92 @@ mod tests {
     }
 
     #[test]
+    fn template_variable_json_paths_select_json() {
+        let (werk, _dir) = session();
+        werk.set_template(
+            "profile",
+            r#"{"company":{"name":"Shared"},"findings":[{"summary":"one"}]}"#,
+        );
+
+        assert_eq!(
+            render(&werk, "{{ profile | findings[*].summary }}").unwrap(),
+            r#"["one"]"#
+        );
+    }
+
+    #[test]
+    fn runtime_variables_override_shared_variables_before_path_selection() {
+        let (werk, _dir) = session();
+        werk.set_template("profile", r#"{"company":{"name":"Shared"}}"#);
+        let runtime = [("profile", r#"{"company":{"name":"Runtime"}}"#.to_string())];
+
+        assert_eq!(
+            werk.render_prompt("{{ profile | company.name }}", &runtime)
+                .unwrap(),
+            "Runtime"
+        );
+    }
+
+    #[test]
+    fn template_variables_without_paths_stay_literal() {
+        let (werk, _dir) = session();
+        let profile = r#"{"company":{"name":"Acme"}}"#;
+        werk.set_template("profile", profile);
+
+        assert_eq!(render(&werk, "{{ profile }}").unwrap(), profile);
+    }
+
+    #[test]
+    fn unknown_template_variables_with_paths_stay_literal() {
+        let werk = Werk::new();
+
+        assert_eq!(
+            render(&werk, "{{ missing | company.name }}").unwrap(),
+            "{{ missing | company.name }}"
+        );
+    }
+
+    #[test]
+    fn malformed_template_variable_json_renders_null() {
+        let (werk, _dir) = session();
+        werk.set_template("profile", "not json");
+
+        assert_eq!(
+            render(&werk, "{{ profile | company.name }}").unwrap(),
+            "null"
+        );
+    }
+
+    #[test]
+    fn only_whitespace_delimited_pipes_start_json_paths() {
+        let (werk, _dir) = session();
+        werk.set_templates([
+            ("profile|company", "compact"),
+            ("profile |company", "left only"),
+            ("profile| company", "right only"),
+        ]);
+
+        for (expression, expected) in [
+            ("{{ profile|company }}", "compact"),
+            ("{{ profile |company }}", "left only"),
+            ("{{ profile| company }}", "right only"),
+        ] {
+            assert_eq!(render(&werk, expression).unwrap(), expected, "{expression}");
+        }
+    }
+
+    #[test]
+    fn invalid_template_variable_json_paths_report_the_parse_failure() {
+        let (werk, _dir) = session();
+        werk.set_template("profile", r#"{"items":[]}"#);
+
+        let error = render(&werk, "{{ profile | items[?active] }}").unwrap_err();
+
+        assert_eq!(error.expression, "profile | items[?active]");
+        assert_eq!(error.message, "invalid JSON path array index");
+    }
+
+    #[test]
     fn four_braces_emit_a_literal_double_brace_expression() {
         let (werk, _dir) = session();
         werk.set_template("company", "Acme");
@@ -721,33 +724,125 @@ mod tests {
     }
 
     #[test]
-    fn readable_formats_the_selected_json_path_value() {
+    fn task_expressions_return_the_first_match_in_query_order() {
         let (werk, _dir) = session();
-        let id = werk.add_task(Task::labeled("research", "go"));
-        werk.set_task_finished(
-            &id,
-            serde_json::json!({"findings": [{"summary": "one"}, {"summary": "two"}]}),
-        )
-        .unwrap();
+        werk.add_task(Task::labeled("scan", serde_json::json!({"file": "one"})));
+        werk.add_task(Task::labeled("scan", serde_json::json!({"file": "two"})));
 
         assert_eq!(
-            render(
-                &werk,
-                "{{ readable(result: research | findings[*].summary) }}",
-            )
-            .unwrap(),
-            "- one\n- two"
+            render(&werk, "{{ task: scan ORDER BY task.id DESC | task.file }}",).unwrap(),
+            "two"
         );
     }
 
     #[test]
-    fn json_path_boundaries_ignore_quoted_aql_pipes() {
+    fn tasks_expressions_use_the_selected_array_as_the_path_root() {
+        let (werk, _dir) = session();
+        let first = werk.add_task(Task::labeled("scan", "one"));
+        let second = werk.add_task(Task::labeled("scan", "two"));
+
+        assert_eq!(
+            render(&werk, "{{ tasks: scan | [*].id }}").unwrap(),
+            serde_json::json!([first, second]).to_string()
+        );
+    }
+
+    #[test]
+    fn task_expressions_use_the_current_task_serde_shape() {
+        let (werk, _dir) = session();
+        werk.add_task(Task::labeled("scan", serde_json::json!({"file": "one"})));
+
+        let serialized: Value =
+            serde_json::from_str(&render(&werk, "{{ task: scan }}").unwrap()).unwrap();
+
+        assert_eq!(serialized["task"]["file"], "one");
+        assert!(serialized.get("result").is_none());
+        assert!(serialized.get("errors").is_none());
+        assert!(serialized.get("replies").is_none());
+        assert!(serialized.get("cancelled").is_none());
+    }
+
+    #[test]
+    fn unmatched_task_expressions_render_null_or_an_empty_array() {
+        let (werk, _dir) = session();
+
+        assert_eq!(render(&werk, "{{ task: missing }}").unwrap(), "null");
+        assert_eq!(render(&werk, "{{ tasks: missing }}").unwrap(), "[]");
+    }
+
+    #[test]
+    fn event_expressions_return_the_first_match_in_log_order() {
+        let (werk, _dir) = session();
+        werk.emit_event(Event::new("inspection").data(serde_json::json!({"name": "one"})));
+        werk.emit_event(Event::new("inspection").data(serde_json::json!({"name": "two"})));
+
+        assert_eq!(
+            render(&werk, "{{ event: event.name = inspection | data.name }}",).unwrap(),
+            "one"
+        );
+    }
+
+    #[test]
+    fn events_expressions_use_the_selected_array_as_the_path_root() {
+        let (werk, _dir) = session();
+        werk.emit_event(Event::new("inspection").data(serde_json::json!({"name": "one"})));
+        werk.emit_event(Event::new("inspection").data(serde_json::json!({"name": "two"})));
+
+        assert_eq!(
+            render(
+                &werk,
+                "{{ events: event.name = inspection | [*].data.name }}",
+            )
+            .unwrap(),
+            r#"["one","two"]"#
+        );
+    }
+
+    #[test]
+    fn event_expressions_use_the_current_event_serde_shape() {
+        let (werk, _dir) = session();
+        werk.emit_event(Event::new("inspection").data(serde_json::json!({"name": "one"})));
+
+        let serialized: Value =
+            serde_json::from_str(&render(&werk, "{{ event: event.name = inspection }}").unwrap())
+                .unwrap();
+
+        assert_eq!(serialized["name"], "inspection");
+        assert_eq!(serialized["data"]["name"], "one");
+    }
+
+    #[test]
+    fn unmatched_event_expressions_render_null_or_an_empty_array() {
+        let (werk, _dir) = session();
+
+        assert_eq!(
+            render(&werk, "{{ event: event.name = absent }}").unwrap(),
+            "null"
+        );
+        assert_eq!(
+            render(&werk, "{{ events: event.name = absent }}").unwrap(),
+            "[]"
+        );
+    }
+
+    #[test]
+    fn removed_template_expressions_stay_literal() {
+        let werk = Werk::new();
+
+        for template in [
+            "{{ readable(result: research) }}",
+            "{{ result_path: research }}",
+            "{{ result_paths: research }}",
+        ] {
+            assert_eq!(render(&werk, template).unwrap(), template);
+        }
+    }
+
+    #[test]
+    fn quoted_aql_pipes_do_not_start_json_paths() {
         let (werk, _dir) = session();
         let id = werk.add_task(Task::labeled("research | notes", "go"));
         werk.set_task_finished(&id, serde_json::json!({"answer": "found"}))
-            .unwrap();
-        let compact = werk.add_task(Task::labeled("research|notes", "go"));
-        werk.set_task_finished(&compact, serde_json::json!("compact"))
             .unwrap();
 
         assert_eq!(
@@ -758,6 +853,15 @@ mod tests {
             .unwrap(),
             "found"
         );
+    }
+
+    #[test]
+    fn compact_aql_pipes_do_not_start_json_paths() {
+        let (werk, _dir) = session();
+        let id = werk.add_task(Task::labeled("research|notes", "go"));
+        werk.set_task_finished(&id, serde_json::json!("compact"))
+            .unwrap();
+
         assert_eq!(
             render(&werk, "{{ result: research|notes }}").unwrap(),
             "compact"
@@ -765,46 +869,65 @@ mod tests {
     }
 
     #[test]
-    fn json_path_boundaries_ignore_parenthesized_and_nested_pipes() {
-        assert_eq!(
-            split_json_path("task.label IN (one | two) | answer"),
-            ("task.label IN (one | two) ", Some(" answer"))
-        );
-        assert_eq!(
-            split_json_path("{{ selection | literal }} | answer"),
-            ("{{ selection | literal }} ", Some(" answer"))
-        );
-        assert_eq!(split_json_path("research|notes"), ("research|notes", None));
-    }
-
-    #[test]
-    fn result_file_paths_cannot_have_json_paths() {
-        let (werk, _dir) = session();
-        let id = werk.add_task("go");
-        werk.set_task_finished(&id, serde_json::json!({"answer": "done"}))
-            .unwrap();
-
-        let error = render(&werk, format!("{{{{ result_path: {id} | answer }}}}")).unwrap_err();
-
-        assert_eq!(error.message, "JSON paths require result: or results:");
-    }
-
-    #[test]
-    fn json_paths_are_static_and_fail_closed() {
+    fn pipes_inside_query_variable_names_do_not_start_json_paths() {
         let (werk, _dir) = session();
         let id = werk.add_task(Task::labeled("research", "go"));
         werk.set_task_finished(&id, serde_json::json!({"answer": "found"}))
             .unwrap();
-        werk.set_templates([("selection", "research | answer"), ("path", "answer")]);
+        werk.set_template("selection | literal", "research");
+
+        assert_eq!(
+            render(&werk, "{{ result: {{ selection | literal }} | answer }}",).unwrap(),
+            "found"
+        );
+    }
+
+    #[test]
+    fn malformed_json_paths_report_the_parse_failure() {
+        let (werk, _dir) = session();
+        let id = werk.add_task(Task::labeled("research", "go"));
+        werk.set_task_finished(&id, serde_json::json!({"answer": "found"}))
+            .unwrap();
+
+        for (prompt, message) in [
+            ("{{ result: research | }}", "JSON path cannot be empty"),
+            (
+                "{{ result: research | answer || missing }}",
+                "unsupported JSON path syntax at byte 6",
+            ),
+        ] {
+            let error = render(&werk, prompt).unwrap_err();
+            assert_eq!(error.expression, prompt[2..prompt.len() - 2].trim());
+            assert_eq!(error.message, message, "{prompt}");
+        }
+    }
+
+    #[test]
+    fn template_variables_cannot_supply_json_paths() {
+        let (werk, _dir) = session();
+        werk.set_templates([("path", "answer"), ("profile", r#"{"answer":"found"}"#)]);
 
         for prompt in [
-            "{{ result: research | }}",
-            "{{ result: research | answer || missing }}",
             "{{ result: research | {{ path }} }}",
-            "{{ result: {{ selection }} }}",
+            "{{ profile | {{ path }} }}",
+            "{{ task: research | {{ path }} }}",
+            "{{ event: event.name = task_finished | {{ path }} }}",
         ] {
-            assert!(render(&werk, prompt).is_err(), "{prompt}");
+            let error = render(&werk, prompt).unwrap_err();
+            assert_eq!(error.expression, prompt[2..prompt.len() - 2].trim());
+            assert_eq!(error.message, "unsupported JSON path syntax at byte 0");
         }
+    }
+
+    #[test]
+    fn query_variables_cannot_introduce_json_paths() {
+        let (werk, _dir) = session();
+        werk.set_template("selection", "research | answer");
+
+        let error = render(&werk, "{{ result: {{ selection }} }}").unwrap_err();
+
+        assert_eq!(error.expression, "result: {{ selection }}");
+        assert_eq!(error.message, "Unexpected `|` in the query.");
     }
 
     #[test]
@@ -872,21 +995,14 @@ mod tests {
     #[test]
     fn empty_plural_result_selectors_render_empty_arrays() {
         let (werk, _dir) = session();
-        for kind in ["results", "result_paths"] {
-            assert_eq!(
-                render(&werk, format!("{{{{ {kind}: missing }}}}")).unwrap(),
-                "[]"
-            );
-        }
+        assert_eq!(render(&werk, "{{ results: missing }}").unwrap(), "[]");
     }
 
     #[test]
     fn missing_singular_result_selectors_are_rejected() {
         let (werk, _dir) = session();
-        for kind in ["result", "result_path"] {
-            let error = render(&werk, format!("{{{{ {kind}: missing }}}}")).unwrap_err();
-            assert_eq!(error.message, "no matching result");
-        }
+        let error = render(&werk, "{{ result: missing }}").unwrap_err();
+        assert_eq!(error.message, "no matching result");
     }
 
     #[test]
@@ -901,6 +1017,16 @@ mod tests {
             (
                 "{{ results: task.label = }}",
                 "results: task.label =",
+                "The query ends in the middle of a term.",
+            ),
+            (
+                "{{ task: task.label = }}",
+                "task: task.label =",
+                "The query ends in the middle of a term.",
+            ),
+            (
+                "{{ events: event.name = }}",
+                "events: event.name =",
                 "The query ends in the middle of a term.",
             ),
         ] {
@@ -919,49 +1045,11 @@ mod tests {
                 "{{ result: task.label = \"oops }}",
                 "unclosed expression or quoted value",
             ),
-            ("{{ readable(result: research }}", "unclosed readable call"),
         ] {
             let error = render(&werk, prompt).unwrap_err();
             assert_eq!(error.message, message, "{prompt}");
             assert!(error.to_string().starts_with("cannot render {{"));
         }
-    }
-
-    #[test]
-    fn result_path_selectors_return_existing_absolute_files() {
-        let (werk, dir) = session();
-        let id = werk.add_task("go");
-        werk.set_task_finished(&id, serde_json::json!({"answer": "done"}))
-            .unwrap();
-        let path = dir
-            .path()
-            .join("tasks")
-            .join(&id)
-            .join("result.json")
-            .canonicalize()
-            .unwrap();
-        assert_eq!(
-            render(&werk, format!("{{{{ result_path: {id} }}}}")).unwrap(),
-            path.to_str().unwrap()
-        );
-        let paths = render(&werk, format!("{{{{ result_paths: {id} }}}}")).unwrap();
-        assert_eq!(
-            serde_json::from_str::<Vec<String>>(&paths).unwrap(),
-            [path.to_string_lossy()]
-        );
-    }
-
-    #[test]
-    fn missing_result_paths_are_rejected_without_recreating_the_file() {
-        let (werk, dir) = session();
-        let id = werk.add_task("go");
-        werk.set_task_finished(&id, serde_json::json!("done"))
-            .unwrap();
-        let path = dir.path().join("tasks").join(&id).join("result.json");
-        std::fs::remove_file(&path).unwrap();
-
-        assert!(render(&werk, format!("{{{{ result_path: {id} }}}}")).is_err());
-        assert!(!path.exists());
     }
 
     #[test]
@@ -978,7 +1066,7 @@ mod tests {
     }
 
     #[test]
-    fn named_query_fragments_expand_before_aql_parsing() {
+    fn query_variables_expand_before_aql_parsing() {
         let (werk, _dir) = session();
         let id = werk.add_task(Task::labeled("research", "go"));
         werk.set_task_finished(&id, serde_json::json!("found"))
@@ -992,7 +1080,7 @@ mod tests {
     }
 
     #[test]
-    fn multiple_named_values_expand_inside_quoted_aql_values() {
+    fn multiple_query_variables_expand_inside_quoted_aql_values() {
         let (werk, _dir) = session();
         let id = werk.add_task(Task::labeled("research", "go"));
         werk.set_task_finished(&id, serde_json::json!("found"))
@@ -1041,7 +1129,7 @@ mod tests {
             ),
             (
                 "{{ prefix {{ name }} }}",
-                "nested values are only supported inside result expressions",
+                "nested values are only supported inside selection expressions",
             ),
         ] {
             assert_eq!(
@@ -1061,121 +1149,5 @@ mod tests {
 
         assert_eq!(error.expression, "result: {{ selection }}");
         assert_eq!(error.message, "The query ends in the middle of a term.");
-    }
-
-    #[test]
-    fn readable_objects_and_arrays_form_an_indented_outline() {
-        let (werk, _dir) = session();
-        let structured = werk.add_task(Task::labeled("detail", "go"));
-        werk.set_task_finished(
-            &structured,
-            serde_json::json!({
-                "name": "Acme",
-                "details": {"active": true, "none": null},
-                "findings": ["one", null, {}, [], "two\ncontinued"],
-                "summary": "Executive\nsummary",
-                "empty": [],
-            }),
-        )
-        .unwrap();
-
-        assert_eq!(
-            render(&werk, "{{ readable(result: detail) }}").unwrap(),
-            "details:\n  active: true\nfindings:\n  - one\n  - two\n    continued\nname: Acme\nsummary: Executive\n         summary"
-        );
-    }
-
-    #[test]
-    fn readable_root_scalars_are_plain_text() {
-        let (werk, _dir) = session();
-        for (label, value, expected) in [
-            ("boolean", serde_json::json!(true), "true"),
-            ("number", serde_json::json!(42), "42"),
-            (
-                "text",
-                serde_json::json!("line one\nline two"),
-                "line one\nline two",
-            ),
-            ("null", Value::Null, ""),
-        ] {
-            let id = werk.add_task(Task::labeled(label, "go"));
-            werk.set_task_finished(&id, value).unwrap();
-            assert_eq!(
-                render(&werk, format!("{{{{ readable(result: {label}) }}}}")).unwrap(),
-                expected,
-            );
-        }
-    }
-
-    #[test]
-    fn readable_empty_root_collections_render_nothing() {
-        let (werk, _dir) = session();
-        for (label, value) in [
-            ("array", serde_json::json!([])),
-            ("object", serde_json::json!({})),
-        ] {
-            let id = werk.add_task(Task::labeled(label, "go"));
-            werk.set_task_finished(&id, value).unwrap();
-            assert_eq!(
-                render(&werk, format!("{{{{ readable(result: {label}) }}}}")).unwrap(),
-                "",
-            );
-        }
-    }
-
-    #[test]
-    fn readable_arrays_render_objects_and_mixed_scalars_as_bullets() {
-        let (werk, _dir) = session();
-        let id = werk.add_task(Task::labeled("mixed", "go"));
-        werk.set_task_finished(
-            &id,
-            serde_json::json!([
-                {"name": "Acme", "active": true},
-                42,
-                false,
-            ]),
-        )
-        .unwrap();
-
-        assert_eq!(
-            render(&werk, "{{ readable(result: mixed) }}").unwrap(),
-            "- active: true\n  name: Acme\n- 42\n- false"
-        );
-    }
-
-    #[test]
-    fn readable_plural_results_omit_empty_values() {
-        let (werk, _dir) = session();
-        let text = werk.add_task(Task::labeled("mixed", "go"));
-        werk.set_task_finished(&text, serde_json::json!("Executive\nsummary"))
-            .unwrap();
-        let empty = werk.add_task(Task::labeled("mixed", "go"));
-        werk.set_task_finished(&empty, Value::Null).unwrap();
-        assert_eq!(
-            render(&werk, "{{ readable(results: mixed) }}").unwrap(),
-            "- Executive\n  summary"
-        );
-    }
-
-    #[test]
-    fn readable_empty_selection_is_empty_text() {
-        let (werk, _dir) = session();
-        assert_eq!(
-            render(&werk, "{{ readable(results: missing) }}").unwrap(),
-            ""
-        );
-    }
-
-    #[test]
-    fn readable_accepts_only_result_selectors() {
-        let (werk, _dir) = session();
-        werk.set_template("name", "research");
-        for prompt in [
-            "{{ readable(name) }}",
-            "{{ readable(result_path: research) }}",
-            "{{ readable(results: {{ readable(result: research) }}) }}",
-        ] {
-            assert!(render(&werk, prompt).is_err(), "{prompt}");
-        }
     }
 }


### PR DESCRIPTION
## Purpose

Extend prompt templates to select structured template values, tasks, results, and events with AQL and JSONPath.

## What changed

- Add singular and plural task and event selectors, plus JSONPath on template values
- Return compact JSON or plain scalar text and retire readable and result-path forms
- Reorganize Rust and Python API docs around tasks with matching reference tables and details

## Examples

`{{ tasks: research | [*].task }}`

`{{ events: event.name = tool_call_failed | [*].data }}`