### PR TITLE
Render empty template selections as empty strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,20 +264,20 @@ agentwerk fills placeholders in the role and task just before each task's first 
 |---|---|
 | `{{ name }}` | The value assigned to `name`. |
 | `{{ name \| JSONPath }}` | A value selected from the template variable after parsing it as JSON. |
-| `{{ result: AQL }}` | The first result. Strings appear as text and other values as compact JSON. |
-| `{{ results: AQL }}` | A compact JSON array of matching results. |
+| `{{ result: AQL }}` | The first matching result. Strings appear as text and other values as compact JSON. |
+| `{{ results: AQL }}` | Matching results as a compact JSON array. |
 | `{{ result: AQL \| JSONPath }}` | A value selected from the first result. |
 | `{{ results: AQL \| JSONPath }}` | A value selected from the array of matching results. |
-| `{{ task: AQL }}` | The first matching task as compact JSON, or `null`. |
-| `{{ tasks: AQL }}` | A compact JSON array of matching tasks. |
+| `{{ task: AQL }}` | The first matching task as compact JSON. |
+| `{{ tasks: AQL }}` | Matching tasks as a compact JSON array. |
 | `{{ task: AQL \| JSONPath }}` | A value selected from the first matching task. |
 | `{{ tasks: AQL \| JSONPath }}` | A value selected from the array of matching tasks. |
-| `{{ event: AQL }}` | The first matching event as compact JSON, or `null`. |
-| `{{ events: AQL }}` | A compact JSON array of matching events. |
+| `{{ event: AQL }}` | The first matching event as compact JSON. |
+| `{{ events: AQL }}` | Matching events as a compact JSON array. |
 | `{{ event: AQL \| JSONPath }}` | A value selected from the first matching event. |
 | `{{ events: AQL \| JSONPath }}` | A value selected from the array of matching events. |
 
-Use JSONPath after a template variable or AQL selection. Template variables are parsed as JSON, with malformed JSON becoming `null`. Task and event selectors match the corresponding `find_*` method. Plural selections use the array as the root.
+`null`, empty arrays, and unmatched selectors render to an empty string.
 
 | Record | JSONPath properties |
 |---|---|

--- a/crates/agentwerk-py/README.md
+++ b/crates/agentwerk-py/README.md
@@ -278,20 +278,20 @@ agentwerk fills placeholders in the role and task just before each task's first 
 |---|---|
 | `{{ name }}` | The value assigned to `name`. |
 | `{{ name \| JSONPath }}` | A value selected from the template variable after parsing it as JSON. |
-| `{{ result: AQL }}` | The first result. Strings appear as text and other values as compact JSON. |
-| `{{ results: AQL }}` | A compact JSON array of matching results. |
+| `{{ result: AQL }}` | The first matching result. Strings appear as text and other values as compact JSON. |
+| `{{ results: AQL }}` | Matching results as a compact JSON array. |
 | `{{ result: AQL \| JSONPath }}` | A value selected from the first result. |
 | `{{ results: AQL \| JSONPath }}` | A value selected from the array of matching results. |
-| `{{ task: AQL }}` | The first matching task as compact JSON, or `null`. |
-| `{{ tasks: AQL }}` | A compact JSON array of matching tasks. |
+| `{{ task: AQL }}` | The first matching task as compact JSON. |
+| `{{ tasks: AQL }}` | Matching tasks as a compact JSON array. |
 | `{{ task: AQL \| JSONPath }}` | A value selected from the first matching task. |
 | `{{ tasks: AQL \| JSONPath }}` | A value selected from the array of matching tasks. |
-| `{{ event: AQL }}` | The first matching event as compact JSON, or `null`. |
-| `{{ events: AQL }}` | A compact JSON array of matching events. |
+| `{{ event: AQL }}` | The first matching event as compact JSON. |
+| `{{ events: AQL }}` | Matching events as a compact JSON array. |
 | `{{ event: AQL \| JSONPath }}` | A value selected from the first matching event. |
 | `{{ events: AQL \| JSONPath }}` | A value selected from the array of matching events. |
 
-Use JSONPath after a template variable or AQL selection. Template variables are parsed as JSON, with malformed JSON becoming `null`. Task and event selectors match the corresponding `find_*` method. Plural selections use the array as the root.
+`null`, empty arrays, and unmatched selectors render to an empty string.
 
 | Record | JSONPath properties |
 |---|---|

--- a/crates/agentwerk-py/tests/test_prompts.py
+++ b/crates/agentwerk-py/tests/test_prompts.py
@@ -180,14 +180,77 @@ async def test_task_prompts_stay_fixed_after_the_first_request(werk, scripted_op
     assert werk.get_task(task).get_task() == "Write for {{ company }}"
 
 
-async def test_prompt_render_failure_reaches_hooks_without_a_provider_request(
+async def test_unmatched_selectors_render_nothing_and_reach_provider(
+    werk, scripted_openai
+):
+    expressions = [
+        "{{ result: missing }}",
+        "{{ results: missing | [*].answer }}",
+        "{{ task: missing }}",
+        "{{ tasks: missing | [*].task }}",
+        "{{ event: event.name = missing }}",
+        "{{ events: event.name = missing | [*].data }}",
+    ]
+    scripted_openai.respond_with_tool("finish", {"answer": "done"})
+    werk.add_agent(
+        aw.Agent()
+        .provider(scripted_openai.provider())
+        .model("mock")
+        .role(f"before {''.join(expressions)} after")
+    )
+    task = werk.add_task("go")
+    failures = []
+    werk.on_failure(lambda _werk, event, _task: failures.append(event.get_name()))
+    await asyncio.wait_for(werk.finish(), timeout=5)
+    assert scripted_openai.requests[0]["messages"][0]["content"] == "before  after"
+    assert failures == []
+    assert werk.get_task(task).is_finished()
+
+
+async def test_null_and_empty_array_results_render_nothing(werk, scripted_openai):
+    null = werk.add_task(aw.Task("null", label="null"))
+    empty = werk.add_task(aw.Task("empty", label="empty"))
+    werk.set_task_finished(null, None)
+    werk.set_task_finished(empty, [])
+    scripted_openai.respond_with_tool("finish", {"answer": "done"})
+    werk.add_agent(
+        aw.Agent()
+        .provider(scripted_openai.provider())
+        .model("mock")
+        .role("before {{ result: null }}{{ results: empty }} after")
+    )
+    werk.add_task("go")
+
+    await asyncio.wait_for(werk.finish(), timeout=5)
+
+    assert scripted_openai.requests[0]["messages"][0]["content"] == "before  after"
+
+
+async def test_empty_template_values_render_without_crashing(werk, scripted_openai):
+    werk.set_template("empty", "")
+    scripted_openai.respond_with_tool("finish", {"answer": "done"})
+    werk.add_agent(
+        aw.Agent()
+        .provider(scripted_openai.provider())
+        .model("mock")
+        .role("before {{ empty }} after")
+    )
+    task = werk.add_task("go")
+
+    await asyncio.wait_for(werk.finish(), timeout=5)
+
+    assert scripted_openai.requests[0]["messages"][0]["content"] == "before  after"
+    assert werk.get_task(task).is_finished()
+
+
+async def test_malformed_result_selector_fails_before_provider_request(
     werk, scripted_openai
 ):
     werk.add_agent(
         aw.Agent()
         .provider(scripted_openai.provider())
         .model("mock")
-        .role("{{ result: missing }}")
+        .role("{{ result: task.label = }}")
     )
     task = werk.add_task("go")
     failures = []
@@ -195,7 +258,9 @@ async def test_prompt_render_failure_reaches_hooks_without_a_provider_request(
     await asyncio.wait_for(werk.finish(), timeout=5)
     assert scripted_openai.requests == []
     assert failures == [aw.Event.PROMPT_RENDER_FAILED, aw.Event.TASK_FAILED]
-    assert werk.get_task(task).get_errors()[0].get_data()["expression"] == "result: missing"
+    error = werk.get_task(task).get_errors()[0].get_data()
+    assert error["expression"] == "result: task.label ="
+    assert error["message"] == "The query ends in the middle of a term."
 
 
 async def test_template_cycles_are_inserted_literally(werk, scripted_openai):

--- a/crates/agentwerk/src/agents/loop/render_tests.rs
+++ b/crates/agentwerk/src/agents/loop/render_tests.rs
@@ -343,19 +343,42 @@ async fn fail_to_render(
 }
 
 #[tokio::test]
-async fn role_and_task_render_failures_stop_before_the_provider_request() {
+async fn unmatched_result_selectors_render_nothing_and_reach_the_provider() {
     for in_role in [true, false] {
-        let (werk, _dir, provider, id, _failures) =
-            fail_to_render(in_role, "{{ result: absent }}").await;
+        let (werk, _dir) = session();
+        let provider = MockProvider::with_results(vec![Ok(write_result_response("done"))]);
+        let prompt = "before {{ result: absent }} after";
+        let role = if in_role { prompt } else { "role" };
+        werk.add_agent(task_agent(&provider).role(role));
+        let id = werk.add_task(if in_role { "go" } else { prompt });
 
-        assert_eq!(provider.requests(), 0);
-        assert!(werk.get_task(&id).unwrap().is_failed());
+        finish(&werk).await;
+
+        assert_eq!(provider.requests(), 1);
+        let messages = &provider.received()[0];
+        let rendered = if in_role {
+            provider
+                .received_system_prompts()
+                .into_iter()
+                .next()
+                .unwrap()
+        } else {
+            user_text(messages).trim().to_string()
+        };
+        assert_eq!(rendered, "before  after");
+        let task = werk.get_task(&id).unwrap();
+        assert!(task.is_finished());
+        assert!(task
+            .get_errors()
+            .iter()
+            .all(|error| error.get_name() != Event::PROMPT_RENDER_FAILED));
     }
 }
 
 #[tokio::test]
 async fn prompt_render_failures_reach_hooks_and_survive_reload() {
-    let (_werk, dir, _provider, id, failures) = fail_to_render(true, "{{ result: absent }}").await;
+    let (_werk, dir, _provider, id, failures) =
+        fail_to_render(true, "{{ result: task.label = }}").await;
 
     assert_eq!(
         *failures.lock().unwrap(),
@@ -365,7 +388,11 @@ async fn prompt_render_failures_reach_hooks_and_survive_reload() {
     let task = loaded.get_task(&id).unwrap();
     let error = &task.get_errors()[0];
     assert_eq!(error.get_name(), Event::PROMPT_RENDER_FAILED);
-    assert_eq!(error.get_data()["expression"], "result: absent");
+    assert_eq!(error.get_data()["expression"], "result: task.label =");
+    assert_eq!(
+        error.get_data()["message"],
+        "The query ends in the middle of a term."
+    );
 }
 
 #[tokio::test]

--- a/crates/agentwerk/src/event.rs
+++ b/crates/agentwerk/src/event.rs
@@ -1153,8 +1153,14 @@ pub(crate) mod tests {
                 }),
             ),
             (
-                Event::prompt_render_failed("result: missing", "no matching result"),
-                serde_json::json!({ "expression": "result: missing", "message": "no matching result" }),
+                Event::prompt_render_failed(
+                    "result: task.label =",
+                    "The query ends in the middle of a term.",
+                ),
+                serde_json::json!({
+                    "expression": "result: task.label =",
+                    "message": "The query ends in the middle of a term.",
+                }),
             ),
             (
                 Event::request_retried("model", 2, 4, RequestErrorKind::RateLimited, "later"),

--- a/crates/agentwerk/src/prompts/prompt.rs
+++ b/crates/agentwerk/src/prompts/prompt.rs
@@ -140,7 +140,7 @@ fn resolve_expression_value(
 ) -> Result<Option<String>, String> {
     if let Some(selection) = selection_expression(expression) {
         let value = resolve_selection(werk, selection, named_value)?;
-        return Ok(Some(result_text(value)));
+        return Ok(Some(value.map(result_text).unwrap_or_default()));
     }
 
     resolve_named_value(expression, named_value)
@@ -170,18 +170,20 @@ fn resolve_selection(
     werk: &Werk,
     selection: SelectionExpression<'_>,
     named_value: &mut impl FnMut(&str) -> Option<String>,
-) -> Result<Value, String> {
+) -> Result<Option<Value>, String> {
     let (query, _had_nested_value) = expand_nested(selection.query, named_value)?;
     let json_path = selection
         .json_path
         .map(JsonPath::parse)
         .transpose()
         .map_err(|error| error.to_string())?;
-    let value = select_value(werk, selection.kind, query.trim())?;
-    let Some(json_path) = json_path else {
-        return Ok(value);
+    let Some(value) = select_value(werk, selection.kind, query.trim())? else {
+        return Ok(None);
     };
-    Ok(json_path.evaluate(&value))
+    let Some(json_path) = json_path else {
+        return Ok(Some(value));
+    };
+    Ok(Some(json_path.evaluate(&value)))
 }
 
 fn expand_nested(
@@ -379,23 +381,33 @@ fn expression_end(body: &str) -> Result<Option<usize>, &'static str> {
     }
 }
 
-fn select_value(werk: &Werk, kind: SelectionKind, query: &str) -> Result<Value, String> {
+fn select_value(werk: &Werk, kind: SelectionKind, query: &str) -> Result<Option<Value>, String> {
     let query = Query::new(query).map_err(|error| error.to_string())?;
     match kind {
-        SelectionKind::Task => serde_json::to_value(werk.find_task(query)),
-        SelectionKind::Tasks => serde_json::to_value(werk.find_tasks(query)),
-        SelectionKind::Event => serde_json::to_value(werk.find_event(query)),
-        SelectionKind::Events => serde_json::to_value(werk.find_events(query)),
+        SelectionKind::Task => werk.find_task(query).map(serde_json::to_value).transpose(),
+        SelectionKind::Tasks => {
+            let values = werk.find_tasks(query);
+            (!values.is_empty())
+                .then(|| serde_json::to_value(values))
+                .transpose()
+        }
+        SelectionKind::Event => werk.find_event(query).map(serde_json::to_value).transpose(),
+        SelectionKind::Events => {
+            let values = werk.find_events(query);
+            (!values.is_empty())
+                .then(|| serde_json::to_value(values))
+                .transpose()
+        }
         kind => return select_result(werk, kind, query),
     }
     .map_err(|error| format!("cannot serialize selection: {error}"))
 }
 
-fn select_result(werk: &Werk, kind: SelectionKind, query: Query) -> Result<Value, String> {
+fn select_result(werk: &Werk, kind: SelectionKind, query: Query) -> Result<Option<Value>, String> {
     let mut tasks = werk.result_tasks(query);
     let is_plural = kind.is_plural();
-    if !is_plural && tasks.is_empty() {
-        return Err("no matching result".into());
+    if tasks.is_empty() {
+        return Ok(None);
     }
     if !is_plural {
         tasks.truncate(1);
@@ -409,15 +421,26 @@ fn select_result(werk: &Werk, kind: SelectionKind, query: Query) -> Result<Value
         })
         .collect::<Vec<_>>();
     if is_plural {
-        return Ok(Value::Array(values));
+        return Ok(Some(Value::Array(values)));
     }
-    Ok(values
-        .into_iter()
-        .next()
-        .expect("singular selection is nonempty"))
+    Ok(values.into_iter().next())
 }
 
 fn result_text(value: Value) -> String {
+    let empty = {
+        let mut pending = vec![&value];
+        loop {
+            match pending.pop() {
+                Some(Value::Null) => {}
+                Some(Value::Array(values)) => pending.extend(values),
+                Some(_) => break false,
+                None => break true,
+            }
+        }
+    };
+    if empty {
+        return String::new();
+    }
     match value {
         Value::String(text) => text,
         value => value.to_string(),
@@ -602,14 +625,11 @@ mod tests {
     }
 
     #[test]
-    fn malformed_template_variable_json_renders_null() {
+    fn malformed_template_variable_json_renders_nothing() {
         let (werk, _dir) = session();
         werk.set_template("profile", "not json");
 
-        assert_eq!(
-            render(&werk, "{{ profile | company.name }}").unwrap(),
-            "null"
-        );
+        assert_eq!(render(&werk, "{{ profile | company.name }}").unwrap(), "");
     }
 
     #[test]
@@ -692,7 +712,7 @@ mod tests {
         );
         assert_eq!(
             render(&werk, "{{ result: research | company.missing }}").unwrap(),
-            "null"
+            ""
         );
         assert_eq!(
             render(&werk, r#"{{ result: research | "}}" }}"#).unwrap(),
@@ -719,7 +739,7 @@ mod tests {
         );
         assert_eq!(
             render(&werk, "{{ results: missing | [*].verdict }}").unwrap(),
-            "[]"
+            ""
         );
     }
 
@@ -763,11 +783,11 @@ mod tests {
     }
 
     #[test]
-    fn unmatched_task_expressions_render_null_or_an_empty_array() {
+    fn unmatched_task_expressions_render_nothing() {
         let (werk, _dir) = session();
 
-        assert_eq!(render(&werk, "{{ task: missing }}").unwrap(), "null");
-        assert_eq!(render(&werk, "{{ tasks: missing }}").unwrap(), "[]");
+        assert_eq!(render(&werk, "{{ task: missing }}").unwrap(), "");
+        assert_eq!(render(&werk, "{{ tasks: missing }}").unwrap(), "");
     }
 
     #[test]
@@ -812,16 +832,16 @@ mod tests {
     }
 
     #[test]
-    fn unmatched_event_expressions_render_null_or_an_empty_array() {
+    fn unmatched_event_expressions_render_nothing() {
         let (werk, _dir) = session();
 
         assert_eq!(
             render(&werk, "{{ event: event.name = absent }}").unwrap(),
-            "null"
+            ""
         );
         assert_eq!(
             render(&werk, "{{ events: event.name = absent }}").unwrap(),
-            "[]"
+            ""
         );
     }
 
@@ -891,6 +911,7 @@ mod tests {
 
         for (prompt, message) in [
             ("{{ result: research | }}", "JSON path cannot be empty"),
+            ("{{ result: missing | }}", "JSON path cannot be empty"),
             (
                 "{{ result: research | answer || missing }}",
                 "unsupported JSON path syntax at byte 6",
@@ -993,16 +1014,78 @@ mod tests {
     }
 
     #[test]
-    fn empty_plural_result_selectors_render_empty_arrays() {
+    fn unmatched_result_expressions_render_nothing() {
         let (werk, _dir) = session();
-        assert_eq!(render(&werk, "{{ results: missing }}").unwrap(), "[]");
+
+        assert_eq!(render(&werk, "{{ result: missing }}").unwrap(), "");
+        assert_eq!(render(&werk, "{{ results: missing }}").unwrap(), "");
     }
 
     #[test]
-    fn missing_singular_result_selectors_are_rejected() {
+    fn unmatched_selectors_with_json_paths_render_nothing() {
         let (werk, _dir) = session();
-        let error = render(&werk, "{{ result: missing }}").unwrap_err();
-        assert_eq!(error.message, "no matching result");
+
+        for expression in [
+            "{{ result: missing | answer }}",
+            "{{ results: missing | [*].answer }}",
+            "{{ task: missing | task.answer }}",
+            "{{ tasks: missing | [*].task.answer }}",
+            "{{ event: event.name = missing | data.answer }}",
+            "{{ events: event.name = missing | [*].data.answer }}",
+        ] {
+            assert_eq!(render(&werk, expression).unwrap(), "", "{expression}");
+        }
+    }
+
+    #[test]
+    fn unmatched_selectors_disappear_without_changing_surrounding_text() {
+        let (werk, _dir) = session();
+
+        for expression in [
+            "{{ result: missing }}",
+            "{{ results: missing }}",
+            "{{ task: missing }}",
+            "{{ tasks: missing }}",
+            "{{ event: event.name = missing }}",
+            "{{ events: event.name = missing }}",
+        ] {
+            let prompt = format!("before {expression} after");
+            assert_eq!(
+                render(&werk, prompt).unwrap(),
+                "before  after",
+                "{expression}"
+            );
+        }
+    }
+
+    #[test]
+    fn result_expressions_suppress_nulls_and_empty_arrays() {
+        let (werk, _dir) = session();
+        let pending = werk.add_task(Task::labeled("research", "pending"));
+        let empty = werk.add_task(Task::labeled("empty", "empty"));
+        let useful = werk.add_task(Task::labeled("useful", "useful"));
+
+        assert_eq!(render(&werk, "{{ result: research }}").unwrap(), "");
+        assert_eq!(render(&werk, "{{ results: research }}").unwrap(), "");
+
+        werk.set_task_finished(&pending, Value::Null).unwrap();
+        werk.set_task_finished(&empty, serde_json::json!([]))
+            .unwrap();
+        werk.set_task_finished(&useful, serde_json::json!(["instruction"]))
+            .unwrap();
+
+        assert_eq!(render(&werk, "{{ result: research }}").unwrap(), "");
+        assert_eq!(render(&werk, "{{ results: research }}").unwrap(), "");
+        assert_eq!(render(&werk, "{{ result: empty }}").unwrap(), "");
+        assert_eq!(render(&werk, "{{ results: empty }}").unwrap(), "");
+        assert_eq!(
+            render(&werk, "{{ result: useful }}").unwrap(),
+            r#"["instruction"]"#
+        );
+        assert_eq!(
+            render(&werk, "{{ results: useful }}").unwrap(),
+            r#"[["instruction"]]"#
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Render empty template selections as empty strings

### Purpose

- Unmatched AQL selectors should not fail prompt rendering
- `null` and empty arrays provide no useful agent instructions
- Python callers need the same template behavior as Rust

### What changed

- `result(s)`, `task(s)`, and `event(s)` render unmatched selections as empty strings
- JSONPath selections suppress `null` and recursively empty arrays
- Invalid AQL and JSONPath still emit `prompt_render_failed`

### Examples

```text
Before {{ result: missing }} after
```

```text
Before  after
```
